### PR TITLE
feat(tier): unlimited conversations on free tier

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -21,7 +21,7 @@ export const TIER_LIMITS: Record<Tier, {
 }> = {
   free: {
     messages_per_month: 1_000,
-    conversations: 5,
+    conversations: -1, // unlimited — messages/month is the only binding cap on free
     seats: 1,
     api_keys: 1,
     webhooks: false,


### PR DESCRIPTION
## Summary

The 5-conversation cap on Free was doing no gating work — the 1,000 msgs/month cap is the real binding constraint. Bumping conversations to unlimited on Free removes a frustrating error surface during evaluation and matches the pattern every higher tier already follows.

One-line constant change. `tier.ts:checkConversationLimit` already handles `-1` as unlimited.

## Test plan

- [x] pnpm test — 29/29 passing
- [x] Worker deployed (`cf3b215a-4eb5-4f6c-9387-d1b620adcdbe`)
- [x] Live smoke test: created a 7th+ conversation on a Free tier API key successfully — previously would have returned `conversation_limit_exceeded`

## Follow-ups (not in this PR)

- [ ] Update engram-web pricing card ("5 conversations" → "Unlimited conversations") — separate PR on engram-web
- [ ] Update local memory `project_pricing.md` to reflect the new Free shape