### PR TITLE
feat(billing): real pricing — Pro $39/mo, Team $49/seat/mo

### DIFF
--- a/apps/mcp-server/src/routes/billing.ts
+++ b/apps/mcp-server/src/routes/billing.ts
@@ -20,11 +20,34 @@ const billing = new Hono<HonoEnv>();
 // POST /api/billing/checkout
 // Authed. Creates a Checkout Session and returns its URL. The caller is
 // expected to redirect the user to the returned URL.
+//
+// Body:
+//   plan        — "pro" (default) or "team"
+//   quantity    — only meaningful for team; defaults to 1 seat. Customers
+//                 can also edit this inside Stripe Checkout via the
+//                 adjustable_quantity toggle.
+//   success_url — override redirect on success
+//   cancel_url  — override redirect on cancel
 billing.post("/checkout", async (c) => {
   const auth = c.get("auth");
   const body = await c.req
-    .json<{ success_url?: string; cancel_url?: string; plan?: string }>()
-    .catch(() => ({}) as Record<string, string>);
+    .json<{
+      success_url?: string;
+      cancel_url?: string;
+      plan?: "pro" | "team";
+      quantity?: number;
+    }>()
+    .catch(() => ({}) as Record<string, never>);
+
+  const plan = body.plan === "team" ? "team" : "pro";
+  const priceId =
+    plan === "team" ? c.env.STRIPE_PRICE_ID_TEAM : c.env.STRIPE_PRICE_ID_PRO;
+  if (!priceId) {
+    return c.json(
+      { error: "price_not_configured", message: `No Stripe price configured for plan="${plan}"` },
+      500,
+    );
+  }
 
   const org = (await getOrganizationById(c.env.DB, auth.organizationId)) as
     | { id: string; email: string | null; stripe_customer_id: string | null }
@@ -58,15 +81,19 @@ billing.post("/checkout", async (c) => {
     `${c.env.APP_URL}/dashboard?upgrade=success&session_id={CHECKOUT_SESSION_ID}`;
   const cancelUrl = body.cancel_url || `${c.env.APP_URL}/pricing?upgrade=cancelled`;
 
+  const quantity = plan === "team" ? Math.max(1, body.quantity ?? 1) : 1;
+
   const session = await createCheckoutSession(c.env.STRIPE_SECRET_KEY, {
     customerId,
-    priceId: c.env.STRIPE_PRICE_ID_PRO,
+    priceId,
+    quantity,
+    adjustableQuantity: plan === "team",
     successUrl,
     cancelUrl,
     organizationId: org.id,
   });
 
-  return c.json({ url: session.url, session_id: session.id });
+  return c.json({ url: session.url, session_id: session.id, plan });
 });
 
 // POST /api/billing/portal
@@ -120,6 +147,7 @@ function priceToTier(
 ): "free" | "pro" | "team" | "enterprise" | null {
   if (!priceId) return null;
   if (priceId === env.STRIPE_PRICE_ID_PRO) return "pro";
+  if (priceId === env.STRIPE_PRICE_ID_TEAM) return "team";
   return null;
 }
 

--- a/apps/mcp-server/src/services/stripe.ts
+++ b/apps/mcp-server/src/services/stripe.ts
@@ -71,23 +71,33 @@ export async function createCheckoutSession(
   params: {
     customerId: string;
     priceId: string;
+    quantity?: number;
+    // If true, we let the customer tweak the quantity inside the Checkout
+    // session itself (e.g. change the seat count before paying).
+    adjustableQuantity?: boolean;
     successUrl: string;
     cancelUrl: string;
     organizationId: string;
   },
 ): Promise<CheckoutSession> {
-  return stripeFetch<CheckoutSession>(secretKey, `/checkout/sessions`, {
+  const body: Record<string, string | number> = {
     customer: params.customerId,
     mode: "subscription",
     "line_items[0][price]": params.priceId,
-    "line_items[0][quantity]": 1,
+    "line_items[0][quantity]": params.quantity ?? 1,
     success_url: params.successUrl,
     cancel_url: params.cancelUrl,
     "metadata[organization_id]": params.organizationId,
     "subscription_data[metadata][organization_id]": params.organizationId,
     allow_promotion_codes: "true",
     billing_address_collection: "auto",
-  });
+  };
+  if (params.adjustableQuantity) {
+    body["line_items[0][adjustable_quantity][enabled]"] = "true";
+    body["line_items[0][adjustable_quantity][minimum]"] = 1;
+    body["line_items[0][adjustable_quantity][maximum]"] = 999;
+  }
+  return stripeFetch<CheckoutSession>(secretKey, `/checkout/sessions`, body);
 }
 
 export interface PortalSession {

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -6,6 +6,7 @@ export interface Env {
   STRIPE_SECRET_KEY: string;
   STRIPE_WEBHOOK_SECRET: string;
   STRIPE_PRICE_ID_PRO: string;
+  STRIPE_PRICE_ID_TEAM: string;
   APP_URL: string; // e.g. "https://getengram.app"
 }
 


### PR DESCRIPTION
## Summary

- Replace the placeholder \$20/mo Pro price (from earlier WIP) with the real numbers on the pricing page: **Pro \$39/mo**, **Team \$49/seat/mo**
- Add `STRIPE_PRICE_ID_TEAM` to the `Env` type and map it in `priceToTier()` so Team subscriptions flow correctly through the webhook
- `/api/billing/checkout` now accepts `{ plan: "pro" | "team", quantity }`. For Team, Stripe's `adjustable_quantity` is on so customers can tweak seat count inside Checkout itself
- Webhook handler needed no changes — it already routes by priceId

## Stripe side (already done)

- Archived `price_1TKzGlDTNomhfcZaVc73p8TT` (\$20/mo — stale placeholder)
- Created `price_1TKzhXDTNomhfcZarUlcFgfP` — Pro \$39/mo on `prod_UJcVVtm108Noa7`
- Created `prod_UJcxTO1VascCZJ` — Engram Team product
- Created `price_1TKzhmDTNomhfcZaImkjZVHx` — Team \$49/seat/mo
- `wrangler secret put STRIPE_PRICE_ID_PRO` → new \$39 ID
- `wrangler secret put STRIPE_PRICE_ID_TEAM` → new Team ID
- Worker deployed to `mcp.getengram.app`

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 29/29 passing
- [x] Worker deployed successfully
- [ ] End-to-end: run `curl -X POST mcp.getengram.app/api/billing/checkout -d '{"plan":"pro"}'` with an authed API key, confirm it returns a Checkout URL at the \$39 price
- [ ] Same for `{"plan":"team","quantity":3}` → \$147/mo total
- [ ] Upgrade flow webhook → `organizations.tier` gets set to `pro` / `team`