### PR TITLE
fix: enforce API key limits in signup endpoints

### DIFF
--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -53,6 +53,16 @@ function prompt(question: string, hidden = false): Promise<string> {
  * No email, no password. Just get a key and start using Engram.
  */
 export async function signup(): Promise<void> {
+  const existing = await loadConfig();
+  if (existing.apiKey) {
+    console.error(
+      "You already have an account. Your API key is saved in ~/.engram/config.json\n\n" +
+        "  engram auth status    # check your account\n" +
+        "  engram auth logout    # remove credentials before creating a new account\n",
+    );
+    process.exit(1);
+  }
+
   console.log("Creating account...");
 
   const res = await fetch(`${API_URL}/signup/anonymous`, {
@@ -214,6 +224,21 @@ export async function login(): Promise<void> {
     },
     body: JSON.stringify({ plan: "free" }),
   });
+
+  if (signupRes.status === 409) {
+    // Account already has a key — check if we have one locally
+    const config = await loadConfig();
+    if (config.apiKey) {
+      console.log(green(`✓ Signed in as ${email.trim()}`));
+      console.log(`  Using existing API key from ~/.engram/config.json`);
+      return;
+    }
+    console.error(
+      red("Your account already has an API key.\n") +
+        "  Use 'engram auth login <key>' to set it, or manage keys at getengram.app/dashboard",
+    );
+    process.exit(1);
+  }
 
   if (!signupRes.ok) {
     const body = await signupRes.text().catch(() => "");

--- a/apps/mcp-server/src/routes/signup.ts
+++ b/apps/mcp-server/src/routes/signup.ts
@@ -10,8 +10,10 @@ import {
   insertOrganization,
   insertOrganizationWithEmail,
   insertApiKey,
+  getApiKeyCount,
   setOrganizationEmail,
 } from "@getengram/db";
+import { TIER_LIMITS, type Tier } from "@getengram/shared";
 import type { Env } from "../types.js";
 import { verifySupabaseJwt } from "../utils/jwt.js";
 
@@ -82,9 +84,27 @@ signup.post("/", async (c) => {
     created = true;
   }
 
-  // Always mint a fresh API key. The caller cannot recover the prior
-  // key (it's hashed at rest), so callers rely on this being the
-  // canonical way to bootstrap server-side credentials for a user.
+  // Only mint a key if the org doesn't already have one at its limit.
+  // Existing orgs that already have keys should use them (or the dashboard
+  // to manage keys) — minting on every login caused duplicate key bloat.
+  if (!created) {
+    const org = (await getOrganizationById(c.env.DB, orgId)) as { tier?: string } | null;
+    const tier = (org?.tier as Tier) ?? "free";
+    const limits = TIER_LIMITS[tier];
+    const count = await getApiKeyCount(c.env.DB, orgId);
+    if (limits.api_keys !== -1 && (count?.count ?? 0) >= limits.api_keys) {
+      return c.json(
+        {
+          error: "api_key_limit_reached",
+          message: "Your account already has an API key. Use your existing key, or manage keys on the dashboard.",
+          organization_id: orgId,
+          plan,
+        },
+        409,
+      );
+    }
+  }
+
   const keyId = generateId("key");
   const { raw, prefix } = generateApiKeyRaw();
   const keyHash = await hashApiKey(raw);


### PR DESCRIPTION
## Summary
- `POST /signup` now checks key count against tier limit before minting — existing orgs at their limit get a 409 instead of a duplicate key
- `engram signup` CLI refuses to create a new account if `~/.engram/config.json` already has a key
- `engram login` CLI handles the 409 gracefully — uses existing local key or tells user where to find their key

## Root cause
`POST /signup` had `// Always mint a fresh API key` — no limit check. Every dashboard login and `engram login` call created another key, even though free/pro plans allow only 1.

## Test plan
- [x] `pnpm build` passes
- [x] All 189 tests pass
- [ ] Manual: `engram signup` twice → second call rejects
- [ ] Manual: `engram login` with existing account → uses local key or shows helpful error

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)