### PR TITLE
feat: admin backfill endpoint to compress existing messages

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -9,6 +9,7 @@ import { webhooks } from "./routes/webhooks.js";
 import { usage } from "./routes/usage.js";
 import { signup } from "./routes/signup.js";
 import { billing, billingWebhook } from "./routes/billing.js";
+import { admin } from "./routes/admin.js";
 import type { Env, AuthContext } from "./types.js";
 
 type HonoEnv = {
@@ -77,5 +78,16 @@ app.route("/api/seats", seats);
 app.route("/api/webhooks", webhooks);
 app.route("/api/usage", usage);
 app.route("/api/billing", billing);
+
+// Admin routes — protected by ADMIN_SECRET, not API key auth.
+app.use("/api/admin/*", async (c, next) => {
+  const auth = c.req.header("Authorization");
+  const secret = (c.env as Env & { ADMIN_SECRET: string }).ADMIN_SECRET;
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  await next();
+});
+app.route("/api/admin", admin);
 
 export default app;

--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -1,0 +1,72 @@
+import { Hono } from "hono";
+import { compressContent, ENCODING_GZIP } from "../utils/compress.js";
+import type { Env } from "../types.js";
+
+type AdminEnv = { Bindings: Env };
+
+export const admin = new Hono<AdminEnv>();
+
+/**
+ * POST /api/admin/backfill/compress
+ *
+ * Compresses existing uncompressed messages in batches.
+ * Call repeatedly until remaining === 0.
+ *
+ * Body (optional):
+ *   { "batch_size": 500 }   — how many messages to process per call (max 1000)
+ */
+admin.post("/backfill/compress", async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const batchSize = Math.min(Math.max(body.batch_size ?? 500, 1), 1000);
+
+  // Count remaining uncompressed messages
+  const countResult = await c.env.DB
+    .prepare("SELECT COUNT(*) as cnt FROM messages WHERE content_encoding IS NULL")
+    .first<{ cnt: number }>();
+  const remaining = countResult?.cnt ?? 0;
+
+  if (remaining === 0) {
+    return c.json({ status: "done", processed: 0, remaining: 0 });
+  }
+
+  // Fetch a batch of uncompressed messages
+  const rows = await c.env.DB
+    .prepare(
+      "SELECT id, content FROM messages WHERE content_encoding IS NULL LIMIT ?"
+    )
+    .bind(batchSize)
+    .all<{ id: string; content: string }>();
+
+  if (!rows.results || rows.results.length === 0) {
+    return c.json({ status: "done", processed: 0, remaining: 0 });
+  }
+
+  // Compress each message
+  const updates = await Promise.all(
+    rows.results.map(async (row) => {
+      const { content, encoding } = await compressContent(row.content);
+      return { id: row.id, content, encoding };
+    })
+  );
+
+  // Batch update
+  const stmts = updates.map((u) =>
+    c.env.DB
+      .prepare(
+        "UPDATE messages SET content = ?, content_encoding = ? WHERE id = ?"
+      )
+      .bind(u.content, u.encoding, u.id)
+  );
+  await c.env.DB.batch(stmts);
+
+  const compressed = updates.filter((u) => u.encoding === ENCODING_GZIP).length;
+  const skipped = updates.length - compressed;
+
+  return c.json({
+    status: "progress",
+    processed: updates.length,
+    compressed,
+    skipped_too_small: skipped,
+    remaining: remaining - updates.length,
+  });
+});

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -8,6 +8,7 @@ export interface Env {
   STRIPE_PRICE_ID_PRO: string;
   STRIPE_PRICE_ID_TEAM: string;
   APP_URL: string; // e.g. "https://getengram.app"
+  ADMIN_SECRET: string; // wrangler secret for /api/admin/* routes
   // Shared secret between engram-web and the worker. engram-web's
   // Next.js server action sends this as a Bearer on /signup so random
   // internet traffic can't mint API keys against arbitrary emails.


### PR DESCRIPTION
## Summary
- Adds `POST /api/admin/backfill/compress` to batch-compress existing uncompressed messages
- Protected by `ADMIN_SECRET` (wrangler secret), not API key auth
- Processes messages in configurable batches (default 500, max 1000)
- Call repeatedly until `remaining === 0`

## Context
DB is at 9.99GB/10GB with 3M uncompressed messages. PR #53 compresses new messages, but existing ones need backfilling. This endpoint does that in batches that fit within Worker CPU limits.

## Test plan
- [x] All 120 tests pass
- [ ] Set ADMIN_SECRET via wrangler
- [ ] Deploy and call endpoint repeatedly to compress all messages
- [ ] Monitor DB size decrease

🤖 Generated with [Claude Code](https://claude.com/claude-code)