### PR TITLE
ci: build workspace packages before worker deploy check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,82 @@
+name: Main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: main
+  cancel-in-progress: false
+
+jobs:
+  # Fast gate — same checks as PR, runs first.
+  check:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+  # Worker deploy dry-run — catches wrangler config errors, missing bindings,
+  # bundle size limits, and compatibility issues that only surface at deploy
+  # time. Runs after the main gate.
+  worker-deploy-check:
+    name: Worker deploy dry-run
+    runs-on: ubuntu-latest
+    needs: check
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build worker (wrangler deploy --dry-run)
+        working-directory: apps/mcp-server
+        run: pnpm build
+
+      - name: Upload worker bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-server-bundle
+          path: apps/mcp-server/dist
+          retention-days: 7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build workspace packages
+        run: pnpm -F @getengram/shared -F @getengram/db build
+
       - name: Build worker (wrangler deploy --dry-run)
         working-directory: apps/mcp-server
         run: pnpm build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,44 @@
+name: PR
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel in-progress runs when a new commit is pushed to the same PR.
+concurrency:
+  group: pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary
- Fix main-branch CI failure in \`worker-deploy-check\` job
- \`@getengram/db\` and \`@getengram/shared\` aren't built yet on a fresh runner, so wrangler's esbuild can't resolve \`./dist/index.js\`
- Build the two workspace packages before running the worker deploy dry-run

## Test plan
- [x] Workflow re-runs green on this PR
- [ ] Post-merge main run goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)