### PR TITLE
license: switch to BSL 1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,107 @@
-Copyright (c) 2026 Get Engram LLC. All rights reserved.
+Business Source License 1.1
 
-This repository contains proprietary source code for Engram, a commercial
-memory service operated by Get Engram LLC.
+Parameters
 
-Exceptions: The following subdirectories are licensed under the MIT License,
-as indicated by a LICENSE file within each directory:
+Licensor:             Get Engram LLC
+Licensed Work:        Engram
+                      The Licensed Work is (c) 2026 Get Engram LLC.
+Additional Use Grant: You may make use of the Licensed Work, provided that
+                      you may not use the Licensed Work for a Memory Service.
 
-  - packages/sdk  (@getengram/sdk, published to npm)
-  - apps/cli      (@getengram/cli, published to npm)
+                      A "Memory Service" is a commercial offering that allows
+                      third parties to access the functionality of the Licensed
+                      Work by providing conversation storage, semantic search,
+                      or agent memory capabilities as a hosted or managed
+                      service.
 
-All other code in this repository is proprietary. No license is granted to
-copy, modify, distribute, or create derivative works of the proprietary
-portions of this repository without express written permission from
-Get Engram LLC.
+                      For clarity, the following are NOT restricted:
+                      - Self-hosting the Licensed Work for your own internal use
+                      - Using the Licensed Work as part of a product that is not
+                        primarily a memory or conversation storage service
+                      - Integrating with the hosted Engram service at
+                        getengram.app via its APIs
 
-Use of the hosted Engram service at getengram.app is governed by the Terms
-of Service at https://getengram.app/terms and the Privacy Policy at
-https://getengram.app/privacy.
+Change Date:          May 14, 2030
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact hello@getengram.app.
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+License text below is the full BSL 1.1 text copyright MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.


### PR DESCRIPTION
## Summary
- Replace proprietary license with Business Source License 1.1
- **Allowed:** self-host, modify, use internally, integrate via APIs
- **Not allowed:** offer a competing hosted memory service using this code
- **Change date:** May 14, 2030 → converts to Apache 2.0
- SDK (`packages/sdk`) and CLI (`apps/cli`) remain MIT

Same model as Sentry, HashiCorp, CockroachDB, MariaDB.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)