### PR TITLE
feat: per-org rate limiting by tier

### DIFF
--- a/apps/mcp-server/src/__tests__/rate-limit.test.ts
+++ b/apps/mcp-server/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { rateLimitMiddleware } from "../middleware/rate-limit.js";
+import type { Env, AuthContext } from "../types.js";
+
+type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
+
+function createApp(tier: AuthContext["tier"] = "free") {
+  const app = new Hono<HonoEnv>();
+
+  // Fake auth middleware — sets auth context
+  app.use("*", async (c, next) => {
+    c.set("auth", {
+      organizationId: `org_${tier}`,
+      apiKeyId: "key_test",
+      tier,
+    });
+    await next();
+  });
+
+  app.use("*", rateLimitMiddleware);
+  app.get("/test", (c) => c.json({ ok: true }));
+
+  return app;
+}
+
+describe("rate limit middleware", () => {
+  it("allows requests under the limit", async () => {
+    const app = createApp("pro"); // 120/min
+    const res = await app.request("/test");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("120");
+  });
+
+  it("returns 429 when limit is exceeded", async () => {
+    const app = createApp("free"); // 30/min
+    // Use a unique org to avoid polluting other tests
+    const uniqueApp = new Hono<HonoEnv>();
+    uniqueApp.use("*", async (c, next) => {
+      c.set("auth", {
+        organizationId: "org_burst_test",
+        apiKeyId: "key_test",
+        tier: "free",
+      });
+      await next();
+    });
+    uniqueApp.use("*", rateLimitMiddleware);
+    uniqueApp.get("/test", (c) => c.json({ ok: true }));
+
+    // Send 31 requests — the 31st should be rejected
+    let lastStatus = 200;
+    for (let i = 0; i < 31; i++) {
+      const res = await uniqueApp.request("/test");
+      lastStatus = res.status;
+      if (lastStatus === 429) break;
+    }
+    expect(lastStatus).toBe(429);
+  });
+
+  it("returns correct error body on 429", async () => {
+    const uniqueApp = new Hono<HonoEnv>();
+    uniqueApp.use("*", async (c, next) => {
+      c.set("auth", {
+        organizationId: "org_error_body_test",
+        apiKeyId: "key_test",
+        tier: "free",
+      });
+      await next();
+    });
+    uniqueApp.use("*", rateLimitMiddleware);
+    uniqueApp.get("/test", (c) => c.json({ ok: true }));
+
+    // Exhaust the limit
+    for (let i = 0; i < 30; i++) {
+      await uniqueApp.request("/test");
+    }
+
+    const res = await uniqueApp.request("/test");
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("rate_limit_exceeded");
+    expect(body.retry_after).toBe(60);
+  });
+
+  it("gives higher limits to paid tiers", async () => {
+    // Enterprise gets 600/min — 31 requests should be fine
+    const app = new Hono<HonoEnv>();
+    app.use("*", async (c, next) => {
+      c.set("auth", {
+        organizationId: "org_enterprise_test",
+        apiKeyId: "key_test",
+        tier: "enterprise",
+      });
+      await next();
+    });
+    app.use("*", rateLimitMiddleware);
+    app.get("/test", (c) => c.json({ ok: true }));
+
+    let allOk = true;
+    for (let i = 0; i < 50; i++) {
+      const res = await app.request("/test");
+      if (res.status !== 200) {
+        allOk = false;
+        break;
+      }
+    }
+    expect(allOk).toBe(true);
+  });
+});

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { authMiddleware } from "./middleware/auth.js";
+import { rateLimitMiddleware } from "./middleware/rate-limit.js";
 import { createMcpServer } from "./mcp/server.js";
 import { keys } from "./routes/keys.js";
 import { seats } from "./routes/seats.js";
@@ -25,7 +26,7 @@ app.get("/health", (c) => {
 });
 
 // MCP endpoint — all methods
-app.all("/mcp", authMiddleware, async (c) => {
+app.all("/mcp", authMiddleware, rateLimitMiddleware, async (c) => {
   const auth = c.get("auth");
   const server = createMcpServer(c.env, auth);
 
@@ -84,6 +85,7 @@ app.use(
   }),
 );
 app.use("/api/*", authMiddleware);
+app.use("/api/*", rateLimitMiddleware);
 app.route("/api/keys", keys);
 app.route("/api/seats", seats);
 app.route("/api/webhooks", webhooks);

--- a/apps/mcp-server/src/middleware/rate-limit.ts
+++ b/apps/mcp-server/src/middleware/rate-limit.ts
@@ -1,0 +1,91 @@
+import type { Context, Next } from "hono";
+import type { Env, AuthContext } from "../types.js";
+import type { Tier } from "@getengram/shared";
+
+/**
+ * Per-org request rate limits (requests per minute).
+ * Generous enough for normal agent usage, tight enough to block abuse.
+ */
+const RATE_LIMITS: Record<Tier, number> = {
+  free: 30,
+  pro: 120,
+  team: 300,
+  enterprise: 600,
+};
+
+interface BucketEntry {
+  tokens: number;
+  lastRefill: number;
+}
+
+// In-memory token bucket per org. Shared across requests within a
+// Worker isolate; resets on deploy or isolate eviction — which is fine,
+// this is burst protection, not billing.
+const buckets = new Map<string, BucketEntry>();
+
+function consumeToken(orgId: string, tier: Tier): boolean {
+  const maxTokens = RATE_LIMITS[tier] ?? RATE_LIMITS.free;
+  const now = Date.now();
+
+  let bucket = buckets.get(orgId);
+  if (!bucket) {
+    bucket = { tokens: maxTokens, lastRefill: now };
+    buckets.set(orgId, bucket);
+  }
+
+  // Refill tokens based on elapsed time (token bucket algorithm)
+  const elapsed = now - bucket.lastRefill;
+  const refill = (elapsed / 60_000) * maxTokens; // full refill per minute
+  bucket.tokens = Math.min(maxTokens, bucket.tokens + refill);
+  bucket.lastRefill = now;
+
+  if (bucket.tokens < 1) {
+    return false;
+  }
+
+  bucket.tokens -= 1;
+  return true;
+}
+
+// Evict stale entries every 1000 requests to prevent memory growth
+let requestCount = 0;
+const EVICT_INTERVAL = 1000;
+const STALE_MS = 5 * 60_000; // 5 minutes
+
+function maybeEvict() {
+  requestCount++;
+  if (requestCount % EVICT_INTERVAL !== 0) return;
+  const now = Date.now();
+  for (const [key, entry] of buckets) {
+    if (now - entry.lastRefill > STALE_MS) {
+      buckets.delete(key);
+    }
+  }
+}
+
+export async function rateLimitMiddleware(
+  c: Context<{ Bindings: Env; Variables: { auth: AuthContext } }>,
+  next: Next,
+) {
+  const auth = c.get("auth");
+  const allowed = consumeToken(auth.organizationId, auth.tier);
+
+  maybeEvict();
+
+  if (!allowed) {
+    const limit = RATE_LIMITS[auth.tier] ?? RATE_LIMITS.free;
+    return c.json(
+      {
+        error: "rate_limit_exceeded",
+        message: `Rate limit exceeded. ${limit} requests per minute allowed for ${auth.tier} tier.`,
+        retry_after: 60,
+      },
+      429,
+    );
+  }
+
+  // Set rate limit headers
+  c.header("X-RateLimit-Limit", String(RATE_LIMITS[auth.tier] ?? RATE_LIMITS.free));
+
+  await next();
+}


### PR DESCRIPTION
## Summary

- Token bucket rate limiter on `/mcp` and `/api/*` endpoints
- Per-org limits by tier: free=30, pro=120, team=300, enterprise=600 req/min
- Returns 429 with `retry_after` when exceeded
- In-memory — no extra D1 queries, automatic stale bucket eviction
- 4 new tests, all 134 passing

Closes #62

## Test plan

- [x] Allows requests under limit
- [x] Returns 429 when exceeded with correct error body
- [x] Paid tiers get higher limits
- [ ] Deploy and verify no impact on normal agent traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)