### PR TITLE
feat: sync health warnings with desktop notifications

### DIFF
--- a/apps/cli/src/daemon/commands.ts
+++ b/apps/cli/src/daemon/commands.ts
@@ -9,8 +9,9 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { bold, dim } from "../output.js";
+import { bold, dim, red } from "../output.js";
 import { DaemonDb } from "./db.js";
+import { readStatus, type SyncStatus } from "./status.js";
 
 const ENGRAM_DIR = join(homedir(), ".engram");
 const PID_FILE = join(ENGRAM_DIR, "daemon.pid");
@@ -171,11 +172,44 @@ export async function daemonStatus(): Promise<void> {
     console.log(`${dim("Files tracked:")}     ${stats.trackedFiles}`);
   }
 
+  // Show sync health warnings
+  const syncStatus = readStatus();
+  printSyncWarnings(syncStatus);
+
   console.log(`${dim("Log:")} ${LOG_FILE}`);
 
   if (isLaunchdInstalled()) {
     console.log(`${dim("Auto-start:")} enabled (launchd)`);
   }
+}
+
+function printSyncWarnings(status: SyncStatus): void {
+  if (status.health === "healthy") {
+    if (status.last_sync_at) {
+      console.log(`${dim("Last sync:")}        ${status.last_sync_at}`);
+    }
+    return;
+  }
+
+  const warnings: Record<string, string> = {
+    auth: "Authentication failed — run 'engram auth login'",
+    billing: "Plan limit reached — upgrade at getengram.app/pricing",
+    rate_limit: "Rate limited — messages queued, will retry",
+    network: "Can't reach servers — messages queued locally",
+    server: "Server error — messages queued, will retry",
+  };
+
+  const msg = warnings[status.error_type ?? "network"] ?? status.last_error ?? "Unknown error";
+
+  console.log("");
+  console.log(red(`  WARNING: ${msg}`));
+  if (status.pending_messages > 0) {
+    console.log(red(`  ${status.pending_messages} messages waiting to sync`));
+  }
+  if (status.last_error_at) {
+    console.log(dim(`  Since: ${status.last_error_at}`));
+  }
+  console.log("");
 }
 
 // ── Launchd integration ──

--- a/apps/cli/src/daemon/db.ts
+++ b/apps/cli/src/daemon/db.ts
@@ -160,6 +160,15 @@ export class DaemonDb {
       .run(...ids);
   }
 
+  /** Count of unsent messages across all conversations. */
+  getPendingCount(): number {
+    return (
+      this.db
+        .prepare("SELECT COUNT(*) as c FROM pending_messages WHERE sent_at IS NULL")
+        .get() as { c: number }
+    ).c;
+  }
+
   // ── Stats ──
 
   getStats(): {

--- a/apps/cli/src/daemon/status.ts
+++ b/apps/cli/src/daemon/status.ts
@@ -1,0 +1,154 @@
+import { writeFileSync, readFileSync, existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const STATUS_FILE = join(homedir(), ".engram", "status.json");
+
+export type SyncHealth = "healthy" | "warning" | "error";
+
+export interface SyncStatus {
+  health: SyncHealth;
+  last_sync_at: string | null;
+  last_error_at: string | null;
+  last_error: string | null;
+  error_type: "auth" | "billing" | "rate_limit" | "network" | "server" | null;
+  pending_messages: number;
+  consecutive_failures: number;
+  updated_at: string;
+}
+
+const DEFAULT_STATUS: SyncStatus = {
+  health: "healthy",
+  last_sync_at: null,
+  last_error_at: null,
+  last_error: null,
+  error_type: null,
+  pending_messages: 0,
+  consecutive_failures: 0,
+  updated_at: new Date().toISOString(),
+};
+
+let currentStatus: SyncStatus = { ...DEFAULT_STATUS };
+let lastNotifiedError: string | null = null;
+
+export function readStatus(): SyncStatus {
+  try {
+    if (existsSync(STATUS_FILE)) {
+      return JSON.parse(readFileSync(STATUS_FILE, "utf-8"));
+    }
+  } catch {
+    // corrupt or missing
+  }
+  return { ...DEFAULT_STATUS };
+}
+
+function writeStatus(): void {
+  currentStatus.updated_at = new Date().toISOString();
+  try {
+    writeFileSync(STATUS_FILE, JSON.stringify(currentStatus, null, 2));
+  } catch {
+    // best effort
+  }
+}
+
+/** Record a successful sync. */
+export function recordSuccess(pendingMessages: number): void {
+  currentStatus.health = "healthy";
+  currentStatus.last_sync_at = new Date().toISOString();
+  currentStatus.last_error = null;
+  currentStatus.last_error_at = null;
+  currentStatus.error_type = null;
+  currentStatus.pending_messages = pendingMessages;
+  currentStatus.consecutive_failures = 0;
+  lastNotifiedError = null;
+  writeStatus();
+}
+
+/** Record a sync failure. Sends a desktop notification on first occurrence. */
+export function recordFailure(
+  error: string,
+  errorType: SyncStatus["error_type"],
+  pendingMessages: number,
+): void {
+  currentStatus.consecutive_failures++;
+  currentStatus.last_error = error;
+  currentStatus.last_error_at = new Date().toISOString();
+  currentStatus.error_type = errorType;
+  currentStatus.pending_messages = pendingMessages;
+
+  // Escalate health based on severity and consecutive failures
+  if (errorType === "auth" || errorType === "billing") {
+    currentStatus.health = "error";
+  } else if (currentStatus.consecutive_failures >= 5) {
+    currentStatus.health = "error";
+  } else {
+    currentStatus.health = "warning";
+  }
+
+  writeStatus();
+
+  // Notify on first occurrence of each error type (don't spam)
+  const notifyKey = `${errorType}:${error}`;
+  if (notifyKey !== lastNotifiedError) {
+    lastNotifiedError = notifyKey;
+    notify(errorType, error);
+  }
+}
+
+/** Update pending count without changing health. */
+export function updatePending(count: number): void {
+  currentStatus.pending_messages = count;
+  writeStatus();
+}
+
+function classifyError(message: string): SyncStatus["error_type"] {
+  if (message.includes("401") || message.includes("403") || message.includes("Authentication")) {
+    return "auth";
+  }
+  if (message.includes("402") || message.includes("limit_exceeded") || message.includes("billing")) {
+    return "billing";
+  }
+  if (message.includes("429") || message.includes("rate")) {
+    return "rate_limit";
+  }
+  if (message.includes("5") && /\b5\d{2}\b/.test(message)) {
+    return "server";
+  }
+  return "network";
+}
+
+export { classifyError };
+
+// macOS desktop notification via osascript
+function notify(errorType: SyncStatus["error_type"], detail: string): void {
+  if (process.platform !== "darwin") return;
+
+  const titles: Record<string, string> = {
+    auth: "Engram: Authentication Failed",
+    billing: "Engram: Billing Issue",
+    rate_limit: "Engram: Rate Limited",
+    network: "Engram: Connection Lost",
+    server: "Engram: Server Error",
+  };
+
+  const messages: Record<string, string> = {
+    auth: "Your API key is invalid or expired. Run 'engram auth login' to fix.",
+    billing: "Your plan limit has been reached. Upgrade at getengram.app/pricing",
+    rate_limit: "Too many requests. Messages are queued and will retry.",
+    network: "Can't reach Engram servers. Messages are safely queued locally.",
+    server: "Engram servers are having issues. Messages are safely queued.",
+  };
+
+  const title = titles[errorType ?? "network"] ?? "Engram: Sync Warning";
+  const message = messages[errorType ?? "network"] ?? detail;
+
+  try {
+    execSync(
+      `osascript -e 'display notification "${message}" with title "${title}"'`,
+      { stdio: "pipe", timeout: 3000 },
+    );
+  } catch {
+    // notification failed, not critical
+  }
+}

--- a/apps/cli/src/daemon/syncer.ts
+++ b/apps/cli/src/daemon/syncer.ts
@@ -1,5 +1,6 @@
 import type { Engram } from "@getengram/sdk";
 import { DaemonDb } from "./db.js";
+import { recordSuccess, recordFailure, classifyError } from "./status.js";
 import type { ParsedMessage, SessionMeta, PendingRow } from "./types.js";
 
 const BATCH_SIZE = 200;
@@ -83,14 +84,23 @@ export class Syncer {
         chunks.push(convIds.slice(i, i + CONCURRENCY));
       }
 
+      let hadError = false;
       for (const chunk of chunks) {
-        await Promise.allSettled(
+        const results = await Promise.allSettled(
           chunk.map((id) => this.flushConversation(id)),
         );
+        if (results.some((r) => r.status === "rejected")) hadError = true;
+      }
+
+      // Report sync health
+      const pending = this.db.getPendingCount();
+      if (!hadError && !this.authFailed) {
+        recordSuccess(pending);
       }
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[engram] flush error: ${msg}`);
+      recordFailure(msg, classifyError(msg), this.db.getPendingCount());
     } finally {
       this.flushing = false;
     }
@@ -128,9 +138,11 @@ export class Syncer {
           if (msg.includes("401") || msg.includes("403")) {
             this.authFailed = true;
             console.error(`[engram] auth error, stopping: ${msg}`);
+            recordFailure(msg, "auth", this.db.getPendingCount());
             return;
           }
           console.error(`[engram] create error (will retry): ${msg}`);
+          recordFailure(msg, classifyError(msg), this.db.getPendingCount());
         }
       }
     }
@@ -152,12 +164,14 @@ export class Syncer {
         if (msg.includes("401") || msg.includes("403") || msg.includes("Authentication")) {
           this.authFailed = true;
           console.error(`[engram] auth error, stopping flush: ${msg}`);
+          recordFailure(msg, "auth", this.db.getPendingCount());
           this.stopFlushLoop();
           return;
         }
 
         // Rate limit or network — leave in queue for next cycle
         console.error(`[engram] send failed (will retry): ${msg}`);
+        recordFailure(msg, classifyError(msg), this.db.getPendingCount());
         return;
       }
     }

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -61,6 +61,17 @@ app.route("/signup", signup);
 // Mounted BEFORE the /api/* auth middleware so it isn't gated.
 app.route("/billing/webhook", billingWebhook);
 
+// Admin routes — protected by ADMIN_SECRET, not API key auth.
+app.use("/admin/*", async (c, next) => {
+  const auth = c.req.header("Authorization");
+  const secret = (c.env as Env & { ADMIN_SECRET: string }).ADMIN_SECRET;
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  await next();
+});
+app.route("/admin", admin);
+
 // REST API routes (all require auth). CORS runs before the auth middleware
 // so preflight OPTIONS requests succeed without a bearer token.
 app.use(
@@ -78,16 +89,5 @@ app.route("/api/seats", seats);
 app.route("/api/webhooks", webhooks);
 app.route("/api/usage", usage);
 app.route("/api/billing", billing);
-
-// Admin routes — protected by ADMIN_SECRET, not API key auth.
-app.use("/api/admin/*", async (c, next) => {
-  const auth = c.req.header("Authorization");
-  const secret = (c.env as Env & { ADMIN_SECRET: string }).ADMIN_SECRET;
-  if (!secret || auth !== `Bearer ${secret}`) {
-    return c.json({ error: "Unauthorized" }, 401);
-  }
-  await next();
-});
-app.route("/api/admin", admin);
 
 export default app;

--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -45,7 +45,10 @@ admin.post("/backfill/compress", async (c) => {
   const updates = await Promise.all(
     rows.results.map(async (row) => {
       const { content, encoding } = await compressContent(row.content);
-      return { id: row.id, content, encoding };
+      // Mark uncompressed messages as 'raw' so they're excluded from
+      // future backfill queries (distinguishes "checked, too small" from
+      // "never processed").
+      return { id: row.id, content, encoding: encoding ?? "raw" };
     })
   );
 

--- a/apps/mcp-server/src/utils/compress.ts
+++ b/apps/mcp-server/src/utils/compress.ts
@@ -68,7 +68,7 @@ export async function decompressContent(
   content: string,
   encoding: string | null | undefined
 ): Promise<string> {
-  if (!encoding) return content;
+  if (!encoding || encoding === "raw") return content;
 
   if (encoding !== ENCODING_GZIP) {
     throw new Error(`Unknown content encoding: ${encoding}`);


### PR DESCRIPTION
## Summary
- Daemon writes sync health to `~/.engram/status.json` on every success/failure
- Sends macOS desktop notification on first occurrence of each error type
- `engram status` shows warnings prominently in red when sync is failing
- Classifies errors: auth, billing, rate_limit, network, server
- Also fixes admin route path and backfill compression for small messages

## What users see

**Desktop notification** (on first failure):
> **Engram: Billing Issue**
> Your plan limit has been reached. Upgrade at getengram.app/pricing

**`engram status`** (when failing):
```
Status: running (pid 12345)
Pending sync:      156 messages

  WARNING: Plan limit reached — upgrade at getengram.app/pricing
  156 messages waiting to sync
  Since: 2026-04-18T20:15:00.000Z
```

## Files changed
- `apps/cli/src/daemon/status.ts` — new status file writer + macOS notification
- `apps/cli/src/daemon/syncer.ts` — records success/failure on every flush
- `apps/cli/src/daemon/db.ts` — adds `getPendingCount()`
- `apps/cli/src/daemon/commands.ts` — shows warnings in `engram status`
- `apps/mcp-server/src/index.ts` — fix admin route to `/admin/*`
- `apps/mcp-server/src/routes/admin.ts` — mark small messages as `raw`
- `apps/mcp-server/src/utils/compress.ts` — handle `raw` encoding on decompress

## Test plan
- [x] All 120 tests pass
- [ ] Simulate auth failure and verify desktop notification fires
- [ ] Verify `engram status` shows warning after failure
- [ ] Verify status clears after successful sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)