### PR TITLE
perf: add missing D1 indexes

### DIFF
--- a/packages/db/migrations/0004_add_perf_indexes.sql
+++ b/packages/db/migrations/0004_add_perf_indexes.sql
@@ -1,0 +1,8 @@
+-- Composite index for search dedup (organization + conversation in one lookup)
+CREATE INDEX IF NOT EXISTS idx_chunks_org_conv ON conversation_chunks(organization_id, conversation_id);
+
+-- Chronological conversation listing
+CREATE INDEX IF NOT EXISTS idx_conversations_created ON conversations(organization_id, created_at DESC);
+
+-- Usage tier checks (organization + period)
+CREATE INDEX IF NOT EXISTS idx_usage_org_period ON usage(organization_id, period);


### PR DESCRIPTION
## Summary
Closes #46. Adds 3 composite indexes for common query patterns.

- `chunks(organization_id, conversation_id)` — search dedup
- `conversations(organization_id, created_at DESC)` — chronological listing
- `usage(organization_id, period)` — tier limit checks

## Deployment
Run `wrangler d1 migrations apply engram-db` after merge.

## Test plan
- [x] Migration SQL is valid (CREATE INDEX IF NOT EXISTS — safe to rerun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)