### PR TITLE
feat(auth): replace shared secret with Supabase JWT verification

### DIFF
--- a/apps/mcp-server/src/__tests__/jwt.test.ts
+++ b/apps/mcp-server/src/__tests__/jwt.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { verifySupabaseJwt } from "../utils/jwt.js";
+
+const SECRET = "super-secret-jwt-token-with-at-least-32-chars";
+
+/** Build a HS256 JWT using Web Crypto (same approach the utility uses). */
+async function signJwt(
+  payload: Record<string, unknown>,
+  secret: string,
+): Promise<string> {
+  const encoder = new TextEncoder();
+
+  function base64Url(buf: ArrayBuffer | Uint8Array): string {
+    const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+    let binary = "";
+    for (const b of bytes) binary += String.fromCharCode(b);
+    return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  }
+
+  const header = base64Url(encoder.encode(JSON.stringify({ alg: "HS256", typ: "JWT" })));
+  const body = base64Url(encoder.encode(JSON.stringify(payload)));
+  const data = encoder.encode(`${header}.${body}`);
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, data);
+
+  return `${header}.${body}.${base64Url(sig)}`;
+}
+
+describe("verifySupabaseJwt", () => {
+  it("verifies a valid token and returns claims", async () => {
+    const token = await signJwt(
+      {
+        sub: "user-123",
+        email: "alice@example.com",
+        role: "authenticated",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      },
+      SECRET,
+    );
+
+    const claims = await verifySupabaseJwt(token, SECRET);
+    expect(claims.sub).toBe("user-123");
+    expect(claims.email).toBe("alice@example.com");
+    expect(claims.role).toBe("authenticated");
+  });
+
+  it("rejects a token signed with the wrong secret", async () => {
+    const token = await signJwt(
+      {
+        sub: "user-123",
+        email: "alice@example.com",
+        role: "authenticated",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      },
+      "wrong-secret-that-is-definitely-not-correct",
+    );
+
+    await expect(verifySupabaseJwt(token, SECRET)).rejects.toThrow(
+      "Invalid JWT signature",
+    );
+  });
+
+  it("rejects an expired token", async () => {
+    const token = await signJwt(
+      {
+        sub: "user-123",
+        email: "alice@example.com",
+        role: "authenticated",
+        exp: Math.floor(Date.now() / 1000) - 60, // expired 1 min ago
+      },
+      SECRET,
+    );
+
+    await expect(verifySupabaseJwt(token, SECRET)).rejects.toThrow(
+      "JWT has expired",
+    );
+  });
+
+  it("rejects a token with wrong role", async () => {
+    const token = await signJwt(
+      {
+        sub: "user-123",
+        email: "alice@example.com",
+        role: "anon",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      },
+      SECRET,
+    );
+
+    await expect(verifySupabaseJwt(token, SECRET)).rejects.toThrow(
+      "JWT role is not 'authenticated'",
+    );
+  });
+
+  it("rejects malformed tokens", async () => {
+    await expect(verifySupabaseJwt("not-a-jwt", SECRET)).rejects.toThrow();
+    await expect(verifySupabaseJwt("a.b", SECRET)).rejects.toThrow("expected 3 parts");
+    await expect(verifySupabaseJwt("", SECRET)).rejects.toThrow();
+  });
+});

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -51,7 +51,7 @@ app.use(
   cors({
     origin: BROWSER_ORIGINS,
     allowMethods: ["POST", "OPTIONS"],
-    allowHeaders: ["Content-Type"],
+    allowHeaders: ["Content-Type", "Authorization"],
   }),
 );
 app.route("/signup", signup);

--- a/apps/mcp-server/src/routes/signup.ts
+++ b/apps/mcp-server/src/routes/signup.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import {
-  SignupSchema,
   generateId,
   generateApiKeyRaw,
   hashApiKey,
@@ -11,50 +10,58 @@ import {
   insertApiKey,
 } from "@getengram/db";
 import type { Env } from "../types.js";
+import { verifySupabaseJwt } from "../utils/jwt.js";
 
 type HonoEnv = { Bindings: Env };
 
 const signup = new Hono<HonoEnv>();
 
-// POST /signup — mint (or attach) an API key for a given email.
+// POST /signup — mint (or attach) an API key for the authenticated user.
 //
-// Auth: shared-secret Bearer. The Next.js server action on engram-web
-// sends `Authorization: Bearer ${WORKER_SIGNUP_SECRET}` so random
-// internet traffic can't mint keys against arbitrary emails. This is
-// a temporary mitigation until stage 2, when the worker will verify
-// Supabase JWTs via JWKS and take the user identity from there.
+// Auth: Supabase JWT Bearer. The Next.js server action on engram-web
+// sends the user's Supabase access token. We verify the HS256 signature
+// using the shared JWT secret and extract the user's email from the
+// token claims — no request body needed for identity.
 //
 // Behavior is idempotent-ish: if an org already exists for this email
-// (either from the pre-Supabase self-serve flow, or from a race on
-// the same user's first sign-in), we attach a fresh API key to the
-// existing org and return it. We never return the user's previous
-// key — it's hashed.
+// (either from a prior sign-in or from the pre-Supabase flow), we
+// attach a fresh API key to the existing org and return it. We never
+// return the user's previous key — it's hashed.
 signup.post("/", async (c) => {
-  // Shared-secret gate
-  const configured = c.env.WORKER_SIGNUP_SECRET;
-  if (!configured) {
+  const jwtSecret = c.env.SUPABASE_JWT_SECRET;
+  if (!jwtSecret) {
     return c.json(
-      { error: "server_misconfigured", message: "WORKER_SIGNUP_SECRET is not set" },
+      { error: "server_misconfigured", message: "SUPABASE_JWT_SECRET is not set" },
       500,
     );
   }
+
+  // Extract and verify the Supabase access token
   const authHeader = c.req.header("authorization") ?? "";
-  const presented = authHeader.replace(/^Bearer\s+/i, "");
-  if (presented !== configured) {
-    return c.json({ error: "unauthorized" }, 401);
+  const token = authHeader.replace(/^Bearer\s+/i, "");
+  if (!token) {
+    return c.json({ error: "unauthorized", message: "Missing Bearer token" }, 401);
   }
 
-  const body = await c.req.json().catch(() => null);
-  const parsed = SignupSchema.safeParse(body);
+  let claims;
+  try {
+    claims = await verifySupabaseJwt(token, jwtSecret);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Invalid token";
+    return c.json({ error: "unauthorized", message }, 401);
+  }
 
-  if (!parsed.success) {
+  const email = claims.email;
+  if (!email) {
     return c.json(
-      { error: "invalid_input", details: parsed.error.flatten() },
+      { error: "invalid_token", message: "JWT does not contain an email claim" },
       400,
     );
   }
 
-  const { email, plan } = parsed.data;
+  // Accept optional plan from body (defaults to free)
+  const body = await c.req.json().catch(() => ({}));
+  const plan = body.plan === "pro" ? "pro" : "free";
 
   // Find-or-create the org
   let orgId: string;
@@ -73,8 +80,8 @@ signup.post("/", async (c) => {
   }
 
   // Always mint a fresh API key. The caller cannot recover the prior
-  // key (it's hashed at rest), so stage-1 callers rely on this being
-  // the canonical way to bootstrap server-side credentials for a user.
+  // key (it's hashed at rest), so callers rely on this being the
+  // canonical way to bootstrap server-side credentials for a user.
   const keyId = generateId("key");
   const { raw, prefix } = generateApiKeyRaw();
   const keyHash = await hashApiKey(raw);

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -8,11 +8,11 @@ export interface Env {
   STRIPE_PRICE_ID_PRO: string;
   STRIPE_PRICE_ID_TEAM: string;
   APP_URL: string; // e.g. "https://getengram.app"
-  // Shared secret between engram-web and the worker. engram-web's
-  // Next.js server action sends this as a Bearer on /signup so random
-  // internet traffic can't mint API keys against arbitrary emails.
-  // Temporary until stage 2 (worker verifies Supabase JWTs via JWKS).
-  WORKER_SIGNUP_SECRET: string;
+  // Supabase JWT secret — used to verify access tokens from engram-web.
+  // The dashboard sends the user's Supabase access token as a Bearer on
+  // /signup; the worker verifies the HS256 signature and extracts the
+  // user's email from the claims.
+  SUPABASE_JWT_SECRET: string;
 }
 
 export interface AuthContext {

--- a/apps/mcp-server/src/utils/jwt.ts
+++ b/apps/mcp-server/src/utils/jwt.ts
@@ -1,0 +1,80 @@
+/**
+ * Verify a Supabase JWT using the project's JWT secret (HS256).
+ * Uses only the Web Crypto API — no Node.js dependencies.
+ */
+
+interface SupabaseJwtPayload {
+  sub: string; // user ID
+  email?: string;
+  role?: string; // "authenticated"
+  aud?: string;
+  iss?: string;
+  exp?: number;
+  iat?: number;
+}
+
+function base64UrlDecode(str: string): Uint8Array {
+  // Convert base64url to base64
+  const base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export async function verifySupabaseJwt(
+  token: string,
+  jwtSecret: string,
+): Promise<SupabaseJwtPayload> {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Invalid JWT: expected 3 parts");
+  }
+
+  const [headerB64, payloadB64, signatureB64] = parts;
+
+  // Verify header declares HS256
+  const header = JSON.parse(new TextDecoder().decode(base64UrlDecode(headerB64)));
+  if (header.alg !== "HS256") {
+    throw new Error(`Unsupported JWT algorithm: ${header.alg}`);
+  }
+
+  // Import the secret as an HMAC key
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(jwtSecret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
+
+  // Verify signature
+  const data = encoder.encode(`${headerB64}.${payloadB64}`);
+  const signature = base64UrlDecode(signatureB64);
+  const valid = await crypto.subtle.verify("HMAC", key, signature, data);
+
+  if (!valid) {
+    throw new Error("Invalid JWT signature");
+  }
+
+  // Decode payload
+  const payload: SupabaseJwtPayload = JSON.parse(
+    new TextDecoder().decode(base64UrlDecode(payloadB64)),
+  );
+
+  // Check expiry
+  if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+    throw new Error("JWT has expired");
+  }
+
+  // Check role
+  if (payload.role !== "authenticated") {
+    throw new Error("JWT role is not 'authenticated'");
+  }
+
+  return payload;
+}

--- a/apps/mcp-server/wrangler.toml
+++ b/apps/mcp-server/wrangler.toml
@@ -6,6 +6,13 @@ compatibility_flags = ["nodejs_compat"]
 [vars]
 APP_URL = "https://getengram.app"
 
+# Secrets (set via `wrangler secret put`):
+#   SUPABASE_JWT_SECRET     — Supabase project JWT secret (HS256, from dashboard → Settings → API)
+#   STRIPE_SECRET_KEY       — Stripe API key
+#   STRIPE_WEBHOOK_SECRET   — Stripe webhook signing secret
+#   STRIPE_PRICE_ID_PRO     — Stripe price ID for Pro plan
+#   STRIPE_PRICE_ID_TEAM    — Stripe price ID for Team plan
+
 [[d1_databases]]
 binding = "DB"
 database_name = "engram-db"


### PR DESCRIPTION
## Summary

Stage 2 auth (closes #30): the worker now verifies Supabase JWTs on `/signup` instead of checking a shared secret (`WORKER_SIGNUP_SECRET`).

- **Worker**: Verifies HS256 signature using `SUPABASE_JWT_SECRET` (Web Crypto API, zero deps), extracts email from JWT claims
- **Dashboard** (engram-web, separate commit): Sends `session.access_token` as Bearer instead of shared secret

### Deployment steps

1. Set the new secret: `wrangler secret put SUPABASE_JWT_SECRET` (value from Supabase dashboard → Settings → API → JWT Secret)
2. Deploy the worker: `npx wrangler deploy`
3. Deploy engram-web (remove `WORKER_SIGNUP_SECRET` env var, it's no longer needed)
4. Delete the old secret: `wrangler secret delete WORKER_SIGNUP_SECRET`

## Test plan

- [x] 5 new JWT verification tests (valid, wrong secret, expired, wrong role, malformed)
- [x] All 53 existing tests pass
- [ ] Deploy to staging and test signup flow end-to-end
- [ ] Verify existing users' dashboard still works (uses stored API key, not /signup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)