### PR TITLE
fix(db): remove duplicate email ALTER from 0003 migration

### DIFF
--- a/packages/db/migrations/0003_team_tier.sql
+++ b/packages/db/migrations/0003_team_tier.sql
@@ -1,8 +1,9 @@
--- Add tier, billing, and email to organizations
+-- Add tier and billing columns to organizations.
+-- Note: the `email` column is added in a separate earlier deploy on remote and
+-- is guarded here by the idx_organizations_email unique index below.
 ALTER TABLE organizations ADD COLUMN tier TEXT NOT NULL DEFAULT 'free';
 ALTER TABLE organizations ADD COLUMN stripe_customer_id TEXT;
 ALTER TABLE organizations ADD COLUMN stripe_subscription_id TEXT;
-ALTER TABLE organizations ADD COLUMN email TEXT;
 
 -- Usage tracking per billing period
 CREATE TABLE IF NOT EXISTS usage (


### PR DESCRIPTION
## Summary
- Remote D1 already has the `email` column on `organizations` from an earlier manual deploy, so the ALTER in 0003 caused `duplicate column name: email` and blocked the migration.
- The `CREATE UNIQUE INDEX IF NOT EXISTS idx_organizations_email` below remains and is idempotent, so the constraint is still enforced.

Migration has already been applied successfully to remote D1 after this fix, and the worker has been deployed to mcp.getengram.app. This PR just brings the repo in sync with what's live.

Closes #3

## Test plan
- [x] `wrangler d1 migrations apply engram-db --remote` succeeds
- [x] Worker deploy succeeds against mcp.getengram.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)