### PR TITLE
Add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 .turbo/
 *.log
 .DS_Store
+.claude/
 *.tsbuildinfo
 .env
 supabase/.temp/


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` so personal Claude Code settings aren't committed
- `CLAUDE.md` (project instructions) remains tracked

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)