### PR TITLE
fix: atomic tier limit check (race condition)

### DIFF
--- a/apps/mcp-server/src/mcp/tools/append-messages.ts
+++ b/apps/mcp-server/src/mcp/tools/append-messages.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { appendMessages } from "../../services/conversation.js";
-import { checkMessageLimit, trackMessagesStored } from "../../services/tier.js";
+import { checkAndTrackMessages } from "../../services/tier.js";
 import { fireWebhooks } from "../../services/webhooks.js";
 import type { Env, AuthContext } from "../../types.js";
 
@@ -29,8 +29,10 @@ export function registerAppendMessages(
         .describe("Messages to append"),
     },
     async (params) => {
-      // Check tier limit before appending
-      const tierCheck = await checkMessageLimit(
+      // Atomically check tier limit AND increment usage in one operation.
+      // Prevents race conditions where concurrent requests both pass the
+      // check but together exceed the limit.
+      const tierCheck = await checkAndTrackMessages(
         env.DB,
         auth.organizationId,
         auth.tier,
@@ -64,9 +66,6 @@ export function registerAppendMessages(
           metadata: m.metadata as Record<string, unknown>,
         }))
       );
-
-      // Track usage (non-blocking)
-      trackMessagesStored(env.DB, auth.organizationId, messages.length).catch(() => {});
 
       // Fire webhooks (non-blocking)
       fireWebhooks(env.DB, auth.organizationId, "messages.appended", {

--- a/apps/mcp-server/src/services/tier.ts
+++ b/apps/mcp-server/src/services/tier.ts
@@ -1,5 +1,5 @@
 import { TIER_LIMITS, type Tier } from "@getengram/shared";
-import { getOrCreateUsage, incrementMessagesStored, incrementSearchesRun } from "@getengram/db";
+import { getOrCreateUsage, atomicIncrementMessages, incrementMessagesStored, incrementSearchesRun } from "@getengram/db";
 import { generateId } from "@getengram/shared";
 
 export interface TierCheckResult {
@@ -19,6 +19,54 @@ async function ensureUsage(db: D1Database, organizationId: string) {
   return getOrCreateUsage(db, id, organizationId);
 }
 
+/**
+ * Atomically check the message limit AND increment the counter in one
+ * operation. Prevents race conditions where concurrent requests both
+ * pass the check but together exceed the limit.
+ *
+ * For unlimited tiers, skips the atomic check and just increments.
+ */
+export async function checkAndTrackMessages(
+  db: D1Database,
+  organizationId: string,
+  tier: Tier,
+  messageCount: number,
+): Promise<TierCheckResult> {
+  const limits = TIER_LIMITS[tier];
+
+  // Ensure usage row exists
+  await ensureUsage(db, organizationId);
+
+  // Unlimited tier — just increment, no limit check
+  if (limits.messages_per_month === -1) {
+    await incrementMessagesStored(db, organizationId, messageCount);
+    return { allowed: true };
+  }
+
+  // Atomic: increment only if within limit
+  const result = await atomicIncrementMessages(
+    db,
+    organizationId,
+    messageCount,
+    limits.messages_per_month,
+  );
+
+  if (!result) {
+    // Limit would be exceeded — fetch current usage for error message
+    const usage = await ensureUsage(db, organizationId);
+    const used = (usage as { messages_stored: number }).messages_stored;
+    return {
+      allowed: false,
+      error: "message_limit_exceeded",
+      limit: limits.messages_per_month,
+      used,
+      tier,
+    };
+  }
+
+  return { allowed: true };
+}
+
 export async function checkMessageLimit(
   db: D1Database,
   organizationId: string,
@@ -27,7 +75,6 @@ export async function checkMessageLimit(
 ): Promise<TierCheckResult> {
   const limits = TIER_LIMITS[tier];
 
-  // Unlimited
   if (limits.messages_per_month === -1) {
     return { allowed: true };
   }

--- a/packages/db/src/queries/usage.ts
+++ b/packages/db/src/queries/usage.ts
@@ -35,6 +35,31 @@ export function incrementMessagesStored(db: D1Database, organizationId: string, 
     .run();
 }
 
+/**
+ * Atomically increment messages_stored only if the new total stays within
+ * the given limit. Returns the updated row if successful, null if the
+ * limit would be exceeded. Prevents race conditions between concurrent
+ * append requests.
+ */
+export function atomicIncrementMessages(
+  db: D1Database,
+  organizationId: string,
+  count: number,
+  limit: number,
+) {
+  const period = getCurrentPeriod();
+  return db
+    .prepare(
+      `UPDATE usage
+       SET messages_stored = messages_stored + ?, updated_at = datetime('now')
+       WHERE organization_id = ? AND period = ?
+         AND messages_stored + ? <= ?
+       RETURNING messages_stored`
+    )
+    .bind(count, organizationId, period, count, limit)
+    .first<{ messages_stored: number }>();
+}
+
 export function incrementSearchesRun(db: D1Database, organizationId: string) {
   const period = getCurrentPeriod();
   return db


### PR DESCRIPTION
## Summary
Closes #47. Prevents concurrent requests from together exceeding the tier message limit.

- Add `atomicIncrementMessages()` — `UPDATE...WHERE messages_stored + ? <= ?...RETURNING`
- New `checkAndTrackMessages()` combines limit check + usage tracking in one call
- `append_messages` tool uses the atomic function instead of separate check + track

Also incorporates #39 fix (deduplicated usage lookups) since it touches the same code.

## Test plan
- [x] All 48 tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)