### PR TITLE
ci: add PR + main GitHub Actions workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,82 @@
+name: Main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: main
+  cancel-in-progress: false
+
+jobs:
+  # Fast gate — same checks as PR, runs first.
+  check:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+  # Worker deploy dry-run — catches wrangler config errors, missing bindings,
+  # bundle size limits, and compatibility issues that only surface at deploy
+  # time. Runs after the main gate.
+  worker-deploy-check:
+    name: Worker deploy dry-run
+    runs-on: ubuntu-latest
+    needs: check
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build worker (wrangler deploy --dry-run)
+        working-directory: apps/mcp-server
+        run: pnpm build
+
+      - name: Upload worker bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-server-bundle
+          path: apps/mcp-server/dist
+          retention-days: 7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,44 @@
+name: PR
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel in-progress runs when a new commit is pushed to the same PR.
+concurrency:
+  group: pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary

First CI workflows for the engram monorepo. Locks in the existing 105 tests (50 shared + 17 SDK + 5 CLI + 33 mcp-server) and the typecheck/build gates behind automated enforcement so we can merge PRs safely.

## What runs

### \`pr.yml\` — on pull requests to main
- Checkout
- Install pnpm 9.15.0 + Node 20 (with pnpm cache)
- \`pnpm install --frozen-lockfile\`
- \`pnpm typecheck\` (turbo → tsc --noEmit on every package)
- \`pnpm test\` (turbo → vitest run on every package)
- \`pnpm build\` (turbo → tsc / wrangler deploy --dry-run)
- Concurrency group: cancels stale runs when new commits are pushed to the same PR
- Target wall time: <2min

### \`main.yml\` — on pushes to main
- Same fast gate (typecheck + test + build)
- **Additional job** \`worker-deploy-check\`: runs wrangler's deploy --dry-run for the MCP server and uploads the \`apps/mcp-server/dist\` bundle as an artifact for 7 days. Catches config errors, missing bindings, bundle-size issues, and compatibility-date problems that only surface at deploy time.
- Concurrency group: serialized on main, never cancelled

## Intentional non-goals for this PR

- **No deploys.** CI builds and artifact-uploads the worker bundle but does not push to Cloudflare. Actual deploys still happen from local via \`wrangler deploy\` with the existing operator creds. When we're ready, we add a \`deploy.yml\` with \`CLOUDFLARE_API_TOKEN\` as a repo secret.
- **No integration tests against real Workers runtime.** The existing mock D1 + mocked Vectorize/AI in \`apps/mcp-server/src/__tests__/helpers.ts\` is good enough to unblock merges today. Migrating to \`@cloudflare/vitest-pool-workers\` is filed as a follow-up.
- **No code coverage reporting.** Adding later once we know what threshold makes sense.
- **No lint.** engram packages don't have per-package lint scripts today; adding later if we want it.

## Test plan

- [ ] Workflow appears in the Actions tab on push
- [ ] All jobs turn green on this PR
- [ ] Merge time after green is <2 minutes
- [ ] On main push, \`worker-deploy-check\` runs and uploads the \`mcp-server-bundle\` artifact

## Follow-up work

- CI for engram-web (separate PR, same structure — lint + typecheck + build)
- Migrate mcp-server tests to \`@cloudflare/vitest-pool-workers\` for real workerd + D1 runtime
- Add \`deploy.yml\` workflow once we're ready to move deploys into GitHub
- Add MCP tool handler contract tests (one per tool) to catch breaking changes like #8 automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)