### PR TITLE
chore: bump CLI to v0.3.2

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getengram/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "CLI for Engram — persistent memory for AI agents",
   "type": "module",
   "bin": {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -17,7 +17,7 @@ import { daemonStart, daemonStop, daemonStatus, daemonInstall, daemonUninstall }
 import { upgrade } from "./commands/upgrade.js";
 import { bold, dim } from "./output.js";
 
-const VERSION = "0.3.1";
+const VERSION = "0.3.2";
 
 // Commands that take 1 word
 const TOP_COMMANDS = new Set([


### PR DESCRIPTION
Version bump for npm + Homebrew publish. Includes non-interactive --email/--password flags from #125.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)