### PR TITLE
feat: GDPR 30-day soft-delete + daily purge cron

### DIFF
--- a/apps/mcp-server/src/__tests__/account.test.ts
+++ b/apps/mcp-server/src/__tests__/account.test.ts
@@ -25,7 +25,7 @@ function createApp(orgId: string) {
 }
 
 describe("DELETE /api/account", () => {
-  it("deletes an organization and returns stats", async () => {
+  it("soft-deletes an organization and returns grace period info", async () => {
     const db = createMockD1();
     const env = createMockEnv(db);
     await insertOrganization(db, "org_del", "Delete Me");
@@ -38,7 +38,7 @@ describe("DELETE /api/account", () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.deleted).toBe(true);
     expect(body.organization_id).toBe("org_del");
-    expect(body.deleted_records).toBeDefined();
+    expect(body.grace_period_days).toBe(30);
   });
 
   it("returns 404 for non-existent org", async () => {
@@ -52,24 +52,30 @@ describe("DELETE /api/account", () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.error).toBe("Organization not found");
   });
+});
 
-  it("calls VECTORIZE.deleteByIds when vectors exist", async () => {
+describe("POST /api/account/restore", () => {
+  it("returns 400 when org is not deleted", async () => {
     const db = createMockD1();
     const env = createMockEnv(db);
-    await insertOrganization(db, "org_vec", "Vec Org");
+    await insertOrganization(db, "org_active", "Active Org");
 
-    // Manually insert a chunk with a vectorize_id
-    await db
-      .prepare(
-        "INSERT INTO conversation_chunks (id, conversation_id, organization_id, chunk_text, start_sequence, end_sequence, vectorize_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
-      )
-      .bind("chk_1", "conv_1", "org_vec", "test", 1, 1, "vec_abc")
-      .run();
+    const app = createApp("org_active");
+    const res = await app.request("/api/account/restore", { method: "POST" }, env);
 
-    const app = createApp("org_vec");
-    const res = await app.request("/api/account", { method: "DELETE" }, env);
+    // Org exists but has no deleted_at set — should return 400
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("Account is not marked for deletion");
+  });
 
-    expect(res.status).toBe(200);
-    expect(env.VECTORIZE.deleteByIds).toHaveBeenCalledWith(["vec_abc"]);
+  it("returns 404 for non-existent org", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+
+    const app = createApp("org_gone");
+    const res = await app.request("/api/account/restore", { method: "POST" }, env);
+
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/mcp-server/src/cron/purge-deleted.ts
+++ b/apps/mcp-server/src/cron/purge-deleted.ts
@@ -1,0 +1,35 @@
+import {
+  getExpiredOrganizations,
+  getVectorizeIdsByOrganization,
+  deleteOrganizationById,
+} from "@getengram/db";
+import type { Env } from "../types.js";
+
+/**
+ * Permanently deletes organizations whose deleted_at is older than 30 days.
+ * Called by the Workers cron trigger (daily).
+ */
+export async function purgeDeletedOrganizations(env: Env): Promise<number> {
+  const expired = await getExpiredOrganizations(env.DB);
+  let purged = 0;
+
+  for (const { id } of expired.results) {
+    // Delete vectors from Vectorize
+    const vectorResult = await getVectorizeIdsByOrganization(env.DB, id);
+    const vectorizeIds = vectorResult.results.map((r) => r.vectorize_id);
+
+    if (vectorizeIds.length > 0) {
+      for (let i = 0; i < vectorizeIds.length; i += 1000) {
+        const batch = vectorizeIds.slice(i, i + 1000);
+        await env.VECTORIZE.deleteByIds(batch);
+      }
+    }
+
+    // Hard-delete from D1
+    await deleteOrganizationById(env.DB, id);
+    purged++;
+    console.log(`[purge] Hard-deleted org ${id} (${vectorizeIds.length} vectors)`);
+  }
+
+  return purged;
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -13,6 +13,7 @@ import { billing, billingWebhook } from "./routes/billing.js";
 import { admin } from "./routes/admin.js";
 import { account } from "./routes/account.js";
 import { dataExport } from "./routes/export.js";
+import { purgeDeletedOrganizations } from "./cron/purge-deleted.js";
 import type { Env, AuthContext } from "./types.js";
 
 type HonoEnv = {
@@ -96,4 +97,12 @@ app.route("/api/billing", billing);
 app.route("/api/account", account);
 app.route("/api/export", dataExport);
 
-export default app;
+export default {
+  fetch: app.fetch,
+  async scheduled(_event: ScheduledEvent, env: Env, _ctx: ExecutionContext) {
+    const purged = await purgeDeletedOrganizations(env);
+    if (purged > 0) {
+      console.log(`[cron] Purged ${purged} expired organization(s)`);
+    }
+  },
+};

--- a/apps/mcp-server/src/routes/account.ts
+++ b/apps/mcp-server/src/routes/account.ts
@@ -1,9 +1,9 @@
 import { Hono } from "hono";
 import {
   getOrganizationById,
-  getVectorizeIdsByOrganization,
-  deleteOrganizationById,
   getOrganizationStats,
+  softDeleteOrganization,
+  restoreOrganization,
 } from "@getengram/db";
 import type { Env, AuthContext } from "../types.js";
 
@@ -11,45 +11,53 @@ type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
 
 const account = new Hono<HonoEnv>();
 
-// DELETE /api/account — delete the authenticated user's organization and all data
+// DELETE /api/account — soft-delete the organization (30-day grace period)
 account.delete("/", async (c) => {
   const auth = c.get("auth");
   const orgId = auth.organizationId;
 
-  // Verify org exists
   const org = await getOrganizationById(c.env.DB, orgId);
   if (!org) {
     return c.json({ error: "Organization not found" }, 404);
   }
 
-  // Gather stats before deletion (for the response)
   const stats = await getOrganizationStats(c.env.DB, orgId);
 
-  // Get all vectorize IDs before D1 deletion
-  const vectorResult = await getVectorizeIdsByOrganization(c.env.DB, orgId);
-  const vectorizeIds = vectorResult.results.map((r) => r.vectorize_id);
-
-  // Delete from Vectorize first (external service — fail before D1 if it errors)
-  if (vectorizeIds.length > 0) {
-    // Vectorize deleteByIds has a max batch size; chunk into groups of 1000
-    for (let i = 0; i < vectorizeIds.length; i += 1000) {
-      const batch = vectorizeIds.slice(i, i + 1000);
-      await c.env.VECTORIZE.deleteByIds(batch);
-    }
-  }
-
-  // Delete from D1 (FTS → chunks → messages → conversations → org)
-  await deleteOrganizationById(c.env.DB, orgId);
+  // Soft-delete: set deleted_at timestamp. Data is purged after 30 days by cron.
+  await softDeleteOrganization(c.env.DB, orgId);
 
   return c.json({
     deleted: true,
     organization_id: orgId,
-    deleted_records: {
+    grace_period_days: 30,
+    message: "Account scheduled for deletion. Data will be permanently removed after 30 days. Call POST /api/account/restore to undo.",
+    affected_records: {
       conversations: stats?.conversations ?? 0,
       messages: stats?.messages ?? 0,
       chunks: stats?.chunks ?? 0,
-      vectors: vectorizeIds.length,
     },
+  });
+});
+
+// POST /api/account/restore — undo soft-delete within 30-day window
+account.post("/restore", async (c) => {
+  const auth = c.get("auth");
+  const orgId = auth.organizationId;
+
+  const org = (await getOrganizationById(c.env.DB, orgId)) as Record<string, unknown> | null;
+  if (!org) {
+    return c.json({ error: "Organization not found" }, 404);
+  }
+
+  if (!org.deleted_at) {
+    return c.json({ error: "Account is not marked for deletion" }, 400);
+  }
+
+  await restoreOrganization(c.env.DB, orgId);
+
+  return c.json({
+    restored: true,
+    organization_id: orgId,
   });
 });
 

--- a/apps/mcp-server/wrangler.toml
+++ b/apps/mcp-server/wrangler.toml
@@ -30,3 +30,7 @@ binding = "AI"
 [[routes]]
 pattern = "mcp.getengram.app/*"
 zone_name = "getengram.app"
+
+# Daily cron — purge soft-deleted orgs older than 30 days (GDPR)
+[triggers]
+crons = ["0 3 * * *"]

--- a/packages/db/migrations/0007_add_deleted_at.sql
+++ b/packages/db/migrations/0007_add_deleted_at.sql
@@ -1,0 +1,4 @@
+-- Soft-delete support for GDPR 30-day grace period.
+-- When a user requests account deletion, we set deleted_at instead of
+-- hard-deleting. A daily cron purges orgs where deleted_at > 30 days.
+ALTER TABLE organizations ADD COLUMN deleted_at TEXT;

--- a/packages/db/src/queries/organizations.ts
+++ b/packages/db/src/queries/organizations.ts
@@ -92,6 +92,30 @@ export function deleteOrganizationById(db: D1Database, id: string) {
   ]);
 }
 
+export function softDeleteOrganization(db: D1Database, id: string) {
+  return db
+    .prepare(
+      "UPDATE organizations SET deleted_at = datetime('now') WHERE id = ?",
+    )
+    .bind(id)
+    .run();
+}
+
+export function restoreOrganization(db: D1Database, id: string) {
+  return db
+    .prepare("UPDATE organizations SET deleted_at = NULL WHERE id = ?")
+    .bind(id)
+    .run();
+}
+
+export function getExpiredOrganizations(db: D1Database) {
+  return db
+    .prepare(
+      "SELECT id FROM organizations WHERE deleted_at IS NOT NULL AND deleted_at < datetime('now', '-30 days')",
+    )
+    .all<{ id: string }>();
+}
+
 export function getOrganizationStats(db: D1Database, organizationId: string) {
   return db
     .prepare(


### PR DESCRIPTION
## Summary
- `DELETE /api/account` now soft-deletes (sets `deleted_at`) instead of hard-deleting
- `POST /api/account/restore` lets users undo deletion within 30-day window
- Daily cron trigger (3am UTC) hard-deletes expired orgs + cleans up Vectorize
- D1 migration adds `deleted_at` column to organizations

Closes #79

## Test plan
- [x] All tests pass (64/64)
- [x] D1 migration applied to production
- [ ] Verify soft-delete sets deleted_at
- [ ] Verify restore clears deleted_at
- [ ] Verify cron purges after 30 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)