### PR TITLE
feat: gzip compress message content to reduce D1 storage ~3x

### DIFF
--- a/apps/mcp-server/src/services/conversation.ts
+++ b/apps/mcp-server/src/services/conversation.ts
@@ -18,6 +18,7 @@ import {
   getVectorizeIdsByConversation,
 } from "@getengram/db";
 import { generateEmbeddings } from "./embedding.js";
+import { compressContent, decompressContent } from "../utils/compress.js";
 import type { Env } from "../types.js";
 
 export async function createConversation(
@@ -74,15 +75,21 @@ export async function appendMessages(
     return msg;
   });
 
-  // Insert messages
+  // Compress message content for storage
+  const compressed = await Promise.all(
+    messages.map((m) => compressContent(m.content))
+  );
+
+  // Insert messages with compressed content
   await insertMessages(
     env.DB,
-    messages.map((m) => ({
+    messages.map((m, i) => ({
       id: m.id,
       conversationId: m.conversation_id,
       organizationId: m.organization_id,
       role: m.role,
-      content: m.content,
+      content: compressed[i].content,
+      contentEncoding: compressed[i].encoding,
       toolCallId: m.tool_call_id,
       toolName: m.tool_name,
       sequence: m.sequence,
@@ -179,11 +186,17 @@ export async function getConversation(
     messageOffset
   );
 
-  const messages = (msgsResult.results as Array<Record<string, unknown>>).map(
-    (m) => ({
+  // Decompress message content in parallel
+  const rawMessages = msgsResult.results as Array<Record<string, unknown>>;
+  const messages = await Promise.all(
+    rawMessages.map(async (m) => ({
       ...m,
+      content: await decompressContent(
+        m.content as string,
+        m.content_encoding as string | null
+      ),
       metadata: JSON.parse((m.metadata as string) || "{}"),
-    })
+    }))
   ) as Message[];
 
   return { conversation, messages };

--- a/apps/mcp-server/src/utils/compress.ts
+++ b/apps/mcp-server/src/utils/compress.ts
@@ -1,0 +1,84 @@
+/**
+ * Gzip compression for message content stored in D1.
+ *
+ * Uses the native CompressionStream / DecompressionStream APIs available in
+ * Cloudflare Workers — zero dependencies. Compressed bytes are base64-encoded
+ * so they fit in a TEXT column without schema changes.
+ *
+ * Messages shorter than MIN_COMPRESS_BYTES are stored raw because gzip
+ * headers + base64 overhead would make them larger.
+ */
+
+const MIN_COMPRESS_BYTES = 128;
+
+export const ENCODING_GZIP = "gzip+base64";
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const len = bytes.length;
+  for (let i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function base64ToUint8(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Compress a string with gzip and return base64-encoded result.
+ * Returns null if the input is too short to benefit from compression.
+ */
+export async function compressContent(
+  text: string
+): Promise<{ content: string; encoding: string | null }> {
+  const raw = new TextEncoder().encode(text);
+
+  if (raw.length < MIN_COMPRESS_BYTES) {
+    return { content: text, encoding: null };
+  }
+
+  const cs = new CompressionStream("gzip");
+  const writer = cs.writable.getWriter();
+  writer.write(raw);
+  writer.close();
+
+  const compressed = await new Response(cs.readable).arrayBuffer();
+  const encoded = uint8ToBase64(new Uint8Array(compressed));
+
+  // Only use compression if it actually saves space
+  if (encoded.length >= text.length) {
+    return { content: text, encoding: null };
+  }
+
+  return { content: encoded, encoding: ENCODING_GZIP };
+}
+
+/**
+ * Decompress content based on its encoding.
+ * If encoding is null/undefined, returns the content as-is (uncompressed).
+ */
+export async function decompressContent(
+  content: string,
+  encoding: string | null | undefined
+): Promise<string> {
+  if (!encoding) return content;
+
+  if (encoding !== ENCODING_GZIP) {
+    throw new Error(`Unknown content encoding: ${encoding}`);
+  }
+
+  const compressed = base64ToUint8(content);
+  const ds = new DecompressionStream("gzip");
+  const writer = ds.writable.getWriter();
+  writer.write(compressed);
+  writer.close();
+
+  return new Response(ds.readable).text();
+}

--- a/packages/db/migrations/0005_add_content_encoding.sql
+++ b/packages/db/migrations/0005_add_content_encoding.sql
@@ -1,0 +1,3 @@
+-- Track which messages have compressed content.
+-- NULL = raw text (all existing rows), 'gzip+base64' = gzip-compressed, base64-encoded.
+ALTER TABLE messages ADD COLUMN content_encoding TEXT;

--- a/packages/db/src/queries/messages.ts
+++ b/packages/db/src/queries/messages.ts
@@ -6,6 +6,7 @@ export function insertMessages(
     organizationId: string;
     role: string;
     content: string;
+    contentEncoding: string | null;
     toolCallId: string | null;
     toolName: string | null;
     sequence: number;
@@ -15,7 +16,7 @@ export function insertMessages(
   const stmts = messages.map((m) =>
     db
       .prepare(
-        "INSERT INTO messages (id, conversation_id, organization_id, role, content, tool_call_id, tool_name, sequence, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        "INSERT INTO messages (id, conversation_id, organization_id, role, content, content_encoding, tool_call_id, tool_name, sequence, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
       )
       .bind(
         m.id,
@@ -23,6 +24,7 @@ export function insertMessages(
         m.organizationId,
         m.role,
         m.content,
+        m.contentEncoding,
         m.toolCallId,
         m.toolName,
         m.sequence,


### PR DESCRIPTION
## Summary
- Gzip-compress message content before storing in D1, base64-encode to fit TEXT column
- Transparent decompression on read in `getConversation`
- Backward-compatible: existing rows with `content_encoding=NULL` returned as-is
- Messages <128 bytes skip compression (gzip overhead would make them larger)
- Migration adds `content_encoding` column to messages table

## Context
D1 database hit the 10GB limit with 3M messages (~3.3KB avg). This reduces new message storage ~3x, buying headroom for growth and unblocking the perf index migration (0004).

## Files changed
- `apps/mcp-server/src/utils/compress.ts` — gzip compress/decompress using native `CompressionStream`/`DecompressionStream` (zero deps)
- `apps/mcp-server/src/services/conversation.ts` — compress on write, decompress on read
- `packages/db/src/queries/messages.ts` — accept `contentEncoding` field in insert
- `packages/db/migrations/0005_add_content_encoding.sql` — add `content_encoding` column

## Test plan
- [x] All 120 existing tests pass
- [ ] Deploy migration to D1 remote
- [ ] Append new messages and verify they're compressed (content_encoding = 'gzip+base64')
- [ ] Retrieve compressed messages and verify content is decompressed correctly
- [ ] Verify old uncompressed messages still read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)