### PR TITLE
feat: engram upgrade command

### DIFF
--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -1,0 +1,80 @@
+import { loadConfig, getBaseUrl } from "../config.js";
+import { green, red, dim } from "../output.js";
+
+const API_URL = process.env.ENGRAM_BASE_URL ?? getBaseUrl();
+
+/**
+ * `engram upgrade [pro|team]` — create a Stripe Checkout session and open it.
+ * Works for both humans (opens browser) and agents (returns URL).
+ */
+export async function upgrade(
+  args: string[],
+  flags: Record<string, string>,
+): Promise<void> {
+  const config = await loadConfig();
+  const apiKey = process.env.ENGRAM_API_KEY ?? config.apiKey;
+
+  if (!apiKey) {
+    console.error(red("Not authenticated. Run 'engram signup' first."));
+    process.exit(1);
+  }
+
+  const plan = args[0] === "team" ? "team" : "pro";
+  const json = "json" in flags;
+
+  const res = await fetch(`${API_URL}/api/billing/checkout`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ plan }),
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as {
+      error?: string;
+      message?: string;
+    };
+
+    if (body.error === "missing_email") {
+      console.error(
+        red("Your account needs an email before upgrading.\n") +
+          "\n  Run: engram link\n",
+      );
+      process.exit(1);
+    }
+
+    console.error(red(body.message || `Upgrade failed: ${res.status}`));
+    process.exit(1);
+  }
+
+  const data = (await res.json()) as {
+    url: string;
+    session_id: string;
+    plan: string;
+  };
+
+  if (json) {
+    console.log(JSON.stringify(data));
+    return;
+  }
+
+  console.log(green(`✓ Checkout session created for ${data.plan}`));
+  console.log(`\n  ${data.url}\n`);
+
+  // Try to open in browser
+  try {
+    const { exec } = await import("node:child_process");
+    const cmd =
+      process.platform === "darwin"
+        ? "open"
+        : process.platform === "win32"
+          ? "start"
+          : "xdg-open";
+    exec(`${cmd} "${data.url}"`);
+    console.log(dim("  Opening in your browser..."));
+  } catch {
+    console.log(dim("  Open the URL above to complete checkout."));
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -14,6 +14,7 @@ import { store } from "./commands/store.js";
 import { search } from "./commands/search.js";
 import { log as showLog } from "./commands/log.js";
 import { daemonStart, daemonStop, daemonStatus, daemonInstall, daemonUninstall } from "./daemon/index.js";
+import { upgrade } from "./commands/upgrade.js";
 import { bold, dim } from "./output.js";
 
 const VERSION = "0.2.1";
@@ -22,7 +23,7 @@ const VERSION = "0.2.1";
 const TOP_COMMANDS = new Set([
   "help", "version", "store", "append", "search", "find", "convs",
   "start", "stop", "status", "install", "uninstall", "log",
-  "signup", "login", "link",
+  "signup", "login", "link", "upgrade",
 ]);
 // Commands that take 2 words (group + subcommand)
 const GROUP_COMMANDS = new Set(["auth", "conversations", "conv", "daemon"]);
@@ -129,6 +130,7 @@ ${bold("COMMANDS")}
   ${bold("store")} -c <id> <message>  Store a message
   ${bold("search")} <query>           Semantic search across memory
   ${bold("log")}                      Show recent AI conversation activity
+  ${bold("upgrade")} [pro|team]       Upgrade your plan (opens Stripe checkout)
 
   ${bold("start")}                    Start background daemon (auto-capture)
   ${bold("stop")}                     Stop the daemon
@@ -243,6 +245,10 @@ async function main(): Promise<void> {
 
       case "log":
         await showLog(await getClient(), args, flags);
+        break;
+
+      case "upgrade":
+        await upgrade(args, flags);
         break;
 
       // Daemon commands — short aliases + namespaced


### PR DESCRIPTION
## Summary
- Adds `engram upgrade [pro|team]` command
- Calls `POST /api/billing/checkout` → returns Stripe Checkout URL
- Opens in browser for humans, `--json` for agents/scripts
- If account has no email, tells user to run `engram link` first

## Agent flow
```bash
# Agent upgrades programmatically
URL=$(engram upgrade pro --json | jq -r '.url')
# Agent can present URL to user or handle payment via Stripe API
```

## Human flow
```bash
engram upgrade pro
# ✓ Checkout session created for pro
#   https://checkout.stripe.com/...
#   Opening in your browser...
```

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)