### PR TITLE
fix(auth): stage 1 worker fixes for Supabase dashboard

### DIFF
--- a/apps/mcp-server/src/routes/signup.ts
+++ b/apps/mcp-server/src/routes/signup.ts
@@ -16,31 +16,65 @@ type HonoEnv = { Bindings: Env };
 
 const signup = new Hono<HonoEnv>();
 
+// POST /signup — mint (or attach) an API key for a given email.
+//
+// Auth: shared-secret Bearer. The Next.js server action on engram-web
+// sends `Authorization: Bearer ${WORKER_SIGNUP_SECRET}` so random
+// internet traffic can't mint keys against arbitrary emails. This is
+// a temporary mitigation until stage 2, when the worker will verify
+// Supabase JWTs via JWKS and take the user identity from there.
+//
+// Behavior is idempotent-ish: if an org already exists for this email
+// (either from the pre-Supabase self-serve flow, or from a race on
+// the same user's first sign-in), we attach a fresh API key to the
+// existing org and return it. We never return the user's previous
+// key — it's hashed.
 signup.post("/", async (c) => {
+  // Shared-secret gate
+  const configured = c.env.WORKER_SIGNUP_SECRET;
+  if (!configured) {
+    return c.json(
+      { error: "server_misconfigured", message: "WORKER_SIGNUP_SECRET is not set" },
+      500,
+    );
+  }
+  const authHeader = c.req.header("authorization") ?? "";
+  const presented = authHeader.replace(/^Bearer\s+/i, "");
+  if (presented !== configured) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
   const body = await c.req.json().catch(() => null);
   const parsed = SignupSchema.safeParse(body);
 
   if (!parsed.success) {
     return c.json(
-      { error: "Invalid input", details: parsed.error.flatten() },
+      { error: "invalid_input", details: parsed.error.flatten() },
       400,
     );
   }
 
   const { email, plan } = parsed.data;
 
-  const existing = await getOrganizationByEmail(c.env.DB, email);
+  // Find-or-create the org
+  let orgId: string;
+  let created: boolean;
+  const existing = (await getOrganizationByEmail(c.env.DB, email)) as
+    | { id: string }
+    | null;
   if (existing) {
-    return c.json(
-      { error: "An account with this email already exists" },
-      409,
-    );
+    orgId = existing.id;
+    created = false;
+  } else {
+    orgId = generateId("org");
+    const orgName = email.split("@")[0];
+    await insertOrganizationWithEmail(c.env.DB, orgId, orgName, email);
+    created = true;
   }
 
-  const orgId = generateId("org");
-  const orgName = email.split("@")[0];
-  await insertOrganizationWithEmail(c.env.DB, orgId, orgName, email);
-
+  // Always mint a fresh API key. The caller cannot recover the prior
+  // key (it's hashed at rest), so stage-1 callers rely on this being
+  // the canonical way to bootstrap server-side credentials for a user.
   const keyId = generateId("key");
   const { raw, prefix } = generateApiKeyRaw();
   const keyHash = await hashApiKey(raw);
@@ -52,8 +86,9 @@ signup.post("/", async (c) => {
       api_key: raw,
       key_prefix: prefix,
       plan,
+      created,
     },
-    201,
+    created ? 201 : 200,
   );
 });
 

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -8,6 +8,11 @@ export interface Env {
   STRIPE_PRICE_ID_PRO: string;
   STRIPE_PRICE_ID_TEAM: string;
   APP_URL: string; // e.g. "https://getengram.app"
+  // Shared secret between engram-web and the worker. engram-web's
+  // Next.js server action sends this as a Bearer on /signup so random
+  // internet traffic can't mint API keys against arbitrary emails.
+  // Temporary until stage 2 (worker verifies Supabase JWTs via JWKS).
+  WORKER_SIGNUP_SECRET: string;
 }
 
 export interface AuthContext {

--- a/packages/db/src/queries/api-keys.ts
+++ b/packages/db/src/queries/api-keys.ts
@@ -33,7 +33,7 @@ export function updateApiKeyLastUsed(db: D1Database, id: string) {
 export function getApiKeysByOrg(db: D1Database, organizationId: string) {
   return db
     .prepare(
-      "SELECT id, key_prefix, name, expires_at, last_used_at, created_at FROM api_keys WHERE organization_id = ? AND revoked_at IS NULL ORDER BY created_at"
+      "SELECT id, key_prefix AS prefix, name, expires_at, last_used_at, created_at FROM api_keys WHERE organization_id = ? AND revoked_at IS NULL ORDER BY created_at"
     )
     .bind(organizationId)
     .all();


### PR DESCRIPTION
Closes #25. Paired with get-engram/engram-web#18.

## Changes

1. **`/signup` idempotent** — if org exists for the email, attach a fresh key to the existing org instead of 409. Unblocks migration from the pre-Supabase self-serve flow and prevents races on first sign-in.
2. **`/signup` shared-secret gated** — requires `Authorization: Bearer ${WORKER_SIGNUP_SECRET}`. engram-web's server action will send this. Closes the "anyone can mint a key for any email" hole until stage 2 (JWKS).
3. **`getApiKeysByOrg` aliases `key_prefix AS prefix`** — fixes a silent bug where the dashboard's API keys list rendered empty prefixes because of the field-name mismatch.

## Deploy checklist

- [ ] `cd apps/mcp-server && wrangler secret put WORKER_SIGNUP_SECRET` (prod)
- [ ] Same secret in engram-web Vercel env (server-only var, NOT `NEXT_PUBLIC_`)
- [ ] Deploy worker (`wrangler deploy`)
- [ ] Deploy engram-web with matching secret

## Test plan

- [ ] Existing tests still pass (verified locally: 45/45 mcp-server, full monorepo green)
- [ ] Manual: `curl -X POST mcp.getengram.app/signup -H 'Authorization: Bearer wrong' -d '{"email":"x@y.z","plan":"free"}'` → 401
- [ ] Manual: `curl -X POST mcp.getengram.app/signup -H 'Authorization: Bearer \$WORKER_SIGNUP_SECRET' -d '{"email":"new@example.com","plan":"free"}'` → 201 + key
- [ ] Manual: same call twice with same email → second returns 200 (not 409) with a new key
- [ ] Manual: call `/api/keys` with a real bearer → each entry has a non-empty `prefix` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)