### PR TITLE
fix: search quality — min_score, dedup, lower snippet default

### DIFF
--- a/apps/mcp-server/src/__tests__/search-service.test.ts
+++ b/apps/mcp-server/src/__tests__/search-service.test.ts
@@ -3,6 +3,7 @@ import { createMockD1, createMockEnv } from "./helpers.js";
 import {
   searchConversations,
   DEFAULT_SNIPPET_CHARS,
+  DEFAULT_MIN_SCORE,
   MAX_SNIPPET_CHARS,
 } from "../services/search.js";
 
@@ -63,7 +64,12 @@ describe("search service", () => {
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "greeting",
-      5
+      5,
+      undefined,
+      undefined,
+      undefined,
+      0,     // minScore — allow all
+      false  // dedupe off — both chunks from conv_1 should return
     );
 
     expect(results.length).toBeGreaterThan(0);
@@ -80,7 +86,12 @@ describe("search service", () => {
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "greeting",
-      5
+      5,
+      undefined,
+      undefined,
+      undefined,
+      0,     // minScore
+      false  // dedupe off
     );
 
     const long = results.find((r) => r.chunk_id === "chk_long");
@@ -103,7 +114,9 @@ describe("search service", () => {
       5,
       undefined,
       undefined,
-      200
+      200,
+      0,     // minScore
+      false  // dedupe off
     );
 
     const long = results.find((r) => r.chunk_id === "chk_long");
@@ -120,13 +133,70 @@ describe("search service", () => {
       5,
       undefined,
       undefined,
-      999_999
+      999_999,
+      0,     // minScore
+      false  // dedupe off
     );
 
     const long = results.find((r) => r.chunk_id === "chk_long");
-    // The seed longText is 3× the default, which is 4500 chars < 5000,
+    // The seed longText is 3× the default, which is 2400 chars < 5000,
     // so with the cap at MAX the long chunk should NOT be truncated.
     expect(long!.chunk_text).not.toContain("[truncated]");
     expect(long!.chunk_text.length).toBeLessThanOrEqual(MAX_SNIPPET_CHARS);
+  });
+
+  it("filters out results below min_score", async () => {
+    // vec_short has score 0.99, vec_long has score 0.88
+    const results = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "greeting",
+      5,
+      undefined,
+      undefined,
+      undefined,
+      0.95,  // only the 0.99 result should pass
+      false  // dedupe off
+    );
+
+    expect(results.length).toBe(1);
+    expect(results[0].chunk_id).toBe("chk_short");
+    expect(results[0].score).toBe(0.99);
+  });
+
+  it("deduplicates chunks from the same conversation by default", async () => {
+    // Both chunks are from conv_1. With dedupe on, only the top-scoring one returns.
+    const results = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "greeting",
+      5,
+      undefined,
+      undefined,
+      undefined,
+      0  // minScore — allow all
+      // dedupe defaults to true
+    );
+
+    expect(results.length).toBe(1);
+    // Highest score wins
+    expect(results[0].chunk_id).toBe("chk_short");
+    expect(results[0].score).toBe(0.99);
+  });
+
+  it("returns all chunks when dedupe is false", async () => {
+    const results = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "greeting",
+      5,
+      undefined,
+      undefined,
+      undefined,
+      0,
+      false
+    );
+
+    expect(results.length).toBe(2);
   });
 });

--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   searchConversations,
   DEFAULT_SNIPPET_CHARS,
+  DEFAULT_MIN_SCORE,
   MAX_SNIPPET_CHARS,
 } from "../../services/search.js";
 import { trackSearchRun } from "../../services/tier.js";
@@ -44,6 +45,22 @@ export function registerSearch(
         .describe(
           `Max characters of chunk_text to return per result (default ${DEFAULT_SNIPPET_CHARS}, max ${MAX_SNIPPET_CHARS}). Longer snippets = larger responses.`
         ),
+      min_score: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .default(DEFAULT_MIN_SCORE)
+        .describe(
+          `Minimum similarity score (0-1) to include a result (default ${DEFAULT_MIN_SCORE}). Filters out low-relevance noise.`
+        ),
+      dedupe: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe(
+          "Deduplicate overlapping chunks from the same conversation (default true). Set false to see all matching chunks."
+        ),
     },
     async (params) => {
       const results = await searchConversations(
@@ -53,7 +70,9 @@ export function registerSearch(
         params.limit,
         params.conversation_id,
         params.tags,
-        params.snippet_chars
+        params.snippet_chars,
+        params.min_score,
+        params.dedupe
       );
 
       // Track usage (non-blocking)

--- a/apps/mcp-server/src/services/search.ts
+++ b/apps/mcp-server/src/services/search.ts
@@ -11,11 +11,12 @@ interface VectorizeMatch {
 
 // Default cap per chunk_text in the search response. Full message bodies
 // can run 1–5k tokens each when tool-call output is included; clipping to
-// ~1500 chars keeps a 10-result search response under ~3k tokens total
+// ~800 chars keeps a 5-result search response under ~1.5k tokens total
 // without destroying the ranking signal. Callers that need the full
 // window should call get_conversation with start_sequence / end_sequence.
-export const DEFAULT_SNIPPET_CHARS = 1500;
+export const DEFAULT_SNIPPET_CHARS = 800;
 export const MAX_SNIPPET_CHARS = 5000;
+export const DEFAULT_MIN_SCORE = 0.5;
 const TRUNCATION_MARKER = "\n...[truncated]";
 
 function truncateSnippet(text: string, maxChars: number): string {
@@ -30,7 +31,9 @@ export async function searchConversations(
   limit: number,
   conversationId?: string,
   tags?: string[],
-  snippetChars: number = DEFAULT_SNIPPET_CHARS
+  snippetChars: number = DEFAULT_SNIPPET_CHARS,
+  minScore: number = DEFAULT_MIN_SCORE,
+  dedupe: boolean = true
 ): Promise<SearchResult[]> {
   const cappedSnippet = Math.min(
     Math.max(snippetChars, 0),
@@ -75,7 +78,7 @@ export async function searchConversations(
   // format, and returning both duplicated the payload (see issue #8). If a
   // caller needs the structured messages they can call get_conversation with
   // start_sequence / end_sequence.
-  const results: SearchResult[] = chunks.map((chunk) => ({
+  let results: SearchResult[] = chunks.map((chunk) => ({
     chunk_id: chunk.id,
     conversation_id: chunk.conversation_id,
     chunk_text: truncateSnippet(chunk.chunk_text, cappedSnippet),
@@ -86,6 +89,23 @@ export async function searchConversations(
 
   // Sort by score descending
   results.sort((a, b) => b.score - a.score);
+
+  // Drop results below the minimum relevance threshold
+  if (minScore > 0) {
+    results = results.filter((r) => r.score >= minScore);
+  }
+
+  // Deduplicate: keep only the highest-scoring chunk per conversation.
+  // Overlapping chunks (window=5, stride=3) cause the same content to
+  // appear multiple times; dedup prevents wasting the caller's tokens.
+  if (dedupe) {
+    const seen = new Set<string>();
+    results = results.filter((r) => {
+      if (seen.has(r.conversation_id)) return false;
+      seen.add(r.conversation_id);
+      return true;
+    });
+  }
 
   return results;
 }


### PR DESCRIPTION
## Summary
- Adds `min_score` param (default 0.5) — drops results below the similarity threshold, eliminating noise
- Adds `dedupe` param (default true) — keeps only the highest-scoring chunk per conversation, preventing overlapping chunks (window=5, stride=3) from wasting tokens
- Lowers `DEFAULT_SNIPPET_CHARS` from 1500 → 800 — a 5-result search response is now ~1.5k tokens instead of ~3k
- All params are optional with backwards-compatible defaults; pass `dedupe: false, min_score: 0` for old behavior

Closes #28

## Test plan
- [x] 48/48 tests pass (3 new: min_score filter, dedup on, dedup off)
- [x] Existing truncation tests updated to pass dedupe/minScore explicitly
- [ ] Deploy to staging and verify real search responses are smaller
- [ ] Verify MCP tool schema exposes new params in Claude Desktop/Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)