### PR TITLE
fix: better CLI error messages for email conflicts

### DIFF
--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -162,8 +162,16 @@ export async function link(args: string[] = [], flags: Record<string, string> = 
   });
 
   if (!linkRes.ok) {
-    const err = (await linkRes.json().catch(() => ({}))) as { message?: string };
-    console.error(red(err.message || `Link failed: ${linkRes.status}`));
+    const err = (await linkRes.json().catch(() => ({}))) as { error?: string; message?: string };
+    if (err.error === "email_taken") {
+      console.error(
+        red(`An account already exists for ${email.trim()}.\n`) +
+          "\n  If that's your account, sign in instead:\n" +
+          `    engram login --email ${email.trim()} --password <your-password>\n`,
+      );
+    } else {
+      console.error(red(err.message || `Link failed: ${linkRes.status}`));
+    }
     process.exit(1);
   }
 

--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -40,7 +40,10 @@ export async function upgrade(
     if (body.error === "missing_email") {
       console.error(
         red("Your account needs an email before upgrading.\n") +
-          "\n  Run: engram link\n",
+          "\n  Link an email to this account:\n" +
+          "    engram link --email you@example.com --password <password>\n" +
+          "\n  Or if you already have an account, sign in:\n" +
+          "    engram login --email you@example.com --password <password>\n",
       );
       process.exit(1);
     }


### PR DESCRIPTION
## Summary
Improve error messages when:
- `engram link` fails because email is already taken → tells user to `engram login` instead
- `engram upgrade` fails because no email → shows both `engram link` and `engram login` options

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)