### PR TITLE
feat: auto-deploy worker on merge to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,3 +83,46 @@ jobs:
           name: mcp-server-bundle
           path: apps/mcp-server/dist
           retention-days: 7
+
+  # Deploy worker to Cloudflare on merge to main.
+  deploy:
+    name: Deploy worker
+    runs-on: ubuntu-latest
+    needs: worker-deploy-check
+    timeout-minutes: 10
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace packages
+        run: pnpm -F @getengram/shared -F @getengram/db build
+
+      - name: Run D1 migrations
+        working-directory: apps/mcp-server
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler d1 migrations apply engram-db --remote
+
+      - name: Deploy worker
+        working-directory: apps/mcp-server
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler deploy


### PR DESCRIPTION
## Summary
- Adds `deploy` job to main workflow: runs D1 migrations then `wrangler deploy`
- Triggers after checks + dry-run pass on merge to main
- Uses `production` GitHub environment for deployment protection rules

## Setup required
Add these GitHub secrets:
- `CLOUDFLARE_API_TOKEN` — scoped to Workers Scripts/Edit, D1/Edit, Workers Routes/Edit
- `CLOUDFLARE_ACCOUNT_ID` — `4e5a202f361c22d87517b8ef8e0b41dd`

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)