### PR TITLE
feat: add engram signup/login CLI commands

### DIFF
--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -1,0 +1,160 @@
+import { createInterface } from "node:readline";
+import { saveConfig, loadConfig, getBaseUrl } from "../config.js";
+import { green, red, dim } from "../output.js";
+import { Engram } from "@getengram/sdk";
+
+const API_URL = process.env.ENGRAM_BASE_URL ?? getBaseUrl();
+
+/** Prompt for input (hides input for passwords). */
+function prompt(question: string, hidden = false): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    if (hidden && process.stdin.isTTY) {
+      // Mute output for password entry
+      process.stdout.write(question);
+      const stdin = process.stdin;
+      const wasRaw = stdin.isRaw;
+      stdin.setRawMode(true);
+      let input = "";
+      const onData = (ch: Buffer) => {
+        const c = ch.toString();
+        if (c === "\n" || c === "\r") {
+          stdin.setRawMode(wasRaw ?? false);
+          stdin.removeListener("data", onData);
+          process.stdout.write("\n");
+          rl.close();
+          resolve(input);
+        } else if (c === "\x03") {
+          // Ctrl+C
+          process.exit(1);
+        } else if (c === "\x7f" || c === "\b") {
+          // Backspace
+          input = input.slice(0, -1);
+        } else {
+          input += c;
+        }
+      };
+      stdin.on("data", onData);
+    } else {
+      rl.question(question, (answer) => {
+        rl.close();
+        resolve(answer);
+      });
+    }
+  });
+}
+
+/**
+ * `engram signup` — create an anonymous account instantly.
+ * No email, no password. Just get a key and start using Engram.
+ */
+export async function signup(): Promise<void> {
+  console.log("Creating account...");
+
+  const res = await fetch(`${API_URL}/signup/anonymous`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    console.error(red(`Signup failed: ${res.status} ${body}`));
+    process.exit(1);
+  }
+
+  const data = (await res.json()) as {
+    organization_id: string;
+    api_key: string;
+  };
+
+  const config = await loadConfig();
+  config.apiKey = data.api_key;
+  await saveConfig(config);
+
+  console.log(green("✓ Account created"));
+  console.log(`  Organization: ${data.organization_id}`);
+  console.log(`  API key saved to ~/.engram/config.json`);
+  console.log(
+    dim("\n  Tip: run 'engram install' to auto-start on login"),
+  );
+  console.log(
+    dim("  Tip: run 'engram link <email>' to claim your account for upgrades"),
+  );
+}
+
+/**
+ * `engram login` — sign in with email + password.
+ * Calls Supabase auth, then the worker /signup to get an API key.
+ */
+export async function login(): Promise<void> {
+  const email = await prompt("Email: ");
+  const password = await prompt("Password: ", true);
+
+  if (!email || !password) {
+    console.error(red("Email and password are required."));
+    process.exit(1);
+  }
+
+  // Sign in via Supabase REST API
+  const supabaseUrl = "https://ygfqaafyfjrutxjeswks.supabase.co";
+  const supabaseAnonKey =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlnZnFhYWZ5ZmpydXR4amVzd2tzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDQ1MDg3ODcsImV4cCI6MjA2MDA4NDc4N30.pK_3TgpMFsYi_4fRR-gBnLGoXxqYINOqSjjKcBqe70c";
+
+  console.log("Signing in...");
+
+  const authRes = await fetch(
+    `${supabaseUrl}/auth/v1/token?grant_type=password`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        apikey: supabaseAnonKey,
+      },
+      body: JSON.stringify({ email: email.trim(), password }),
+    },
+  );
+
+  if (!authRes.ok) {
+    const err = (await authRes.json().catch(() => ({}))) as {
+      error_description?: string;
+    };
+    console.error(
+      red(err.error_description || `Login failed: ${authRes.status}`),
+    );
+    process.exit(1);
+  }
+
+  const session = (await authRes.json()) as { access_token: string };
+
+  // Exchange Supabase token for Engram API key
+  const signupRes = await fetch(`${API_URL}/signup`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.access_token}`,
+    },
+    body: JSON.stringify({ plan: "free" }),
+  });
+
+  if (!signupRes.ok) {
+    const body = await signupRes.text().catch(() => "");
+    console.error(red(`Failed to get API key: ${signupRes.status} ${body}`));
+    process.exit(1);
+  }
+
+  const data = (await signupRes.json()) as {
+    organization_id: string;
+    api_key: string;
+  };
+
+  const config = await loadConfig();
+  config.apiKey = data.api_key;
+  await saveConfig(config);
+
+  console.log(green(`✓ Signed in as ${email.trim()}`));
+  console.log(`  API key saved to ~/.engram/config.json`);
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,6 +3,7 @@
 import { Engram } from "@getengram/sdk";
 import { loadConfig, getBaseUrl } from "./config.js";
 import { authLogin, authLogout, authStatus } from "./commands/auth.js";
+import { signup, login } from "./commands/login.js";
 import {
   listConversations,
   createConversation,
@@ -21,6 +22,7 @@ const VERSION = "0.2.1";
 const TOP_COMMANDS = new Set([
   "help", "version", "store", "append", "search", "find", "convs",
   "start", "stop", "status", "install", "uninstall", "log",
+  "signup", "login",
 ]);
 // Commands that take 2 words (group + subcommand)
 const GROUP_COMMANDS = new Set(["auth", "conversations", "conv", "daemon"]);
@@ -91,9 +93,8 @@ async function getClient(): Promise<Engram> {
   if (!apiKey) {
     console.error(
       "Not authenticated. Run:\n\n" +
-        "  engram auth login <api-key>\n" +
-        "  # or\n" +
-        "  export ENGRAM_API_KEY=engram_sk_live_...\n",
+        "  engram signup     # create a free account\n" +
+        "  engram login      # sign in with email + password\n",
     );
     process.exit(1);
   }
@@ -112,7 +113,10 @@ ${bold("USAGE")}
   engram <command> [options]
 
 ${bold("COMMANDS")}
-  ${bold("auth login")} <key>         Authenticate with API key
+  ${bold("signup")}                   Create a free account instantly
+  ${bold("login")}                    Sign in with email + password
+
+  ${bold("auth login")} <key>         Authenticate with API key ${dim("(manual)")}
   ${bold("auth logout")}              Remove stored credentials
   ${bold("auth status")}              Show authentication status
 
@@ -141,7 +145,8 @@ ${bold("OPTIONS")}
   --agent <id>    Filter by agent ID
 
 ${bold("EXAMPLES")}
-  engram auth login engram_sk_live_abc123
+  engram signup
+  engram login
   engram conversations create --title "My Chat" --tags dev,test
   engram store -c conv_abc "deployed v2.1 to production"
   engram search "when did we deploy"
@@ -177,6 +182,14 @@ async function main(): Promise<void> {
       case "--version":
       case "-v":
         console.log(`engram ${VERSION}`);
+        break;
+
+      case "signup":
+        await signup();
+        break;
+
+      case "login":
+        await login();
         break;
 
       case "auth login":

--- a/apps/mcp-server/src/routes/signup.ts
+++ b/apps/mcp-server/src/routes/signup.ts
@@ -6,6 +6,7 @@ import {
 } from "@getengram/shared";
 import {
   getOrganizationByEmail,
+  insertOrganization,
   insertOrganizationWithEmail,
   insertApiKey,
 } from "@getengram/db";
@@ -45,7 +46,7 @@ signup.post("/", async (c) => {
 
   let claims;
   try {
-    claims = await verifySupabaseJwt(token, jwtSecret);
+    claims = await verifySupabaseJwt(token, jwtSecret, c.env.SUPABASE_URL);
   } catch (err) {
     const message = err instanceof Error ? err.message : "Invalid token";
     return c.json({ error: "unauthorized", message }, 401);
@@ -96,6 +97,31 @@ signup.post("/", async (c) => {
       created,
     },
     created ? 201 : 200,
+  );
+});
+
+// POST /signup/anonymous — mint an org + API key with no auth required.
+// This powers `engram signup` from the CLI, letting AI agents self-provision
+// accounts without any human interaction.
+signup.post("/anonymous", async (c) => {
+  const orgId = generateId("org");
+  const orgName = `anon-${orgId.slice(4, 12)}`;
+  await insertOrganization(c.env.DB, orgId, orgName);
+
+  const keyId = generateId("key");
+  const { raw, prefix } = generateApiKeyRaw();
+  const keyHash = await hashApiKey(raw);
+  await insertApiKey(c.env.DB, keyId, orgId, keyHash, prefix, "Default");
+
+  return c.json(
+    {
+      organization_id: orgId,
+      api_key: raw,
+      key_prefix: prefix,
+      plan: "free",
+      created: true,
+    },
+    201,
   );
 });
 


### PR DESCRIPTION
## Summary
- Add `POST /signup/anonymous` endpoint — no auth, creates org + API key instantly
- Add `engram signup` — zero-friction account creation from the terminal
- Add `engram login` — email + password sign-in for existing accounts
- Old `engram auth login <key>` still works for manual entry

New user flow:
```
$ engram signup
Creating account...
✓ Account created
  API key saved to ~/.engram/config.json
```

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)