### PR TITLE
feat: PII/secret redaction pipeline + simplify search tool

### DIFF
--- a/apps/mcp-server/src/__tests__/mcp-tools-contract.test.ts
+++ b/apps/mcp-server/src/__tests__/mcp-tools-contract.test.ts
@@ -161,7 +161,7 @@ describe("MCP tool contract — wire field names", () => {
       // Schema snake_case.
       expect(tool!.schema).toHaveProperty("query");
       expect(tool!.schema).toHaveProperty("conversation_id");
-      expect(tool!.schema).toHaveProperty("snippet_chars");
+      expect(tool!.schema).toHaveProperty("tags");
 
       const { data, isError } = parseToolResponse(
         await tool!.handler({ query: "anything", limit: 5 })

--- a/apps/mcp-server/src/__tests__/search-service.test.ts
+++ b/apps/mcp-server/src/__tests__/search-service.test.ts
@@ -1,16 +1,7 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { createMockD1, createMockEnv } from "./helpers.js";
-import {
-  searchConversations,
-  DEFAULT_SNIPPET_CHARS,
-  DEFAULT_MIN_SCORE,
-  MAX_SNIPPET_CHARS,
-} from "../services/search.js";
+import { searchConversations } from "../services/search.js";
 
-// Covers the shape changes from issue #8: search responses must drop
-// the structured `messages` field entirely, and must truncate chunk_text
-// to the snippet_chars cap so a single result can never dominate the
-// response.
 describe("search service", () => {
   const organizationId = "org_search";
   let db: D1Database;
@@ -19,8 +10,8 @@ describe("search service", () => {
   beforeAll(() => {
     db = createMockD1();
 
-    // Seed two chunks: one short, one well over the default snippet cap.
-    const longText = "a".repeat(DEFAULT_SNIPPET_CHARS * 3);
+    // Seed two chunks: one short, one very long.
+    const longText = "a".repeat(6000);
     db.prepare(
       "INSERT INTO conversation_chunks (id, conversation_id, organization_id, chunk_text, start_sequence, end_sequence, vectorize_id, created_at) VALUES (?,?,?,?,?,?,?,?)"
     )
@@ -74,14 +65,13 @@ describe("search service", () => {
 
     expect(results.length).toBeGreaterThan(0);
     for (const r of results) {
-      // The whole point of the bloat fix — `messages` must be gone.
       expect((r as unknown as Record<string, unknown>).messages).toBeUndefined();
       expect(r.chunk_id).toBeTypeOf("string");
       expect(r.chunk_text).toBeTypeOf("string");
     }
   });
 
-  it("truncates chunk_text to the default snippet cap with a marker", async () => {
+  it("truncates chunk_text to the snippet cap with a marker", async () => {
     const results = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
@@ -90,15 +80,14 @@ describe("search service", () => {
       undefined,
       undefined,
       undefined,
-      0,     // minScore
-      false  // dedupe off
+      0,
+      false
     );
 
     const long = results.find((r) => r.chunk_id === "chk_long");
     expect(long).toBeDefined();
-    expect(long!.chunk_text.length).toBeLessThanOrEqual(
-      DEFAULT_SNIPPET_CHARS + 20 /* marker overhead */
-    );
+    // Default snippet is 2000 chars; the 6000-char chunk should be truncated
+    expect(long!.chunk_text.length).toBeLessThanOrEqual(2020);
     expect(long!.chunk_text).toContain("[truncated]");
 
     // Short chunks should pass through unchanged.
@@ -115,17 +104,16 @@ describe("search service", () => {
       undefined,
       undefined,
       200,
-      0,     // minScore
-      false  // dedupe off
+      0,
+      false
     );
 
     const long = results.find((r) => r.chunk_id === "chk_long");
-    expect(long!.chunk_text.length).toBeLessThanOrEqual(200 + 20);
+    expect(long!.chunk_text.length).toBeLessThanOrEqual(220);
     expect(long!.chunk_text).toContain("[truncated]");
   });
 
-  it("caps snippet_chars at MAX_SNIPPET_CHARS", async () => {
-    // Asking for 999_999 should silently clamp, not throw.
+  it("caps snippet_chars at 5000", async () => {
     const results = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
@@ -134,20 +122,17 @@ describe("search service", () => {
       undefined,
       undefined,
       999_999,
-      0,     // minScore
-      false  // dedupe off
+      0,
+      false
     );
 
     const long = results.find((r) => r.chunk_id === "chk_long");
-    // The seed longText is 3× the default, which is 2400 chars < 5000,
-    // so with the cap at MAX the long chunk should NOT be truncated.
-    expect(long!.chunk_text).not.toContain("[truncated]");
-    expect(long!.chunk_text.length).toBeLessThanOrEqual(MAX_SNIPPET_CHARS);
+    // 6000-char text capped at 5000 — should be truncated
+    expect(long!.chunk_text.length).toBeLessThanOrEqual(5020);
+    expect(long!.chunk_text).toContain("[truncated]");
   });
 
   it("filters out results below min_score", async () => {
-    // With RRF normalization, rank-0 vector-only result scores ~0.5
-    // and rank-1 scores slightly less. Use a threshold that splits them.
     const allResults = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
@@ -156,16 +141,15 @@ describe("search service", () => {
       undefined,
       undefined,
       undefined,
-      0,     // get all first
+      0,
       false
     );
-    // Both should exist with different scores
     expect(allResults.length).toBe(2);
     const topScore = allResults[0].score;
     const lowScore = allResults[1].score;
     expect(topScore).toBeGreaterThan(lowScore);
 
-    // Now filter with a threshold between the two scores
+    // Filter with a threshold between the two scores
     const midpoint = (topScore + lowScore) / 2;
     const filtered = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
@@ -184,7 +168,6 @@ describe("search service", () => {
   });
 
   it("deduplicates chunks from the same conversation by default", async () => {
-    // Both chunks are from conv_1. With dedupe on, only the top-scoring one returns.
     const results = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
@@ -193,12 +176,11 @@ describe("search service", () => {
       undefined,
       undefined,
       undefined,
-      0  // minScore — allow all
+      0
       // dedupe defaults to true
     );
 
     expect(results.length).toBe(1);
-    // Highest score wins
     expect(results[0].chunk_id).toBe("chk_short");
     expect(results[0].score).toBeGreaterThan(0);
   });

--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -1,11 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import {
-  searchConversations,
-  DEFAULT_SNIPPET_CHARS,
-  DEFAULT_MIN_SCORE,
-  MAX_SNIPPET_CHARS,
-} from "../../services/search.js";
+import { searchConversations } from "../../services/search.js";
 import { trackSearchRun } from "../../services/tier.js";
 import type { Env, AuthContext } from "../../types.js";
 
@@ -16,17 +11,17 @@ export function registerSearch(
 ) {
   server.tool(
     "search",
-    "Hybrid search (semantic + keyword) across stored conversations. Combines vector similarity with BM25 keyword matching for better results. Returns chunk_text snippets with conversation_title, tags, and relevance scores. Use short, focused queries — one search should be enough. For full structured messages, call get_conversation with the returned conversation_id + start_sequence / end_sequence.",
+    "Hybrid search (semantic + keyword) across stored conversations. Returns the most relevant chunk_text snippets with conversation_title, tags, and scores. One search is enough — do not retry with rephrased queries.",
     {
       query: z.string().describe("Search query text"),
       limit: z
         .number()
         .int()
         .min(1)
-        .max(50)
+        .max(20)
         .optional()
         .default(5)
-        .describe("Max results to return (default 5)"),
+        .describe("Max results (default 5)"),
       conversation_id: z
         .string()
         .optional()
@@ -35,32 +30,6 @@ export function registerSearch(
         .array(z.string())
         .optional()
         .describe("Filter by conversation tags"),
-      snippet_chars: z
-        .number()
-        .int()
-        .min(0)
-        .max(MAX_SNIPPET_CHARS)
-        .optional()
-        .default(DEFAULT_SNIPPET_CHARS)
-        .describe(
-          `Max characters of chunk_text to return per result (default ${DEFAULT_SNIPPET_CHARS}, max ${MAX_SNIPPET_CHARS}). Longer snippets = larger responses.`
-        ),
-      min_score: z
-        .number()
-        .min(0)
-        .max(1)
-        .optional()
-        .default(DEFAULT_MIN_SCORE)
-        .describe(
-          `Minimum similarity score (0-1) to include a result (default ${DEFAULT_MIN_SCORE}). Filters out low-relevance noise.`
-        ),
-      dedupe: z
-        .boolean()
-        .optional()
-        .default(true)
-        .describe(
-          "Deduplicate overlapping chunks from the same conversation (default true). Set false to see all matching chunks."
-        ),
     },
     async (params) => {
       const results = await searchConversations(
@@ -70,9 +39,6 @@ export function registerSearch(
         params.limit,
         params.conversation_id,
         params.tags,
-        params.snippet_chars,
-        params.min_score,
-        params.dedupe
       );
 
       // Track usage (non-blocking)

--- a/apps/mcp-server/src/services/conversation.ts
+++ b/apps/mcp-server/src/services/conversation.ts
@@ -1,6 +1,7 @@
 import {
   generateId,
   chunkMessages,
+  redactMessages,
   type MessageInput,
   type Message,
   type Conversation,
@@ -75,15 +76,21 @@ export async function appendMessages(
     return msg;
   });
 
+  // Redact secrets, credentials, and PII before storage
+  const { messages: redacted, totalRedactions } = redactMessages(messages);
+  if (totalRedactions > 0) {
+    console.log(`[redact] Scrubbed ${totalRedactions} sensitive pattern(s) from ${conversationId}`);
+  }
+
   // Compress message content for storage
   const compressed = await Promise.all(
-    messages.map((m) => compressContent(m.content))
+    redacted.map((m) => compressContent(m.content))
   );
 
   // Insert messages with compressed content
   await insertMessages(
     env.DB,
-    messages.map((m, i) => ({
+    redacted.map((m, i) => ({
       id: m.id,
       conversationId: m.conversation_id,
       organizationId: m.organization_id,
@@ -98,10 +105,10 @@ export async function appendMessages(
   );
 
   // Update conversation message count
-  await updateConversationMessageCount(env.DB, conversationId, messages.length);
+  await updateConversationMessageCount(env.DB, conversationId, redacted.length);
 
-  // Chunk the new messages for embedding
-  const chunks = chunkMessages(messages);
+  // Chunk the redacted messages for embedding
+  const chunks = chunkMessages(redacted);
 
   if (chunks.length > 0) {
     // Generate embeddings for all chunks

--- a/apps/mcp-server/src/services/search.ts
+++ b/apps/mcp-server/src/services/search.ts
@@ -9,9 +9,9 @@ interface VectorizeMatch {
   metadata?: Record<string, unknown>;
 }
 
-export const DEFAULT_SNIPPET_CHARS = 800;
-export const MAX_SNIPPET_CHARS = 5000;
-export const DEFAULT_MIN_SCORE = 0.5;
+const DEFAULT_SNIPPET_CHARS = 2000;
+const MAX_SNIPPET_CHARS = 5000;
+const DEFAULT_MIN_SCORE = 0.3;
 const TRUNCATION_MARKER = "\n...[truncated]";
 
 // RRF constant — dampens high-rank dominance. k=60 is standard.

--- a/packages/shared/src/__tests__/redact.test.ts
+++ b/packages/shared/src/__tests__/redact.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import { redact, redactMessages } from "../utils/redact.js";
+
+const R = "[REDACTED]";
+
+describe("redact", () => {
+  // --- Provider API keys ---
+
+  it("redacts OpenAI keys", () => {
+    const input = "My key is sk-abc123def456ghi789jkl012mno345pqr678";
+    const { text, redactionCount } = redact(input);
+    expect(text).toBe(`My key is ${R}`);
+    expect(redactionCount).toBe(1);
+  });
+
+  it("redacts Anthropic keys", () => {
+    const { text } = redact("key: sk-ant-api03-abcdefghijklmnopqrstuvwxyz");
+    expect(text).toBe(`key: ${R}`);
+  });
+
+  it("redacts AWS access keys", () => {
+    const { text } = redact("aws_key = AKIAIOSFODNN7EXAMPLE");
+    expect(text).toBe(`aws_key = ${R}`);
+  });
+
+  it("redacts GitHub tokens", () => {
+    const { text } = redact(
+      "here: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl"
+    );
+    expect(text).toBe(`here: ${R}`);
+  });
+
+  it("redacts Stripe keys", () => {
+    const { text } = redact("sk_live_abc123def456ghi789jkl");
+    expect(text).toBe(R);
+  });
+
+  it("redacts Cloudflare keys", () => {
+    const { text } = redact(
+      "cfk_uARZ7QwKbJE5mss6zIRHf13RkGve125cnJC5f5cR09c21877"
+    );
+    expect(text).toBe(R);
+  });
+
+  it("redacts Slack tokens", () => {
+    const { text } = redact("xoxb-123456789012-abcdefghij");
+    expect(text).toBe(R);
+  });
+
+  it("redacts npm tokens", () => {
+    const { text } = redact(
+      "npm_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+    );
+    expect(text).toBe(R);
+  });
+
+  // --- JWTs ---
+
+  it("redacts JWTs", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const { text, redactionCount } = redact(`Bearer ${jwt}`);
+    // Bearer pattern and/or JWT pattern fires
+    expect(text).not.toContain("eyJ");
+    expect(redactionCount).toBeGreaterThanOrEqual(1);
+  });
+
+  // --- Connection strings ---
+
+  it("redacts postgres connection strings", () => {
+    const { text } = redact(
+      "DATABASE_URL=postgres://user:pass@host.com:5432/dbname"
+    );
+    expect(text).not.toContain("pass");
+    expect(text).not.toContain("host.com");
+  });
+
+  it("redacts redis connection strings", () => {
+    const { text } = redact("REDIS_URL=redis://default:secret@redis.io:6379");
+    expect(text).not.toContain("secret");
+  });
+
+  // --- Private keys ---
+
+  it("redacts PEM private keys", () => {
+    const pem = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF2PbnGMh
+-----END RSA PRIVATE KEY-----`;
+    const { text, redactionCount } = redact(`Here is my key:\n${pem}\nDone.`);
+    expect(text).not.toContain("MIIEpAIBAAK");
+    expect(redactionCount).toBeGreaterThanOrEqual(1);
+  });
+
+  // --- Secret assignments ---
+
+  it("redacts password= assignments", () => {
+    const { text } = redact('DB_PASSWORD="SuperSecret123!"');
+    expect(text).toBe(R);
+  });
+
+  it("redacts api_key= assignments", () => {
+    const { text } = redact("api_key=abcd1234efgh5678");
+    expect(text).not.toContain("abcd1234");
+  });
+
+  it("redacts jwt_secret= assignments", () => {
+    const { text } = redact("jwt_secret: my-very-secret-key-here");
+    expect(text).not.toContain("my-very-secret");
+  });
+
+  // --- PII ---
+
+  it("redacts email addresses", () => {
+    const { text } = redact("Contact me at john.doe@example.com please");
+    expect(text).toBe(`Contact me at ${R} please`);
+  });
+
+  it("redacts SSNs", () => {
+    const { text } = redact("SSN: 123-45-6789");
+    expect(text).toBe(`SSN: ${R}`);
+  });
+
+  it("redacts phone numbers", () => {
+    const { text } = redact("Call me at (555) 123-4567");
+    expect(text).not.toContain("123-4567");
+  });
+
+  it("redacts phone numbers with country code", () => {
+    const { text } = redact("Phone: +1-555-123-4567");
+    expect(text).not.toContain("555-123-4567");
+  });
+
+  // --- Generic high-entropy tokens ---
+
+  it("redacts long hex strings", () => {
+    const hex = "a".repeat(40);
+    const { text } = redact(`here ${hex} end`);
+    expect(text).toBe(`here ${R} end`);
+  });
+
+  // --- Multiple patterns ---
+
+  it("redacts multiple secrets in one string", () => {
+    const input = [
+      "OPENAI_KEY=sk-abc123def456ghi789jkl012mno345pqr678",
+      "DB_URL=postgres://user:pass@db.com/prod",
+      "email: user@example.com",
+    ].join("\n");
+
+    const { text, redactionCount } = redact(input);
+    expect(text).not.toContain("sk-abc");
+    expect(text).not.toContain("pass");
+    expect(text).not.toContain("user@example");
+    expect(redactionCount).toBeGreaterThanOrEqual(3);
+  });
+
+  // --- Preserves normal text ---
+
+  it("does not redact normal conversation text", () => {
+    const input =
+      "The user asked about implementing a search feature. I suggested using FTS5 with BM25 ranking.";
+    const { text, redactionCount } = redact(input);
+    expect(text).toBe(input);
+    expect(redactionCount).toBe(0);
+  });
+
+  it("does not redact short tokens or normal IDs", () => {
+    const input = "conv_abc123 msg_def456 chk_ghi789";
+    const { text, redactionCount } = redact(input);
+    expect(text).toBe(input);
+    expect(redactionCount).toBe(0);
+  });
+
+  it("does not redact code examples without real secrets", () => {
+    const input = 'const x = 42;\nif (password.length < 8) throw new Error("too short");';
+    const { text, redactionCount } = redact(input);
+    expect(text).toBe(input);
+    expect(redactionCount).toBe(0);
+  });
+});
+
+describe("redactMessages", () => {
+  it("redacts content across multiple messages", () => {
+    const messages = [
+      { content: "My API key is sk-abc123def456ghi789jkl012mno345pqr678" },
+      { content: "Normal message with no secrets" },
+      { content: "Password: postgres://user:pass@db.com/prod" },
+    ];
+
+    const { messages: result, totalRedactions } = redactMessages(messages);
+    expect(result[0].content).not.toContain("sk-abc");
+    expect(result[1].content).toBe("Normal message with no secrets");
+    expect(result[2].content).not.toContain("pass");
+    expect(totalRedactions).toBeGreaterThanOrEqual(2);
+  });
+
+  it("preserves other message fields", () => {
+    const messages = [
+      { content: "sk-abc123def456ghi789jkl012mno345pqr678", role: "user", id: "msg_1" },
+    ];
+
+    const { messages: result } = redactMessages(messages);
+    expect((result[0] as any).role).toBe("user");
+    expect((result[0] as any).id).toBe("msg_1");
+  });
+
+  it("returns zero redactions for clean messages", () => {
+    const messages = [
+      { content: "Hello, how can I help you today?" },
+      { content: "I'd like to learn about TypeScript." },
+    ];
+
+    const { totalRedactions } = redactMessages(messages);
+    expect(totalRedactions).toBe(0);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,4 +3,5 @@ export * from "./schemas/index.js";
 export * from "./utils/id.js";
 export * from "./utils/chunk.js";
 export * from "./utils/auth.js";
+export * from "./utils/redact.js";
 export * from "./constants.js";

--- a/packages/shared/src/utils/redact.ts
+++ b/packages/shared/src/utils/redact.ts
@@ -1,0 +1,126 @@
+const REDACTED = "[REDACTED]";
+
+// --- Pattern definitions ---
+
+// Generic high-entropy tokens: hex ≥32 chars, base64-ish ≥40 chars
+const HEX_TOKEN = /\b[0-9a-fA-F]{32,}\b/g;
+const BASE64_TOKEN = /\b[A-Za-z0-9+/]{40,}={0,2}\b/g;
+
+// Provider API keys — each has a distinctive prefix
+const PROVIDER_KEYS = [
+  // OpenAI
+  /\bsk-[A-Za-z0-9]{20,}\b/g,
+  // Anthropic
+  /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g,
+  // AWS
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bASIA[0-9A-Z]{16}\b/g,
+  // GitHub
+  /\b(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}\b/g,
+  // Stripe
+  /\b[rs]k_(test|live)_[A-Za-z0-9]{10,}\b/g,
+  // Cloudflare
+  /\bcfk_[A-Za-z0-9]{30,}\b/g,
+  // Supabase
+  /\bsbp_[A-Za-z0-9]{30,}\b/g,
+  // Slack
+  /\bxox[bpras]-[A-Za-z0-9-]{10,}\b/g,
+  // npm
+  /\bnpm_[A-Za-z0-9]{30,}\b/g,
+  // Sendgrid
+  /\bSG\.[A-Za-z0-9_-]{22,}\.[A-Za-z0-9_-]{22,}\b/g,
+  // Twilio
+  /\bSK[0-9a-fA-F]{32}\b/g,
+  // Generic Bearer tokens on a single line
+  /Bearer\s+[A-Za-z0-9._~+/=-]{20,}/g,
+];
+
+// Connection strings (postgres, mysql, redis, mongodb, amqp)
+const CONNECTION_STRING =
+  /\b(postgres|postgresql|mysql|redis|rediss|mongodb|mongodb\+srv|amqp|amqps):\/\/[^\s"'`]+/gi;
+
+// Private keys (PEM blocks)
+const PRIVATE_KEY =
+  /-----BEGIN\s+(RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]*?-----END\s+(RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/g;
+
+// Key=value assignments where key suggests a secret
+// Allows prefixes like DB_PASSWORD, STRIPE_SECRET, etc.
+const SECRET_ASSIGNMENT =
+  /\b\w*(password|passwd|secret|token|api_key|apikey|api[-_]?secret|private[-_]?key|access[-_]?key|auth[-_]?token|client[-_]?secret|signing[-_]?key|encryption[-_]?key|jwt[-_]?secret)\s*[:=]\s*["']?[^\s"']{8,}["']?/gi;
+
+// PII patterns
+const EMAIL = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z]{2,}\b/gi;
+const PHONE = /(\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g;
+const SSN = /\b\d{3}-\d{2}-\d{4}\b/g;
+const CREDIT_CARD = /\b(?:\d[ -]*?){13,19}\b/g;
+
+// JWTs (three base64url segments separated by dots)
+const JWT = /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
+
+export interface RedactResult {
+  text: string;
+  redactionCount: number;
+}
+
+/**
+ * Redact secrets, credentials, and PII from text.
+ * Returns the cleaned text and a count of redactions applied.
+ */
+export function redact(input: string): RedactResult {
+  let text = input;
+  let count = 0;
+
+  function apply(pattern: RegExp) {
+    text = text.replace(pattern, () => {
+      count++;
+      return REDACTED;
+    });
+  }
+
+  // Order matters — specific patterns first, then generic
+
+  // 1. PEM private keys (multi-line)
+  apply(PRIVATE_KEY);
+
+  // 2. Provider-specific API keys
+  for (const pat of PROVIDER_KEYS) {
+    apply(pat);
+  }
+
+  // 3. JWTs
+  apply(JWT);
+
+  // 4. Connection strings
+  apply(CONNECTION_STRING);
+
+  // 5. Secret assignments (password=..., token:..., etc.)
+  apply(SECRET_ASSIGNMENT);
+
+  // 6. PII
+  apply(SSN);
+  apply(CREDIT_CARD);
+  apply(EMAIL);
+  apply(PHONE);
+
+  // 7. Generic high-entropy tokens (last — catches stragglers)
+  apply(HEX_TOKEN);
+  apply(BASE64_TOKEN);
+
+  return { text, redactionCount: count };
+}
+
+/**
+ * Redact an array of message contents in place.
+ * Returns total redaction count across all messages.
+ */
+export function redactMessages<T extends { content: string }>(
+  messages: T[]
+): { messages: T[]; totalRedactions: number } {
+  let total = 0;
+  const redacted = messages.map((m) => {
+    const result = redact(m.content);
+    total += result.redactionCount;
+    return { ...m, content: result.text };
+  });
+  return { messages: redacted, totalRedactions: total };
+}


### PR DESCRIPTION
## Summary

- **Redaction pipeline** (closes #64): scrubs secrets, credentials, and PII from message content before it reaches D1, FTS5, or Vectorize. Patterns cover API keys (OpenAI, Anthropic, AWS, GitHub, Stripe, Cloudflare, Supabase, Slack, npm, Sendgrid, Twilio), JWTs, connection strings, PEM private keys, password assignments, emails, SSNs, phone numbers, credit cards, and generic high-entropy tokens.
- **Simplified search tool**: removed `snippet_chars`, `min_score`, and `dedupe` parameters from the MCP tool schema. Agents were overriding defaults with worse values (3000 chars, 0.3 min_score). Now uses hardcoded optimized defaults internally (2000 chars, 0.3 score threshold, always dedupe).
- **Stronger tool description**: explicitly tells agents "one search is enough — do not retry with rephrased queries"

## Test plan

- [x] 27 new redaction tests covering all pattern categories
- [x] All 130 tests passing across all packages
- [x] Redaction integrates after message creation but before compression/chunking/embedding
- [ ] Deploy and verify search still works end-to-end
- [ ] Verify redaction logging appears in worker logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)