### PR TITLE
feat: add engram link command and /signup/link endpoint

### DIFF
--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -87,6 +87,81 @@ export async function signup(): Promise<void> {
 }
 
 /**
+ * `engram link` — attach an email + password to an anonymous account.
+ * Creates a Supabase user and links it to the existing org.
+ */
+export async function link(): Promise<void> {
+  const config = await loadConfig();
+  const apiKey = process.env.ENGRAM_API_KEY ?? config.apiKey;
+
+  if (!apiKey) {
+    console.error(red("Not authenticated. Run 'engram signup' first."));
+    process.exit(1);
+  }
+
+  const email = await prompt("Email: ");
+  const password = await prompt("Password: ", true);
+
+  if (!email || !password) {
+    console.error(red("Email and password are required."));
+    process.exit(1);
+  }
+
+  if (password.length < 8) {
+    console.error(red("Password must be at least 8 characters."));
+    process.exit(1);
+  }
+
+  console.log("Linking account...");
+
+  // 1. Create Supabase user
+  const supabaseUrl = "https://ygfqaafyfjrutxjeswks.supabase.co";
+  const supabaseAnonKey =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlnZnFhYWZ5ZmpydXR4amVzd2tzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDQ1MDg3ODcsImV4cCI6MjA2MDA4NDc4N30.pK_3TgpMFsYi_4fRR-gBnLGoXxqYINOqSjjKcBqe70c";
+
+  const signupRes = await fetch(`${supabaseUrl}/auth/v1/signup`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: supabaseAnonKey,
+    },
+    body: JSON.stringify({ email: email.trim(), password }),
+  });
+
+  if (!signupRes.ok) {
+    const err = (await signupRes.json().catch(() => ({}))) as {
+      msg?: string;
+      error_description?: string;
+    };
+    const msg = err.msg || err.error_description || `Signup failed: ${signupRes.status}`;
+    // "User already registered" is fine — they can still link
+    if (!msg.includes("already")) {
+      console.error(red(msg));
+      process.exit(1);
+    }
+  }
+
+  // 2. Link email to org via worker
+  const linkRes = await fetch(`${API_URL}/signup/link`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ email: email.trim() }),
+  });
+
+  if (!linkRes.ok) {
+    const err = (await linkRes.json().catch(() => ({}))) as { message?: string };
+    console.error(red(err.message || `Link failed: ${linkRes.status}`));
+    process.exit(1);
+  }
+
+  console.log(green(`✓ Account linked to ${email.trim()}`));
+  console.log(`  You can now sign in at getengram.app/login`);
+}
+
+/**
  * `engram login` — sign in with email + password.
  * Calls Supabase auth, then the worker /signup to get an API key.
  */

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,7 +3,7 @@
 import { Engram } from "@getengram/sdk";
 import { loadConfig, getBaseUrl } from "./config.js";
 import { authLogin, authLogout, authStatus } from "./commands/auth.js";
-import { signup, login } from "./commands/login.js";
+import { signup, login, link } from "./commands/login.js";
 import {
   listConversations,
   createConversation,
@@ -22,7 +22,7 @@ const VERSION = "0.2.1";
 const TOP_COMMANDS = new Set([
   "help", "version", "store", "append", "search", "find", "convs",
   "start", "stop", "status", "install", "uninstall", "log",
-  "signup", "login",
+  "signup", "login", "link",
 ]);
 // Commands that take 2 words (group + subcommand)
 const GROUP_COMMANDS = new Set(["auth", "conversations", "conv", "daemon"]);
@@ -115,6 +115,7 @@ ${bold("USAGE")}
 ${bold("COMMANDS")}
   ${bold("signup")}                   Create a free account instantly
   ${bold("login")}                    Sign in with email + password
+  ${bold("link")}                     Link email to your account for dashboard access
 
   ${bold("auth login")} <key>         Authenticate with API key ${dim("(manual)")}
   ${bold("auth logout")}              Remove stored credentials
@@ -190,6 +191,10 @@ async function main(): Promise<void> {
 
       case "login":
         await login();
+        break;
+
+      case "link":
+        await link();
         break;
 
       case "auth login":

--- a/apps/mcp-server/src/routes/signup.ts
+++ b/apps/mcp-server/src/routes/signup.ts
@@ -6,9 +6,11 @@ import {
 } from "@getengram/shared";
 import {
   getOrganizationByEmail,
+  getOrganizationById,
   insertOrganization,
   insertOrganizationWithEmail,
   insertApiKey,
+  setOrganizationEmail,
 } from "@getengram/db";
 import type { Env } from "../types.js";
 import { verifySupabaseJwt } from "../utils/jwt.js";
@@ -123,6 +125,53 @@ signup.post("/anonymous", async (c) => {
     },
     201,
   );
+});
+
+// POST /signup/link — attach an email to an anonymous org.
+// Auth: Engram API key Bearer. The CLI sends the user's API key.
+// Body: { email: string }
+//
+// This updates the organization's email field so the account can be
+// found via email-based login later.
+signup.post("/link", async (c) => {
+  // Verify the API key manually (this route is under /signup, not /api/*)
+  const authHeader = c.req.header("authorization") ?? "";
+  const token = authHeader.replace(/^Bearer\s+/i, "");
+  if (!token || !token.startsWith("engram_sk_live_")) {
+    return c.json({ error: "unauthorized", message: "Missing or invalid API key" }, 401);
+  }
+
+  // Hash and look up the key
+  const { hashApiKey } = await import("@getengram/shared");
+  const keyHash = await hashApiKey(token);
+  const keyRow = await c.env.DB.prepare(
+    "SELECT k.organization_id FROM api_keys k WHERE k.key_hash = ?",
+  )
+    .bind(keyHash)
+    .first<{ organization_id: string }>();
+
+  if (!keyRow) {
+    return c.json({ error: "unauthorized", message: "Invalid API key" }, 401);
+  }
+
+  const body = await c.req.json<{ email?: string }>().catch(() => ({}));
+  const email = body.email?.trim();
+  if (!email || !email.includes("@")) {
+    return c.json({ error: "invalid_email", message: "A valid email is required" }, 400);
+  }
+
+  // Check if another org already uses this email
+  const existing = await getOrganizationByEmail(c.env.DB, email);
+  if (existing && (existing as { id: string }).id !== keyRow.organization_id) {
+    return c.json(
+      { error: "email_taken", message: "This email is already linked to another account" },
+      409,
+    );
+  }
+
+  await setOrganizationEmail(c.env.DB, keyRow.organization_id, email);
+
+  return c.json({ linked: true, organization_id: keyRow.organization_id, email });
 });
 
 export { signup };

--- a/packages/db/src/queries/organizations.ts
+++ b/packages/db/src/queries/organizations.ts
@@ -31,6 +31,17 @@ export function getOrganizationByEmail(db: D1Database, email: string) {
     .first();
 }
 
+export function setOrganizationEmail(
+  db: D1Database,
+  id: string,
+  email: string,
+) {
+  return db
+    .prepare("UPDATE organizations SET email = ? WHERE id = ?")
+    .bind(email, id)
+    .run();
+}
+
 export function getOrganizationByStripeCustomer(
   db: D1Database,
   stripeCustomerId: string,


### PR DESCRIPTION
## Summary
- `engram link` — attach email+password to anonymous CLI accounts for dashboard access
- `POST /signup/link` — worker endpoint to set org email (authenticated by API key)
- `setOrganizationEmail` DB query helper

Full CLI auth flow is now:
```
engram signup    # instant anonymous account
engram link      # optional: attach email for dashboard + upgrades
engram login     # sign in with email+password
```

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)