### PR TITLE
fix: CLI v0.3.1 — replace workspace:* with real SDK version

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getengram/cli",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "description": "CLI for Engram — persistent memory for AI agents",
   "type": "module",
   "bin": {
@@ -35,7 +35,7 @@
   },
   "homepage": "https://getengram.app",
   "dependencies": {
-    "@getengram/sdk": "workspace:*",
+    "@getengram/sdk": "^0.1.1",
     "better-sqlite3": "^12.8.0",
     "chokidar": "^5.0.0"
   },

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -17,7 +17,7 @@ import { daemonStart, daemonStop, daemonStatus, daemonInstall, daemonUninstall }
 import { upgrade } from "./commands/upgrade.js";
 import { bold, dim } from "./output.js";
 
-const VERSION = "0.2.1";
+const VERSION = "0.3.1";
 
 // Commands that take 1 word
 const TOP_COMMANDS = new Set([

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
   apps/cli:
     dependencies:
       '@getengram/sdk':
-        specifier: workspace:*
-        version: link:../../packages/sdk
+        specifier: ^0.1.1
+        version: 0.1.1
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -490,6 +490,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@getengram/sdk@0.1.1':
+    resolution: {integrity: sha512-9n1qjNYnn1oTaoysPox7ZyR9xJQ+2icLg7gTpmfl1fCVy69Po5VXuKikw/8FnQpAg7f0qlSXQzyqAYcc5B6zAQ==}
 
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
@@ -1846,6 +1849,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.4':
     optional: true
+
+  '@getengram/sdk@0.1.1': {}
 
   '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:


### PR DESCRIPTION
## Summary
- Fix broken `workspace:*` dependency in published CLI package
- Bump CLI to v0.3.1

## Problem
`@getengram/cli@0.3.0` was published to npm with `"@getengram/sdk": "workspace:*"` — a pnpm monorepo protocol that doesn't resolve outside the repo. This breaks both `npm install -g @getengram/cli` and `brew install get-engram/engram/engram`.

## Fix
- Replace `workspace:*` with `^0.1.1` (the actual published SDK version)
- Bump version to 0.3.1

## After merge
- [ ] Publish to npm: `cd apps/cli && pnpm publish`
- [ ] Update Homebrew formula to 0.3.1

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)