### PR TITLE
fix: exempt billing routes from rate limiting

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -88,12 +88,15 @@ app.use(
   }),
 );
 app.use("/api/*", authMiddleware);
+
+// Billing routes are exempt from rate limiting — never block someone trying to pay.
+app.route("/api/billing", billing);
+
 app.use("/api/*", rateLimitMiddleware);
 app.route("/api/keys", keys);
 app.route("/api/seats", seats);
 app.route("/api/webhooks", webhooks);
 app.route("/api/usage", usage);
-app.route("/api/billing", billing);
 app.route("/api/account", account);
 app.route("/api/export", dataExport);
 


### PR DESCRIPTION
## Summary
Billing routes (`/api/billing/checkout`, `/api/billing/portal`) are now exempt from rate limiting. Never block a user trying to upgrade.

## Change
Mount billing routes before the rate limit middleware so they only go through auth, not the token bucket.

## Test plan
- [ ] All 90 tests pass
- [ ] `engram upgrade pro` works even when rate limited on other endpoints
- [ ] Other `/api/*` routes still rate limited normally

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)