### PR TITLE
feat: non-interactive --email/--password flags for agent usage

### DIFF
--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -100,7 +100,7 @@ export async function signup(): Promise<void> {
  * `engram link` — attach an email + password to an anonymous account.
  * Creates a Supabase user and links it to the existing org.
  */
-export async function link(): Promise<void> {
+export async function link(args: string[] = [], flags: Record<string, string> = {}): Promise<void> {
   const config = await loadConfig();
   const apiKey = process.env.ENGRAM_API_KEY ?? config.apiKey;
 
@@ -109,8 +109,8 @@ export async function link(): Promise<void> {
     process.exit(1);
   }
 
-  const email = await prompt("Email: ");
-  const password = await prompt("Password: ", true);
+  const email = flags.email || await prompt("Email: ");
+  const password = flags.password || await prompt("Password: ", true);
 
   if (!email || !password) {
     console.error(red("Email and password are required."));
@@ -175,9 +175,9 @@ export async function link(): Promise<void> {
  * `engram login` — sign in with email + password.
  * Calls Supabase auth, then the worker /signup to get an API key.
  */
-export async function login(): Promise<void> {
-  const email = await prompt("Email: ");
-  const password = await prompt("Password: ", true);
+export async function login(args: string[] = [], flags: Record<string, string> = {}): Promise<void> {
+  const email = flags.email || await prompt("Email: ");
+  const password = flags.password || await prompt("Password: ", true);
 
   if (!email || !password) {
     console.error(red("Email and password are required."));

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -118,6 +118,8 @@ ${bold("COMMANDS")}
   ${bold("login")}                    Sign in with email + password
   ${bold("link")}                     Link email to your account for dashboard access
 
+  All auth commands accept ${dim("--email")} and ${dim("--password")} flags for non-interactive (agent) usage.
+
   ${bold("auth login")} <key>         Authenticate with API key ${dim("(manual)")}
   ${bold("auth logout")}              Remove stored credentials
   ${bold("auth status")}              Show authentication status
@@ -192,11 +194,11 @@ async function main(): Promise<void> {
         break;
 
       case "login":
-        await login();
+        await login(args, flags);
         break;
 
       case "link":
-        await link();
+        await link(args, flags);
         break;
 
       case "auth login":


### PR DESCRIPTION
## Summary
Make `engram link` and `engram login` fully usable by agents (e.g. Claude Code) without interactive prompts.

## Changes
- `engram link --email user@example.com --password secret123`
- `engram login --email user@example.com --password secret123`
- Falls back to interactive prompts when flags aren't provided (human usage)
- Updated help text

## Why
Agents can't type into interactive stdin prompts. Every CLI command should be callable non-interactively.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)