### PR TITLE
chore: MIT-license SDK + CLI, proprietary everywhere else

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026 Get Engram LLC. All rights reserved.
+
+This repository contains proprietary source code for Engram, a commercial
+memory service operated by Get Engram LLC.
+
+Exceptions: The following subdirectories are licensed under the MIT License,
+as indicated by a LICENSE file within each directory:
+
+  - packages/sdk  (@getengram/sdk, published to npm)
+  - apps/cli      (@getengram/cli, published to npm)
+
+All other code in this repository is proprietary. No license is granted to
+copy, modify, distribute, or create derivative works of the proprietary
+portions of this repository without express written permission from
+Get Engram LLC.
+
+Use of the hosted Engram service at getengram.app is governed by the Terms
+of Service at https://getengram.app/terms and the Privacy Policy at
+https://getengram.app/privacy.

--- a/apps/cli/LICENSE
+++ b/apps/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Get Engram LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getengram/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI for Engram — persistent memory for AI agents",
   "type": "module",
   "bin": {
@@ -25,7 +25,10 @@
     "cli",
     "mcp"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/get-engram/engram"

--- a/packages/sdk/LICENSE
+++ b/packages/sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Get Engram LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getengram/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript SDK for Engram — persistent memory for AI agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -31,7 +31,10 @@
     "context",
     "cloudflare"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/get-engram/engram"


### PR DESCRIPTION
## Summary
- Adopts the standard SaaS licensing pattern used by Stripe, OpenAI, Clerk, Supabase, Resend, etc.: MIT on the client SDK + CLI, proprietary on the backend.
- \`packages/sdk\` and \`apps/cli\` each get their own MIT LICENSE and \`license: "MIT"\` in package.json.
- Root LICENSE declares "All rights reserved" for the rest of the repo with explicit MIT carve-outs for the two published packages, and points to getengram.app/terms for service usage.
- Bumps both to 0.1.1 and these have been **published to npm** already: \`@getengram/sdk@0.1.1\`, \`@getengram/cli@0.1.1\`. This PR just syncs the repo with what's on the registry.

The previous 0.1.0 publish had a bug: the published \`@getengram/cli/package.json\` had \`"@getengram/sdk": "workspace:*"\` literally, which is unresolvable for end users. \`pnpm publish\` correctly rewrites it to \`0.1.1\` — verified in the packed tarball before publish.

## Test plan
- [x] \`pnpm pack\` on both packages — verified LICENSE, dist/, README.md present
- [x] Verified CLI published package.json has \`"@getengram/sdk": "0.1.1"\` (not \`workspace:*\`)
- [x] \`npm view @getengram/sdk version\` → 0.1.1
- [x] \`npm view @getengram/cli version\` → 0.1.1
- [x] \`npm view @getengram/cli dependencies\` → \`{ '@getengram/sdk': '0.1.1' }\`
- [ ] End-to-end: \`npx @getengram/cli --help\` in a clean directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)