### PR TITLE
fix: improve search quality and result context

### DIFF
--- a/apps/mcp-server/src/services/search.ts
+++ b/apps/mcp-server/src/services/search.ts
@@ -47,8 +47,15 @@ export async function searchConversations(
     filter.conversation_id = conversationId;
   }
 
+  // Over-fetch from Vectorize when dedupe is on. Overlapping chunks mean
+  // multiple results per conversation, so we need headroom to still return
+  // `limit` unique conversations after dedup. Also over-fetch when tags
+  // are specified since tag filtering is post-query.
+  const needsOverfetch = dedupe || (tags && tags.length > 0);
+  const fetchK = needsOverfetch ? Math.min(limit * 3, 50) : limit;
+
   const vectorResults = await env.VECTORIZE.query(queryEmbedding, {
-    topK: limit,
+    topK: fetchK,
     filter,
     returnMetadata: "all",
   });
@@ -73,19 +80,45 @@ export async function searchConversations(
     vectorize_id: string;
   }>;
 
+  // Hydrate conversation title + tags for each unique conversation in
+  // the result set. Single batched query instead of N+1.
+  const uniqueConvIds = [...new Set(chunks.map((c) => c.conversation_id))];
+  const convMeta = new Map<string, { title: string; tags: string[] }>();
+
+  if (uniqueConvIds.length > 0) {
+    const placeholders = uniqueConvIds.map(() => "?").join(",");
+    const rows = await env.DB.prepare(
+      `SELECT id, title, tags FROM conversations WHERE id IN (${placeholders}) AND organization_id = ?`
+    )
+      .bind(...uniqueConvIds, organizationId)
+      .all<{ id: string; title: string; tags: string }>();
+
+    for (const row of rows.results) {
+      convMeta.set(row.id, {
+        title: row.title,
+        tags: row.tags ? JSON.parse(row.tags) : [],
+      });
+    }
+  }
+
   // Note: we intentionally do NOT hydrate full Message rows here. chunk_text
   // already contains the same window in a model-friendly `[role]: content`
   // format, and returning both duplicated the payload (see issue #8). If a
   // caller needs the structured messages they can call get_conversation with
   // start_sequence / end_sequence.
-  let results: SearchResult[] = chunks.map((chunk) => ({
-    chunk_id: chunk.id,
-    conversation_id: chunk.conversation_id,
-    chunk_text: truncateSnippet(chunk.chunk_text, cappedSnippet),
-    score: scoreMap.get(chunk.vectorize_id) ?? 0,
-    start_sequence: chunk.start_sequence,
-    end_sequence: chunk.end_sequence,
-  }));
+  let results: SearchResult[] = chunks.map((chunk) => {
+    const meta = convMeta.get(chunk.conversation_id);
+    return {
+      chunk_id: chunk.id,
+      conversation_id: chunk.conversation_id,
+      conversation_title: meta?.title,
+      tags: meta?.tags,
+      chunk_text: truncateSnippet(chunk.chunk_text, cappedSnippet),
+      score: scoreMap.get(chunk.vectorize_id) ?? 0,
+      start_sequence: chunk.start_sequence,
+      end_sequence: chunk.end_sequence,
+    };
+  });
 
   // Sort by score descending
   results.sort((a, b) => b.score - a.score);
@@ -93,6 +126,14 @@ export async function searchConversations(
   // Drop results below the minimum relevance threshold
   if (minScore > 0) {
     results = results.filter((r) => r.score >= minScore);
+  }
+
+  // Filter by tags — a result matches if its conversation has ALL requested tags
+  if (tags && tags.length > 0) {
+    results = results.filter((r) => {
+      if (!r.tags) return false;
+      return tags.every((t) => r.tags!.includes(t));
+    });
   }
 
   // Deduplicate: keep only the highest-scoring chunk per conversation.
@@ -107,5 +148,6 @@ export async function searchConversations(
     });
   }
 
-  return results;
+  // Cap to requested limit after all filtering
+  return results.slice(0, limit);
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -109,10 +109,14 @@ export interface MessageInput {
 export interface SearchResult {
   chunk_id: string;
   conversation_id: string;
+  /** Title of the conversation this chunk belongs to. */
+  conversation_title?: string;
+  /** Tags on the conversation this chunk belongs to. */
+  tags?: string[];
   /**
    * The chunked window of the original conversation in
    * `[role]: content\n` form. Truncated to the request's `snippet_chars`
-   * (default 1500) with a `...[truncated]` marker if exceeded. Call
+   * (default 800) with a `...[truncated]` marker if exceeded. Call
    * `get_conversation` with `start_sequence` / `end_sequence` to fetch
    * the full structured messages.
    */


### PR DESCRIPTION
## Summary

- **Over-fetch from Vectorize** — requests `limit * 3` vectors when dedupe or tag filters are active, so post-processing doesn't starve the final result set (previously requesting exactly `limit` meant dedup could return fewer than expected)
- **Hydrate conversation_title + tags** into each SearchResult — agents now see what conversation a chunk came from without a follow-up `get_conversation` call
- **Tag filtering actually works** — the `tags` parameter was accepted but never applied; now filters results to conversations that have ALL requested tags
- **Cap to limit after filtering** — final `results.slice(0, limit)` ensures consistent result count

## Test plan

- [x] All 48 mcp-server tests pass
- [ ] Deploy and search with tags to verify filtering
- [ ] Verify search results include `conversation_title` and `tags` fields
- [ ] Test with dedupe=true that we get the expected number of unique conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)