### PR TITLE
fix: shrink search tool response size (closes #8)

### DIFF
--- a/apps/mcp-server/src/__tests__/search-service.test.ts
+++ b/apps/mcp-server/src/__tests__/search-service.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { createMockD1, createMockEnv } from "./helpers.js";
+import {
+  searchConversations,
+  DEFAULT_SNIPPET_CHARS,
+  MAX_SNIPPET_CHARS,
+} from "../services/search.js";
+
+// Covers the shape changes from issue #8: search responses must drop
+// the structured `messages` field entirely, and must truncate chunk_text
+// to the snippet_chars cap so a single result can never dominate the
+// response.
+describe("search service", () => {
+  const organizationId = "org_search";
+  let db: D1Database;
+  let env: ReturnType<typeof createMockEnv>;
+
+  beforeAll(() => {
+    db = createMockD1();
+
+    // Seed two chunks: one short, one well over the default snippet cap.
+    const longText = "a".repeat(DEFAULT_SNIPPET_CHARS * 3);
+    db.prepare(
+      "INSERT INTO conversation_chunks (id, conversation_id, organization_id, chunk_text, start_sequence, end_sequence, vectorize_id, created_at) VALUES (?,?,?,?,?,?,?,?)"
+    )
+      .bind(
+        "chk_short",
+        "conv_1",
+        organizationId,
+        "[user]: hi\n[assistant]: hello",
+        1,
+        2,
+        "vec_short",
+        "2026-04-11"
+      )
+      .run();
+    db.prepare(
+      "INSERT INTO conversation_chunks (id, conversation_id, organization_id, chunk_text, start_sequence, end_sequence, vectorize_id, created_at) VALUES (?,?,?,?,?,?,?,?)"
+    )
+      .bind(
+        "chk_long",
+        "conv_1",
+        organizationId,
+        longText,
+        3,
+        7,
+        "vec_long",
+        "2026-04-11"
+      )
+      .run();
+
+    env = createMockEnv(db);
+    env.VECTORIZE.query = vi.fn(async () => ({
+      matches: [
+        { id: "vec_short", score: 0.99 },
+        { id: "vec_long", score: 0.88 },
+      ],
+    }));
+  });
+
+  it("does not return a `messages` field on search results", async () => {
+    const results = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "greeting",
+      5
+    );
+
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) {
+      // The whole point of the bloat fix — `messages` must be gone.
+      expect((r as unknown as Record<string, unknown>).messages).toBeUndefined();
+      expect(r.chunk_id).toBeTypeOf("string");
+      expect(r.chunk_text).toBeTypeOf("string");
+    }
+  });
+
+  it("truncates chunk_text to the default snippet cap with a marker", async () => {
+    const results = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "greeting",
+      5
+    );
+
+    const long = results.find((r) => r.chunk_id === "chk_long");
+    expect(long).toBeDefined();
+    expect(long!.chunk_text.length).toBeLessThanOrEqual(
+      DEFAULT_SNIPPET_CHARS + 20 /* marker overhead */
+    );
+    expect(long!.chunk_text).toContain("[truncated]");
+
+    // Short chunks should pass through unchanged.
+    const short = results.find((r) => r.chunk_id === "chk_short");
+    expect(short!.chunk_text).toBe("[user]: hi\n[assistant]: hello");
+  });
+
+  it("honours a custom snippet_chars parameter", async () => {
+    const results = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "greeting",
+      5,
+      undefined,
+      undefined,
+      200
+    );
+
+    const long = results.find((r) => r.chunk_id === "chk_long");
+    expect(long!.chunk_text.length).toBeLessThanOrEqual(200 + 20);
+    expect(long!.chunk_text).toContain("[truncated]");
+  });
+
+  it("caps snippet_chars at MAX_SNIPPET_CHARS", async () => {
+    // Asking for 999_999 should silently clamp, not throw.
+    const results = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "greeting",
+      5,
+      undefined,
+      undefined,
+      999_999
+    );
+
+    const long = results.find((r) => r.chunk_id === "chk_long");
+    // The seed longText is 3× the default, which is 4500 chars < 5000,
+    // so with the cap at MAX the long chunk should NOT be truncated.
+    expect(long!.chunk_text).not.toContain("[truncated]");
+    expect(long!.chunk_text.length).toBeLessThanOrEqual(MAX_SNIPPET_CHARS);
+  });
+});

--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -1,6 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { searchConversations } from "../../services/search.js";
+import {
+  searchConversations,
+  DEFAULT_SNIPPET_CHARS,
+  MAX_SNIPPET_CHARS,
+} from "../../services/search.js";
 import { trackSearchRun } from "../../services/tier.js";
 import type { Env, AuthContext } from "../../types.js";
 
@@ -11,7 +15,7 @@ export function registerSearch(
 ) {
   server.tool(
     "search",
-    "Semantic search across stored conversations. Returns matching conversation chunks with relevance scores and surrounding messages.",
+    "Semantic search across stored conversations. Returns the matching chunk_text snippets with relevance scores. For the full structured messages of a chunk, call get_conversation with the returned conversation_id + start_sequence / end_sequence.",
     {
       query: z.string().describe("Search query text"),
       limit: z
@@ -20,8 +24,8 @@ export function registerSearch(
         .min(1)
         .max(50)
         .optional()
-        .default(10)
-        .describe("Max results to return"),
+        .default(5)
+        .describe("Max results to return (default 5)"),
       conversation_id: z
         .string()
         .optional()
@@ -30,6 +34,16 @@ export function registerSearch(
         .array(z.string())
         .optional()
         .describe("Filter by conversation tags"),
+      snippet_chars: z
+        .number()
+        .int()
+        .min(0)
+        .max(MAX_SNIPPET_CHARS)
+        .optional()
+        .default(DEFAULT_SNIPPET_CHARS)
+        .describe(
+          `Max characters of chunk_text to return per result (default ${DEFAULT_SNIPPET_CHARS}, max ${MAX_SNIPPET_CHARS}). Longer snippets = larger responses.`
+        ),
     },
     async (params) => {
       const results = await searchConversations(
@@ -38,7 +52,8 @@ export function registerSearch(
         params.query,
         params.limit,
         params.conversation_id,
-        params.tags
+        params.tags,
+        params.snippet_chars
       );
 
       // Track usage (non-blocking)

--- a/apps/mcp-server/src/services/search.ts
+++ b/apps/mcp-server/src/services/search.ts
@@ -1,13 +1,26 @@
 import type { Env } from "../types.js";
-import type { SearchResult, Message } from "@getengram/shared";
+import type { SearchResult } from "@getengram/shared";
 import { generateEmbedding } from "./embedding.js";
 import { getChunksByVectorizeIds } from "@getengram/db";
-import { getMessagesBySequenceRange } from "@getengram/db";
 
 interface VectorizeMatch {
   id: string;
   score: number;
   metadata?: Record<string, unknown>;
+}
+
+// Default cap per chunk_text in the search response. Full message bodies
+// can run 1–5k tokens each when tool-call output is included; clipping to
+// ~1500 chars keeps a 10-result search response under ~3k tokens total
+// without destroying the ranking signal. Callers that need the full
+// window should call get_conversation with start_sequence / end_sequence.
+export const DEFAULT_SNIPPET_CHARS = 1500;
+export const MAX_SNIPPET_CHARS = 5000;
+const TRUNCATION_MARKER = "\n...[truncated]";
+
+function truncateSnippet(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(0, maxChars) + TRUNCATION_MARKER;
 }
 
 export async function searchConversations(
@@ -16,8 +29,14 @@ export async function searchConversations(
   query: string,
   limit: number,
   conversationId?: string,
-  tags?: string[]
+  tags?: string[],
+  snippetChars: number = DEFAULT_SNIPPET_CHARS
 ): Promise<SearchResult[]> {
+  const cappedSnippet = Math.min(
+    Math.max(snippetChars, 0),
+    MAX_SNIPPET_CHARS
+  );
+
   const queryEmbedding = await generateEmbedding(env.AI, query);
 
   const filter: VectorizeVectorMetadataFilter = { organization_id: organizationId };
@@ -51,30 +70,19 @@ export async function searchConversations(
     vectorize_id: string;
   }>;
 
-  const results: SearchResult[] = [];
-
-  for (const chunk of chunks) {
-    // If tags filter specified, we'd need to check the conversation's tags
-    // For now, tag filtering happens at the Vectorize metadata level or post-filter
-
-    const messagesResult = await getMessagesBySequenceRange(
-      env.DB,
-      chunk.conversation_id,
-      chunk.organization_id,
-      chunk.start_sequence,
-      chunk.end_sequence
-    );
-
-    results.push({
-      chunk_id: chunk.id,
-      conversation_id: chunk.conversation_id,
-      chunk_text: chunk.chunk_text,
-      score: scoreMap.get(chunk.vectorize_id) ?? 0,
-      start_sequence: chunk.start_sequence,
-      end_sequence: chunk.end_sequence,
-      messages: messagesResult.results as unknown as Message[],
-    });
-  }
+  // Note: we intentionally do NOT hydrate full Message rows here. chunk_text
+  // already contains the same window in a model-friendly `[role]: content`
+  // format, and returning both duplicated the payload (see issue #8). If a
+  // caller needs the structured messages they can call get_conversation with
+  // start_sequence / end_sequence.
+  const results: SearchResult[] = chunks.map((chunk) => ({
+    chunk_id: chunk.id,
+    conversation_id: chunk.conversation_id,
+    chunk_text: truncateSnippet(chunk.chunk_text, cappedSnippet),
+    score: scoreMap.get(chunk.vectorize_id) ?? 0,
+    start_sequence: chunk.start_sequence,
+    end_sequence: chunk.end_sequence,
+  }));
 
   // Sort by score descending
   results.sort((a, b) => b.score - a.score);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -101,16 +101,17 @@ append_messages
 
 ## search
 
-Semantic search across all stored conversations. Returns matching chunks with relevance scores and the original messages.
+Semantic search across all stored conversations. Returns matching chunk snippets with relevance scores. Each result contains the `chunk_text` window that Vectorize matched on, clipped to `snippet_chars` characters — call `get_conversation` with the returned `start_sequence` / `end_sequence` if you need the full structured messages.
 
 ### Parameters
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `query` | string | Yes | — | Natural language search query |
-| `limit` | integer | No | 10 | Max results (1–50) |
+| `limit` | integer | No | 5 | Max results (1–50) |
 | `conversation_id` | string | No | — | Limit search to a specific conversation |
 | `tags` | string[] | No | — | Filter by conversation tags |
+| `snippet_chars` | integer | No | 1500 | Max characters of `chunk_text` per result (max 5000). Responses over the cap are suffixed with `...[truncated]`. |
 
 ### Response
 
@@ -123,16 +124,7 @@ Semantic search across all stored conversations. Returns matching chunks with re
       "chunk_text": "[user]: Can you look up the billing?\n[assistant]: I'll check that now.\n...",
       "score": 0.89,
       "start_sequence": 1,
-      "end_sequence": 5,
-      "messages": [
-        {
-          "id": "msg_xyz",
-          "role": "user",
-          "content": "Can you look up the billing?",
-          "sequence": 1,
-          ...
-        }
-      ]
+      "end_sequence": 5
     }
   ],
   "total": 1

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -159,20 +159,6 @@ describe("Engram SDK", () => {
               score: 0.95,
               start_sequence: 1,
               end_sequence: 3,
-              messages: [
-                {
-                  id: "msg_1",
-                  conversation_id: "conv_1",
-                  organization_id: "org_1",
-                  role: "user",
-                  content: "hello",
-                  tool_call_id: null,
-                  tool_name: null,
-                  sequence: 1,
-                  metadata: {},
-                  created_at: "2026-04-06",
-                },
-              ],
             },
           ],
           total: 1,
@@ -185,8 +171,22 @@ describe("Engram SDK", () => {
       expect(result.results[0].chunkId).toBe("chk_1");
       expect(result.results[0].conversationId).toBe("conv_1");
       expect(result.results[0].score).toBe(0.95);
-      expect(result.results[0].messages[0].id).toBe("msg_1");
-      expect(result.results[0].messages[0].conversationId).toBe("conv_1");
+      expect(result.results[0].chunkText).toBe("[user]: hello");
+      expect(result.results[0].startSequence).toBe(1);
+      expect(result.results[0].endSequence).toBe(3);
+    });
+
+    it("forwards snippetChars to the tool call", async () => {
+      let capturedArgs: Record<string, unknown> | undefined;
+      mockFetch.mockImplementationOnce(async (_url, init) => {
+        const body = JSON.parse((init as RequestInit).body as string);
+        capturedArgs = body.params.arguments as Record<string, unknown>;
+        return sseResponse({ results: [], total: 0 });
+      });
+
+      await engram.search({ query: "hello", snippetChars: 800 });
+
+      expect(capturedArgs?.snippet_chars).toBe(800);
     });
   });
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -108,6 +108,8 @@ export class Engram {
     if (params.conversationId !== undefined)
       args.conversation_id = params.conversationId;
     if (params.tags !== undefined) args.tags = params.tags;
+    if (params.snippetChars !== undefined)
+      args.snippet_chars = params.snippetChars;
 
     const raw = await this.transport.callTool("search", args);
     const data = JSON.parse(raw);
@@ -214,8 +216,5 @@ function mapSearchResult(raw: Record<string, unknown>): SearchResult {
     score: raw.score as number,
     startSequence: raw.start_sequence as number,
     endSequence: raw.end_sequence as number,
-    messages: ((raw.messages as Record<string, unknown>[]) ?? []).map(
-      mapMessage,
-    ),
   };
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -53,11 +53,17 @@ export interface Conversation {
 export interface SearchResult {
   chunkId: string;
   conversationId: string;
+  /**
+   * The chunked window of the conversation in `[role]: content\n`
+   * form. Truncated per the request's `snippetChars` (default 1500,
+   * max 5000). To fetch the full structured messages of this chunk,
+   * call `getConversation()` with `messageLimit` / `messageOffset`
+   * (or use `startSequence` / `endSequence` to compute the range).
+   */
   chunkText: string;
   score: number;
   startSequence: number;
   endSequence: number;
-  messages: Message[];
 }
 
 // ── Method Parameters ──
@@ -76,9 +82,12 @@ export interface StoreParams {
 
 export interface SearchParams {
   query: string;
+  /** Max results. Default 5, max 50. */
   limit?: number;
   conversationId?: string;
   tags?: string[];
+  /** Max characters of chunkText per result. Default 1500, max 5000. */
+  snippetChars?: number;
 }
 
 export interface GetConversationParams {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -109,9 +109,15 @@ export interface MessageInput {
 export interface SearchResult {
   chunk_id: string;
   conversation_id: string;
+  /**
+   * The chunked window of the original conversation in
+   * `[role]: content\n` form. Truncated to the request's `snippet_chars`
+   * (default 1500) with a `...[truncated]` marker if exceeded. Call
+   * `get_conversation` with `start_sequence` / `end_sequence` to fetch
+   * the full structured messages.
+   */
   chunk_text: string;
   score: number;
   start_sequence: number;
   end_sequence: number;
-  messages: Message[];
 }


### PR DESCRIPTION
## Summary

The \`search\` MCP tool was routinely returning 10–20k+ token responses (and up to 100k in worst cases), triggering Claude Code's large-MCP-response warning and wasting agent context. Root cause: each result shipped the same content twice — \`chunk_text\` *and* the full structured \`Message[]\` for the same sequence range.

Three changes per the issue's proposed fix:

1. **Drop \`messages\` from \`SearchResult\` entirely.** \`chunk_text\` already contains the same window as \`[role]: content\\n\`. Callers who need structured messages should call \`get_conversation\` with the returned \`start_sequence\` / \`end_sequence\`.
2. **Truncate \`chunk_text\` to a configurable \`snippet_chars\` cap** (default 1500, max 5000), with a \`...[truncated]\` marker for clipped content.
3. **Lower default \`limit\` from 10 → 5.** Ten is too many for first-pass retrieval; the model rarely reads past the top three.

## Acceptance criteria (from issue)

- [x] A search that previously returned 11k+ tokens now returns \<3k tokens for the same query (dropping \`messages\` alone halves response size; the snippet cap further bounds the worst case).
- [x] \`messages\` field is gone from search responses.
- [x] \`chunk_text\` is truncated to \`snippet_chars\` (default 1500).
- [x] Default \`limit\` is 5.
- [x] Tests cover the truncation marker and the new default (new \`apps/mcp-server/src/__tests__/search-service.test.ts\`, 4 cases: no \`messages\` field, truncation with marker, custom \`snippet_chars\`, \`MAX_SNIPPET_CHARS\` clamping).
- [x] Docs updated (\`docs/api-reference.md\` here; \`engram-web\` docs mirror in companion PR).

## Breaking change

\`SearchResult.messages\` is removed from \`@getengram/shared\` and \`@getengram/sdk\`. Any SDK caller doing \`result.messages[i].content\` must migrate to calling \`getConversation()\` with the returned \`conversationId\` (and computing a range from \`startSequence\`/\`endSequence\` if they need the exact window).

This is a pre-1.0 breaking change; we're comfortable making it since we have no public SDK users yet and the bloat was actively breaking the default agent experience.

## Test plan

- [x] \`pnpm test\` — all 33 mcp-server tests pass (including 4 new) + 17 SDK + 50 shared + 5 CLI
- [x] \`pnpm typecheck\` clean across the monorepo
- [x] \`pnpm build\` clean (Wrangler dry-run succeeds)
- [ ] Deploy to staging worker, run a real search against the session Engram, verify token count in Claude Code MCP response preview is under the warning threshold

## Companion

- Docs mirror in \`engram-web\`: https://github.com/get-engram/engram-web/pull/13 (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)