### PR TITLE
feat(server): CORS on /api/* for browser dashboard

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -37,15 +37,19 @@ app.all("/mcp", authMiddleware, async (c) => {
   return transport.handleRequest(c.req.raw);
 });
 
-// Public signup endpoint (CORS for the marketing site)
+// CORS for browser-originated calls from the marketing site + dashboard.
+// /signup and /api/* both need this; the Stripe webhook does not (it's
+// called by Stripe's servers, not a browser).
+const BROWSER_ORIGINS = [
+  "https://getengram.app",
+  "https://www.getengram.app",
+  "http://localhost:3000",
+];
+
 app.use(
   "/signup",
   cors({
-    origin: [
-      "https://getengram.app",
-      "https://www.getengram.app",
-      "http://localhost:3000",
-    ],
+    origin: BROWSER_ORIGINS,
     allowMethods: ["POST", "OPTIONS"],
     allowHeaders: ["Content-Type"],
   }),
@@ -56,7 +60,17 @@ app.route("/signup", signup);
 // Mounted BEFORE the /api/* auth middleware so it isn't gated.
 app.route("/billing/webhook", billingWebhook);
 
-// REST API routes (all require auth)
+// REST API routes (all require auth). CORS runs before the auth middleware
+// so preflight OPTIONS requests succeed without a bearer token.
+app.use(
+  "/api/*",
+  cors({
+    origin: BROWSER_ORIGINS,
+    allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+    allowHeaders: ["Content-Type", "Authorization"],
+    maxAge: 86400,
+  }),
+);
 app.use("/api/*", authMiddleware);
 app.route("/api/keys", keys);
 app.route("/api/seats", seats);


### PR DESCRIPTION
## Summary
- Adds CORS middleware to \`/api/*\` with the getengram.app origins and the \`Authorization\` header allowed, mounted before \`authMiddleware\` so preflight \`OPTIONS\` succeeds without a bearer token.
- Factored the \`BROWSER_ORIGINS\` list so \`/signup\` and \`/api/*\` share a single source of truth.

## Why
The upcoming \`/dashboard\` page on getengram.app calls \`/api/usage\`, \`/api/keys\`, and \`/api/billing/*\` directly from the browser with the user's API key. Without CORS those fetches fail with a preflight error.

## Test plan
- [x] \`pnpm -F @getengram/mcp-server typecheck\`
- [x] \`pnpm -F @getengram/mcp-server test\` (29/29)
- [ ] After deploy: \`curl -i -X OPTIONS -H 'Origin: https://getengram.app' -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: authorization' https://mcp.getengram.app/api/usage\` returns 204 with \`Access-Control-Allow-Origin\` and \`Access-Control-Allow-Headers: authorization\`.