### PR TITLE
feat: GDPR account deletion endpoint

### DIFF
--- a/apps/mcp-server/src/__tests__/account.test.ts
+++ b/apps/mcp-server/src/__tests__/account.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { account } from "../routes/account.js";
+import { createMockD1, createMockEnv } from "./helpers.js";
+import { insertOrganization, insertConversation } from "@getengram/db";
+import type { Env, AuthContext } from "../types.js";
+
+type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
+
+function createApp(orgId: string) {
+  const app = new Hono<HonoEnv>();
+
+  // Fake auth middleware
+  app.use("*", async (c, next) => {
+    c.set("auth", {
+      organizationId: orgId,
+      apiKeyId: "key_test",
+      tier: "free" as const,
+    });
+    await next();
+  });
+
+  app.route("/api/account", account);
+  return app;
+}
+
+describe("DELETE /api/account", () => {
+  it("deletes an organization and returns stats", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    await insertOrganization(db, "org_del", "Delete Me");
+    await insertConversation(db, "conv_1", "org_del", "Test", null, [], {});
+
+    const app = createApp("org_del");
+    const res = await app.request("/api/account", { method: "DELETE" }, env);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.deleted).toBe(true);
+    expect(body.organization_id).toBe("org_del");
+    expect(body.deleted_records).toBeDefined();
+  });
+
+  it("returns 404 for non-existent org", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+
+    const app = createApp("org_ghost");
+    const res = await app.request("/api/account", { method: "DELETE" }, env);
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("Organization not found");
+  });
+
+  it("calls VECTORIZE.deleteByIds when vectors exist", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    await insertOrganization(db, "org_vec", "Vec Org");
+
+    // Manually insert a chunk with a vectorize_id
+    await db
+      .prepare(
+        "INSERT INTO conversation_chunks (id, conversation_id, organization_id, chunk_text, start_sequence, end_sequence, vectorize_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind("chk_1", "conv_1", "org_vec", "test", 1, 1, "vec_abc")
+      .run();
+
+    const app = createApp("org_vec");
+    const res = await app.request("/api/account", { method: "DELETE" }, env);
+
+    expect(res.status).toBe(200);
+    expect(env.VECTORIZE.deleteByIds).toHaveBeenCalledWith(["vec_abc"]);
+  });
+});

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -11,6 +11,7 @@ import { usage } from "./routes/usage.js";
 import { signup } from "./routes/signup.js";
 import { billing, billingWebhook } from "./routes/billing.js";
 import { admin } from "./routes/admin.js";
+import { account } from "./routes/account.js";
 import type { Env, AuthContext } from "./types.js";
 
 type HonoEnv = {
@@ -91,5 +92,6 @@ app.route("/api/seats", seats);
 app.route("/api/webhooks", webhooks);
 app.route("/api/usage", usage);
 app.route("/api/billing", billing);
+app.route("/api/account", account);
 
 export default app;

--- a/apps/mcp-server/src/routes/account.ts
+++ b/apps/mcp-server/src/routes/account.ts
@@ -1,0 +1,56 @@
+import { Hono } from "hono";
+import {
+  getOrganizationById,
+  getVectorizeIdsByOrganization,
+  deleteOrganizationById,
+  getOrganizationStats,
+} from "@getengram/db";
+import type { Env, AuthContext } from "../types.js";
+
+type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
+
+const account = new Hono<HonoEnv>();
+
+// DELETE /api/account — delete the authenticated user's organization and all data
+account.delete("/", async (c) => {
+  const auth = c.get("auth");
+  const orgId = auth.organizationId;
+
+  // Verify org exists
+  const org = await getOrganizationById(c.env.DB, orgId);
+  if (!org) {
+    return c.json({ error: "Organization not found" }, 404);
+  }
+
+  // Gather stats before deletion (for the response)
+  const stats = await getOrganizationStats(c.env.DB, orgId);
+
+  // Get all vectorize IDs before D1 deletion
+  const vectorResult = await getVectorizeIdsByOrganization(c.env.DB, orgId);
+  const vectorizeIds = vectorResult.results.map((r) => r.vectorize_id);
+
+  // Delete from Vectorize first (external service — fail before D1 if it errors)
+  if (vectorizeIds.length > 0) {
+    // Vectorize deleteByIds has a max batch size; chunk into groups of 1000
+    for (let i = 0; i < vectorizeIds.length; i += 1000) {
+      const batch = vectorizeIds.slice(i, i + 1000);
+      await c.env.VECTORIZE.deleteByIds(batch);
+    }
+  }
+
+  // Delete from D1 (FTS → chunks → messages → conversations → org)
+  await deleteOrganizationById(c.env.DB, orgId);
+
+  return c.json({
+    deleted: true,
+    organization_id: orgId,
+    deleted_records: {
+      conversations: stats?.conversations ?? 0,
+      messages: stats?.messages ?? 0,
+      chunks: stats?.chunks ?? 0,
+      vectors: vectorizeIds.length,
+    },
+  });
+});
+
+export { account };

--- a/packages/db/src/queries/organizations.ts
+++ b/packages/db/src/queries/organizations.ts
@@ -65,3 +65,41 @@ export function setOrganizationTier(
     .bind(tier, stripeSubscriptionId, id)
     .run();
 }
+
+export function getVectorizeIdsByOrganization(
+  db: D1Database,
+  organizationId: string,
+) {
+  return db
+    .prepare(
+      "SELECT vectorize_id FROM conversation_chunks WHERE organization_id = ?",
+    )
+    .bind(organizationId)
+    .all<{ vectorize_id: string }>();
+}
+
+export function deleteOrganizationById(db: D1Database, id: string) {
+  return db.batch([
+    // FTS delete must come before chunks (subquery references conversation_chunks)
+    db.prepare(
+      "DELETE FROM chunks_fts WHERE chunk_id IN (SELECT id FROM conversation_chunks WHERE organization_id = ?)",
+    ).bind(id),
+    // CASCADE handles the rest, but explicit deletes are safer for ordering
+    db.prepare("DELETE FROM conversation_chunks WHERE organization_id = ?").bind(id),
+    db.prepare("DELETE FROM messages WHERE organization_id = ?").bind(id),
+    db.prepare("DELETE FROM conversations WHERE organization_id = ?").bind(id),
+    db.prepare("DELETE FROM organizations WHERE id = ?").bind(id),
+  ]);
+}
+
+export function getOrganizationStats(db: D1Database, organizationId: string) {
+  return db
+    .prepare(
+      `SELECT
+        (SELECT COUNT(*) FROM conversations WHERE organization_id = ?) AS conversations,
+        (SELECT COUNT(*) FROM messages WHERE organization_id = ?) AS messages,
+        (SELECT COUNT(*) FROM conversation_chunks WHERE organization_id = ?) AS chunks`,
+    )
+    .bind(organizationId, organizationId, organizationId)
+    .first<{ conversations: number; messages: number; chunks: number }>();
+}


### PR DESCRIPTION
## Summary
- Adds `DELETE /api/account` endpoint for GDPR Article 17 (right to erasure)
- Deletes all org data: Vectorize embeddings → FTS → chunks → messages → conversations → org
- New DB helpers: `getVectorizeIdsByOrganization`, `deleteOrganizationById`, `getOrganizationStats`
- 3 tests covering: successful deletion, 404 for missing org, Vectorize cleanup

Closes #74

## Test plan
- [x] Unit tests pass (60/60)
- [ ] Manual test: create org, add data, call DELETE /api/account, verify all data gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)