### PR TITLE
fix: resolve typecheck errors blocking CI deploys

### DIFF
--- a/apps/mcp-server/src/__tests__/helpers.ts
+++ b/apps/mcp-server/src/__tests__/helpers.ts
@@ -186,11 +186,14 @@ export function createMockEnv(db: D1Database) {
       run: vi.fn(async () => ({
         data: [[0.1, 0.2, 0.3]], // minimal fake embedding
       })),
-    },
+    } as unknown as Ai,
     VECTORIZE: {
       query: vi.fn(async () => ({ matches: [] })),
       upsert: vi.fn(async () => ({ count: 0 })),
       deleteByIds: vi.fn(async () => ({ count: 0 })),
-    },
+      describe: vi.fn(async () => ({})),
+      insert: vi.fn(async () => ({ count: 0 })),
+      getByIds: vi.fn(async () => []),
+    } as unknown as VectorizeIndex,
   };
 }

--- a/apps/mcp-server/src/__tests__/search-service.test.ts
+++ b/apps/mcp-server/src/__tests__/search-service.test.ts
@@ -42,7 +42,8 @@ describe("search service", () => {
       .run();
 
     env = createMockEnv(db);
-    env.VECTORIZE.query = vi.fn(async () => ({
+    (env.VECTORIZE as unknown as Record<string, unknown>).query = vi.fn(async () => ({
+      count: 2,
       matches: [
         { id: "vec_short", score: 0.99 },
         { id: "vec_long", score: 0.88 },

--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -44,7 +44,7 @@ export function registerSearch(
 
       // Track usage (non-blocking)
       trackSearchRun(env.DB, auth.organizationId).catch(() => {});
-      audit(env.DB, auth.organizationId, auth.apiKeyId, "search", null, null, {
+      audit(env.DB, auth.organizationId, auth.apiKeyId, "search", undefined, undefined, {
         query: params.query,
         results: results.length,
       });

--- a/apps/mcp-server/src/middleware/auth.ts
+++ b/apps/mcp-server/src/middleware/auth.ts
@@ -22,7 +22,7 @@ export async function authMiddleware(
   const row = await getApiKeyWithOrg(c.env.DB, keyHash);
 
   if (!row) {
-    audit(c.env.DB, "unknown", null, "auth.failure", null, null, {
+    audit(c.env.DB, "unknown", null, "auth.failure", undefined, undefined, {
       reason: "invalid_key",
     });
     return c.json({ error: "Invalid API key" }, 401);

--- a/apps/mcp-server/src/routes/export.ts
+++ b/apps/mcp-server/src/routes/export.ts
@@ -82,7 +82,7 @@ dataExport.get("/", async (c) => {
     conversations,
   };
 
-  audit(c.env.DB, orgId, auth.apiKeyId, "data.export", null, null, {
+  audit(c.env.DB, orgId, auth.apiKeyId, "data.export", undefined, undefined, {
     conversations: conversations.length,
   });
 

--- a/apps/mcp-server/src/routes/signup.ts
+++ b/apps/mcp-server/src/routes/signup.ts
@@ -174,7 +174,7 @@ signup.post("/link", async (c) => {
     return c.json({ error: "unauthorized", message: "Invalid API key" }, 401);
   }
 
-  const body = await c.req.json<{ email?: string }>().catch(() => ({}));
+  const body = await c.req.json<{ email?: string }>().catch(() => ({} as { email?: string }));
   const email = body.email?.trim();
   if (!email || !email.includes("@")) {
     return c.json({ error: "invalid_email", message: "A valid email is required" }, 400);

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -14,6 +14,7 @@ export interface Env {
   // /signup; the worker verifies the HS256 signature and extracts the
   // user's email from the claims.
   SUPABASE_JWT_SECRET: string;
+  SUPABASE_URL: string;
 }
 
 export interface AuthContext {

--- a/apps/mcp-server/src/utils/jwt.ts
+++ b/apps/mcp-server/src/utils/jwt.ts
@@ -28,6 +28,7 @@ function base64UrlDecode(str: string): Uint8Array {
 export async function verifySupabaseJwt(
   token: string,
   jwtSecret: string,
+  _issuer?: string,
 ): Promise<SupabaseJwtPayload> {
   const parts = token.split(".");
   if (parts.length !== 3) {

--- a/packages/shared/src/utils/id.ts
+++ b/packages/shared/src/utils/id.ts
@@ -10,6 +10,7 @@ const PREFIXES = {
   whk: "whk_",
   whd: "whd_",
   usg: "usg_",
+  aud: "aud_",
 } as const;
 
 type PrefixKey = keyof typeof PREFIXES;


### PR DESCRIPTION
## Summary

- Typecheck has been failing in CI since **Apr 25** (commit `ad5a82f` — audit logging PR #84), which means the `deploy` job has been **skipped on every merge for 22 days**
- The Cloudflare Worker eventually stopped serving requests, returning plain text `404 Not Found`
- This PR fixes all 8 type errors so CI can pass and auto-deploy resumes

## Changes

- Add `"aud"` prefix to shared `generateId()` for audit log entries
- Add `SUPABASE_URL` to `Env` type (used by signup route since JWT auth PR)
- Accept optional `issuer` param in `verifySupabaseJwt()` to match caller in signup
- Fix `null` → `undefined` in `audit()` optional params (auth, search, export)
- Fix union type narrowing in `/signup/link` route body parsing
- Fix mock `Vectorize`/`AI` types in test helpers to satisfy updated CF worker type defs

## Test plan

- [x] `pnpm typecheck` — all 8 packages pass
- [x] `pnpm test` — all 189 tests pass
- [ ] Verify CI passes on this PR
- [ ] After merge, confirm auto-deploy runs and `mcp.getengram.app/mcp` responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)