### PR TITLE
feat(billing): Stripe Checkout, Billing Portal, and webhook handler

### DIFF
--- a/apps/mcp-server/src/__tests__/stripe.test.ts
+++ b/apps/mcp-server/src/__tests__/stripe.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { verifyWebhookSignature } from "../services/stripe.js";
+
+// Compute a valid Stripe signature the same way Stripe does, so we can
+// exercise the verifier without needing real Stripe traffic.
+async function signStripePayload(
+  secret: string,
+  body: string,
+  timestamp: number,
+): Promise<string> {
+  const payload = `${timestamp}.${body}`;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const mac = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payload),
+  );
+  const hex = Array.from(new Uint8Array(mac))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `t=${timestamp},v1=${hex}`;
+}
+
+describe("verifyWebhookSignature", () => {
+  const secret = "whsec_test_abc123";
+  const body = JSON.stringify({ id: "evt_1", type: "checkout.session.completed" });
+
+  it("accepts a fresh, correctly signed payload", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const header = await signStripePayload(secret, body, now);
+    expect(await verifyWebhookSignature(body, header, secret)).toBe(true);
+  });
+
+  it("rejects a tampered body", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const header = await signStripePayload(secret, body, now);
+    const tampered = body.replace("evt_1", "evt_2");
+    expect(await verifyWebhookSignature(tampered, header, secret)).toBe(false);
+  });
+
+  it("rejects a payload signed with a different secret", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const header = await signStripePayload("whsec_wrong", body, now);
+    expect(await verifyWebhookSignature(body, header, secret)).toBe(false);
+  });
+
+  it("rejects a stale timestamp (replay protection)", async () => {
+    const stale = Math.floor(Date.now() / 1000) - 10 * 60; // 10 minutes ago
+    const header = await signStripePayload(secret, body, stale);
+    expect(await verifyWebhookSignature(body, header, secret)).toBe(false);
+  });
+
+  it("rejects a malformed signature header", async () => {
+    expect(await verifyWebhookSignature(body, "garbage", secret)).toBe(false);
+    expect(await verifyWebhookSignature(body, "", secret)).toBe(false);
+  });
+
+  it("accepts when one of multiple v1 signatures matches (secret rotation)", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const good = await signStripePayload(secret, body, now);
+    const goodHex = good.split("v1=")[1];
+    const header = `t=${now},v1=0000000000000000000000000000000000000000000000000000000000000000,v1=${goodHex}`;
+    expect(await verifyWebhookSignature(body, header, secret)).toBe(true);
+  });
+});

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -8,6 +8,7 @@ import { seats } from "./routes/seats.js";
 import { webhooks } from "./routes/webhooks.js";
 import { usage } from "./routes/usage.js";
 import { signup } from "./routes/signup.js";
+import { billing, billingWebhook } from "./routes/billing.js";
 import type { Env, AuthContext } from "./types.js";
 
 type HonoEnv = {
@@ -51,11 +52,16 @@ app.use(
 );
 app.route("/signup", signup);
 
+// Stripe webhook — public, verified by HMAC signature instead of API key.
+// Mounted BEFORE the /api/* auth middleware so it isn't gated.
+app.route("/billing/webhook", billingWebhook);
+
 // REST API routes (all require auth)
 app.use("/api/*", authMiddleware);
 app.route("/api/keys", keys);
 app.route("/api/seats", seats);
 app.route("/api/webhooks", webhooks);
 app.route("/api/usage", usage);
+app.route("/api/billing", billing);
 
 export default app;

--- a/apps/mcp-server/src/routes/billing.ts
+++ b/apps/mcp-server/src/routes/billing.ts
@@ -1,0 +1,227 @@
+import { Hono } from "hono";
+import {
+  getOrganizationById,
+  getOrganizationByStripeCustomer,
+  setOrganizationStripeCustomer,
+  setOrganizationTier,
+} from "@getengram/db";
+import {
+  createCheckoutSession,
+  createOrGetCustomer,
+  createPortalSession,
+  verifyWebhookSignature,
+} from "../services/stripe.js";
+import type { Env, AuthContext } from "../types.js";
+
+type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
+
+const billing = new Hono<HonoEnv>();
+
+// POST /api/billing/checkout
+// Authed. Creates a Checkout Session and returns its URL. The caller is
+// expected to redirect the user to the returned URL.
+billing.post("/checkout", async (c) => {
+  const auth = c.get("auth");
+  const body = await c.req
+    .json<{ success_url?: string; cancel_url?: string; plan?: string }>()
+    .catch(() => ({}) as Record<string, string>);
+
+  const org = (await getOrganizationById(c.env.DB, auth.organizationId)) as
+    | { id: string; email: string | null; stripe_customer_id: string | null }
+    | null;
+  if (!org) return c.json({ error: "organization_not_found" }, 404);
+  if (!org.email) {
+    return c.json(
+      {
+        error: "missing_email",
+        message:
+          "Organization has no email on file. Contact support to attach one.",
+      },
+      400,
+    );
+  }
+
+  // Ensure a Stripe customer exists and is cached on the org row
+  let customerId = org.stripe_customer_id;
+  if (!customerId) {
+    const customer = await createOrGetCustomer(
+      c.env.STRIPE_SECRET_KEY,
+      org.email,
+      org.id,
+    );
+    customerId = customer.id;
+    await setOrganizationStripeCustomer(c.env.DB, org.id, customerId);
+  }
+
+  const successUrl =
+    body.success_url ||
+    `${c.env.APP_URL}/dashboard?upgrade=success&session_id={CHECKOUT_SESSION_ID}`;
+  const cancelUrl = body.cancel_url || `${c.env.APP_URL}/pricing?upgrade=cancelled`;
+
+  const session = await createCheckoutSession(c.env.STRIPE_SECRET_KEY, {
+    customerId,
+    priceId: c.env.STRIPE_PRICE_ID_PRO,
+    successUrl,
+    cancelUrl,
+    organizationId: org.id,
+  });
+
+  return c.json({ url: session.url, session_id: session.id });
+});
+
+// POST /api/billing/portal
+// Authed. Creates a Billing Portal session and returns its URL.
+billing.post("/portal", async (c) => {
+  const auth = c.get("auth");
+  const body = await c.req
+    .json<{ return_url?: string }>()
+    .catch(() => ({}) as Record<string, string>);
+
+  const org = (await getOrganizationById(c.env.DB, auth.organizationId)) as
+    | { stripe_customer_id: string | null }
+    | null;
+  if (!org?.stripe_customer_id) {
+    return c.json(
+      {
+        error: "no_subscription",
+        message: "No Stripe customer is attached to this organization yet.",
+      },
+      400,
+    );
+  }
+
+  const returnUrl = body.return_url || `${c.env.APP_URL}/dashboard`;
+
+  const session = await createPortalSession(c.env.STRIPE_SECRET_KEY, {
+    customerId: org.stripe_customer_id,
+    returnUrl,
+  });
+
+  return c.json({ url: session.url });
+});
+
+export { billing };
+
+// ---------------------------------------------------------------------------
+// Public webhook handler (NOT authed — verified by HMAC signature instead)
+// ---------------------------------------------------------------------------
+
+export const billingWebhook = new Hono<{ Bindings: Env }>();
+
+type StripeEvent = {
+  id: string;
+  type: string;
+  data: { object: Record<string, unknown> };
+};
+
+function priceToTier(
+  env: Env,
+  priceId: string | undefined,
+): "free" | "pro" | "team" | "enterprise" | null {
+  if (!priceId) return null;
+  if (priceId === env.STRIPE_PRICE_ID_PRO) return "pro";
+  return null;
+}
+
+async function resolveOrgIdFromEvent(
+  env: Env,
+  obj: Record<string, unknown>,
+): Promise<string | null> {
+  // Prefer explicit metadata set at checkout time
+  const meta = (obj.metadata || {}) as Record<string, string>;
+  if (meta.organization_id) return meta.organization_id;
+
+  // Fall back to looking up the customer
+  const customer = obj.customer as string | undefined;
+  if (customer) {
+    const org = (await getOrganizationByStripeCustomer(env.DB, customer)) as
+      | { id: string }
+      | null;
+    if (org) return org.id;
+  }
+  return null;
+}
+
+billingWebhook.post("/", async (c) => {
+  const signature = c.req.header("stripe-signature");
+  if (!signature) {
+    return c.json({ error: "missing_signature" }, 400);
+  }
+
+  // Must use raw body for signature verification
+  const rawBody = await c.req.text();
+
+  const valid = await verifyWebhookSignature(
+    rawBody,
+    signature,
+    c.env.STRIPE_WEBHOOK_SECRET,
+  );
+  if (!valid) {
+    return c.json({ error: "invalid_signature" }, 400);
+  }
+
+  let event: StripeEvent;
+  try {
+    event = JSON.parse(rawBody) as StripeEvent;
+  } catch {
+    return c.json({ error: "invalid_json" }, 400);
+  }
+
+  const obj = event.data.object;
+
+  switch (event.type) {
+    case "checkout.session.completed": {
+      // Cache the customer id on the org (usually already done at /checkout
+      // time, but defensive).
+      const orgId = await resolveOrgIdFromEvent(c.env, obj);
+      const customer = obj.customer as string | undefined;
+      if (orgId && customer) {
+        await setOrganizationStripeCustomer(c.env.DB, orgId, customer);
+      }
+      break;
+    }
+
+    case "customer.subscription.created":
+    case "customer.subscription.updated": {
+      const orgId = await resolveOrgIdFromEvent(c.env, obj);
+      if (!orgId) break;
+
+      const status = obj.status as string;
+      const subscriptionId = obj.id as string;
+      const items = (obj.items as { data?: Array<{ price?: { id?: string } }> })
+        ?.data;
+      const priceId = items?.[0]?.price?.id;
+
+      const newTier = priceToTier(c.env, priceId);
+
+      if (
+        (status === "active" || status === "trialing") &&
+        newTier
+      ) {
+        await setOrganizationTier(c.env.DB, orgId, newTier, subscriptionId);
+      } else if (
+        status === "canceled" ||
+        status === "incomplete_expired" ||
+        status === "unpaid" ||
+        status === "past_due"
+      ) {
+        await setOrganizationTier(c.env.DB, orgId, "free", null);
+      }
+      break;
+    }
+
+    case "customer.subscription.deleted": {
+      const orgId = await resolveOrgIdFromEvent(c.env, obj);
+      if (orgId) {
+        await setOrganizationTier(c.env.DB, orgId, "free", null);
+      }
+      break;
+    }
+
+    default:
+      // Acknowledge unknown events with 200 so Stripe doesn't keep retrying
+      break;
+  }
+
+  return c.json({ received: true });
+});

--- a/apps/mcp-server/src/services/stripe.ts
+++ b/apps/mcp-server/src/services/stripe.ts
@@ -1,0 +1,173 @@
+// Minimal Stripe client for Cloudflare Workers — uses fetch against the
+// Stripe REST API directly and Web Crypto for webhook signature
+// verification, so we don't need to ship the `stripe` npm package (which
+// pulls in Node-only Buffer / crypto code).
+
+const STRIPE_API = "https://api.stripe.com/v1";
+
+function encodeForm(obj: Record<string, string | number | undefined>): string {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined || v === null) continue;
+    params.append(k, String(v));
+  }
+  return params.toString();
+}
+
+async function stripeFetch<T = unknown>(
+  secretKey: string,
+  path: string,
+  body?: Record<string, string | number | undefined>,
+): Promise<T> {
+  const init: RequestInit = {
+    method: body ? "POST" : "GET",
+    headers: {
+      Authorization: `Bearer ${secretKey}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+  };
+  if (body) init.body = encodeForm(body);
+
+  const res = await fetch(`${STRIPE_API}${path}`, init);
+  const json = (await res.json()) as T & { error?: { message: string } };
+  if (!res.ok) {
+    const msg = json?.error?.message || `Stripe API ${res.status}`;
+    throw new Error(`stripe: ${msg}`);
+  }
+  return json;
+}
+
+export interface StripeCustomer {
+  id: string;
+  email: string | null;
+}
+
+export async function createOrGetCustomer(
+  secretKey: string,
+  email: string,
+  organizationId: string,
+): Promise<StripeCustomer> {
+  // Search for an existing customer with this email + org metadata
+  const search = await stripeFetch<{ data: StripeCustomer[] }>(
+    secretKey,
+    `/customers?email=${encodeURIComponent(email)}&limit=1`,
+  );
+  if (search.data && search.data.length > 0) {
+    return search.data[0];
+  }
+  return stripeFetch<StripeCustomer>(secretKey, `/customers`, {
+    email,
+    "metadata[organization_id]": organizationId,
+  });
+}
+
+export interface CheckoutSession {
+  id: string;
+  url: string;
+}
+
+export async function createCheckoutSession(
+  secretKey: string,
+  params: {
+    customerId: string;
+    priceId: string;
+    successUrl: string;
+    cancelUrl: string;
+    organizationId: string;
+  },
+): Promise<CheckoutSession> {
+  return stripeFetch<CheckoutSession>(secretKey, `/checkout/sessions`, {
+    customer: params.customerId,
+    mode: "subscription",
+    "line_items[0][price]": params.priceId,
+    "line_items[0][quantity]": 1,
+    success_url: params.successUrl,
+    cancel_url: params.cancelUrl,
+    "metadata[organization_id]": params.organizationId,
+    "subscription_data[metadata][organization_id]": params.organizationId,
+    allow_promotion_codes: "true",
+    billing_address_collection: "auto",
+  });
+}
+
+export interface PortalSession {
+  id: string;
+  url: string;
+}
+
+export async function createPortalSession(
+  secretKey: string,
+  params: { customerId: string; returnUrl: string },
+): Promise<PortalSession> {
+  return stripeFetch<PortalSession>(secretKey, `/billing_portal/sessions`, {
+    customer: params.customerId,
+    return_url: params.returnUrl,
+  });
+}
+
+// Stripe webhook signatures: "t=TIMESTAMP,v1=SIG1,v1=SIG2,..."
+// Verify by computing HMAC-SHA256 over `${timestamp}.${rawBody}` and
+// checking that at least one of the v1 signatures matches in constant time.
+export async function verifyWebhookSignature(
+  rawBody: string,
+  signatureHeader: string,
+  secret: string,
+  toleranceSeconds = 300,
+): Promise<boolean> {
+  const parts = signatureHeader.split(",").map((p) => p.trim());
+  const kv = new Map<string, string[]>();
+  for (const part of parts) {
+    const [k, v] = part.split("=");
+    if (!k || !v) continue;
+    const arr = kv.get(k) || [];
+    arr.push(v);
+    kv.set(k, arr);
+  }
+  const timestamp = kv.get("t")?.[0];
+  const signatures = kv.get("v1") || [];
+  if (!timestamp || signatures.length === 0) return false;
+
+  // Timestamp freshness check (prevents replay)
+  const t = Number(timestamp);
+  if (!Number.isFinite(t)) return false;
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - t) > toleranceSeconds) return false;
+
+  const payload = `${timestamp}.${rawBody}`;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const mac = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payload),
+  );
+  const expected = bufferToHex(mac);
+
+  for (const sig of signatures) {
+    if (constantTimeEquals(sig, expected)) return true;
+  }
+  return false;
+}
+
+function bufferToHex(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i].toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -2,6 +2,11 @@ export interface Env {
   DB: D1Database;
   VECTORIZE: VectorizeIndex;
   AI: Ai;
+  // Stripe (wrangler secrets)
+  STRIPE_SECRET_KEY: string;
+  STRIPE_WEBHOOK_SECRET: string;
+  STRIPE_PRICE_ID_PRO: string;
+  APP_URL: string; // e.g. "https://getengram.app"
 }
 
 export interface AuthContext {

--- a/apps/mcp-server/wrangler.toml
+++ b/apps/mcp-server/wrangler.toml
@@ -3,6 +3,9 @@ main = "src/index.ts"
 compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]
 
+[vars]
+APP_URL = "https://getengram.app"
+
 [[d1_databases]]
 binding = "DB"
 database_name = "engram-db"

--- a/packages/db/src/queries/organizations.ts
+++ b/packages/db/src/queries/organizations.ts
@@ -30,3 +30,38 @@ export function getOrganizationByEmail(db: D1Database, email: string) {
     .bind(email)
     .first();
 }
+
+export function getOrganizationByStripeCustomer(
+  db: D1Database,
+  stripeCustomerId: string,
+) {
+  return db
+    .prepare("SELECT * FROM organizations WHERE stripe_customer_id = ?")
+    .bind(stripeCustomerId)
+    .first();
+}
+
+export function setOrganizationStripeCustomer(
+  db: D1Database,
+  id: string,
+  stripeCustomerId: string,
+) {
+  return db
+    .prepare("UPDATE organizations SET stripe_customer_id = ? WHERE id = ?")
+    .bind(stripeCustomerId, id)
+    .run();
+}
+
+export function setOrganizationTier(
+  db: D1Database,
+  id: string,
+  tier: "free" | "pro" | "team" | "enterprise",
+  stripeSubscriptionId: string | null,
+) {
+  return db
+    .prepare(
+      "UPDATE organizations SET tier = ?, stripe_subscription_id = ? WHERE id = ?",
+    )
+    .bind(tier, stripeSubscriptionId, id)
+    .run();
+}


### PR DESCRIPTION
## Summary
- Adds full subscription flow: Checkout → Webhook-driven tier upgrade → Billing Portal for self-service.
- Pattern matches ChatGPT Plus / Claude Pro: user hits an Upgrade button, lands on Stripe Checkout, pays, is redirected back, and their tier updates via webhook. Existing subscribers get a Manage Billing link to the Stripe Portal.
- **No \`stripe\` npm dependency** — the Workers runtime has no Node Buffer/crypto, so we call api.stripe.com directly via \`fetch\` and verify webhook signatures with Web Crypto (HMAC-SHA256). ~200 LoC vs ~300KB for the stripe SDK.

## Endpoints
| Method | Path | Auth | Purpose |
|---|---|---|---|
| POST | \`/api/billing/checkout\` | API key | Create a Checkout Session → return URL |
| POST | \`/api/billing/portal\`   | API key | Create a Billing Portal Session → return URL |
| POST | \`/billing/webhook\`      | HMAC sig | Stripe → us; updates tier/subscription |

## Webhook events handled
- \`checkout.session.completed\` — caches \`stripe_customer_id\` on the org
- \`customer.subscription.created\` / \`updated\` — upgrades tier if \`active\`/\`trialing\`, downgrades on bad statuses
- \`customer.subscription.deleted\` — downgrades to free

Unknown events are acknowledged with 200 so Stripe doesn't retry.

## Security
- Webhook signature verification uses Web Crypto HMAC-SHA256
- 5-minute timestamp freshness window (replay protection)
- Constant-time hex comparison
- Multiple \`v1=\` entries supported (secret rotation)
- Webhook route is mounted BEFORE the \`/api/*\` auth middleware so Stripe can hit it unauthenticated

## Tests
- 6 new tests for the webhook verifier: happy path, tampered body, wrong secret, stale timestamp, malformed header, multi-signature rotation
- \`pnpm test\` → 29/29 passing

## Smoke-tested in production
\`\`\`
POST mcp.getengram.app/signup                 → 201 + api_key
POST mcp.getengram.app/api/billing/checkout   → 200 + cs_test_... URL
POST mcp.getengram.app/api/billing/portal     → 200 + test_... URL
POST mcp.getengram.app/billing/webhook (bad)  → 400 invalid_signature
POST mcp.getengram.app/billing/webhook (none) → 400 missing_signature
\`\`\`

## Stripe config (test mode)
- Product: \`prod_UJcVVtm108Noa7\` — "Engram Pro"
- Price:   \`price_1TKzGlDTNomhfcZaVc73p8TT\` — $20/mo USD recurring
- Webhook endpoint: \`we_1TKzNPDTNomhfcZamLqXIH7x\` → \`mcp.getengram.app/billing/webhook\`
- Worker secrets already set: \`STRIPE_SECRET_KEY\`, \`STRIPE_WEBHOOK_SECRET\`, \`STRIPE_PRICE_ID_PRO\`
- \`APP_URL\` = \`https://getengram.app\` (in wrangler.toml)

## Not in this PR (follow-ups)
- [ ] Swap test keys for live keys once Get Engram LLC Stripe account is live
- [ ] Frontend: Upgrade button on engram-web that POSTs to \`/api/billing/checkout\`
- [ ] Dashboard "Manage Billing" button wired to \`/api/billing/portal\`
- [ ] ToS + Privacy on getengram.app (required before charging real money)

🤖 Generated with [Claude Code](https://claude.com/claude-code)