### PR TITLE
feat: server-side login, remove hardcoded Supabase key from CLI

### DIFF
--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -110,48 +110,17 @@ export async function link(args: string[] = [], flags: Record<string, string> = 
   }
 
   const email = flags.email || await prompt("Email: ");
-  const password = flags.password || await prompt("Password: ", true);
 
-  if (!email || !password) {
-    console.error(red("Email and password are required."));
-    process.exit(1);
-  }
-
-  if (password.length < 8) {
-    console.error(red("Password must be at least 8 characters."));
+  if (!email) {
+    console.error(red("Email is required."));
     process.exit(1);
   }
 
   console.log("Linking account...");
 
-  // 1. Create Supabase user
-  const supabaseUrl = "https://ygfqaafyfjrutxjeswks.supabase.co";
-  const supabaseAnonKey =
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlnZnFhYWZ5ZmpydXR4amVzd2tzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDQ1MDg3ODcsImV4cCI6MjA2MDA4NDc4N30.pK_3TgpMFsYi_4fRR-gBnLGoXxqYINOqSjjKcBqe70c";
-
-  const signupRes = await fetch(`${supabaseUrl}/auth/v1/signup`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      apikey: supabaseAnonKey,
-    },
-    body: JSON.stringify({ email: email.trim(), password }),
-  });
-
-  if (!signupRes.ok) {
-    const err = (await signupRes.json().catch(() => ({}))) as {
-      msg?: string;
-      error_description?: string;
-    };
-    const msg = err.msg || err.error_description || `Signup failed: ${signupRes.status}`;
-    // "User already registered" is fine — they can still link
-    if (!msg.includes("already")) {
-      console.error(red(msg));
-      process.exit(1);
-    }
-  }
-
-  // 2. Link email to org via worker
+  // Link email to org via worker. Supabase user creation happens
+  // lazily on first dashboard login — the CLI only needs the email
+  // attached to the org for billing.
   const linkRes = await fetch(`${API_URL}/signup/link`, {
     method: "POST",
     headers: {
@@ -192,45 +161,13 @@ export async function login(args: string[] = [], flags: Record<string, string> =
     process.exit(1);
   }
 
-  // Sign in via Supabase REST API
-  const supabaseUrl = "https://ygfqaafyfjrutxjeswks.supabase.co";
-  const supabaseAnonKey =
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlnZnFhYWZ5ZmpydXR4amVzd2tzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDQ1MDg3ODcsImV4cCI6MjA2MDA4NDc4N30.pK_3TgpMFsYi_4fRR-gBnLGoXxqYINOqSjjKcBqe70c";
-
   console.log("Signing in...");
 
-  const authRes = await fetch(
-    `${supabaseUrl}/auth/v1/token?grant_type=password`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        apikey: supabaseAnonKey,
-      },
-      body: JSON.stringify({ email: email.trim(), password }),
-    },
-  );
-
-  if (!authRes.ok) {
-    const err = (await authRes.json().catch(() => ({}))) as {
-      error_description?: string;
-    };
-    console.error(
-      red(err.error_description || `Login failed: ${authRes.status}`),
-    );
-    process.exit(1);
-  }
-
-  const session = (await authRes.json()) as { access_token: string };
-
-  // Exchange Supabase token for Engram API key
-  const signupRes = await fetch(`${API_URL}/signup`, {
+  // Authenticate via worker — keeps Supabase credentials server-side
+  const signupRes = await fetch(`${API_URL}/signup/login`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${session.access_token}`,
-    },
-    body: JSON.stringify({ plan: "free" }),
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: email.trim(), password }),
   });
 
   if (signupRes.status === 409) {
@@ -249,8 +186,8 @@ export async function login(args: string[] = [], flags: Record<string, string> =
   }
 
   if (!signupRes.ok) {
-    const body = await signupRes.text().catch(() => "");
-    console.error(red(`Failed to get API key: ${signupRes.status} ${body}`));
+    const err = (await signupRes.json().catch(() => ({}))) as { message?: string };
+    console.error(red(err.message || `Login failed: ${signupRes.status}`));
     process.exit(1);
   }
 

--- a/apps/mcp-server/src/routes/signup.ts
+++ b/apps/mcp-server/src/routes/signup.ts
@@ -194,4 +194,80 @@ signup.post("/link", async (c) => {
   return c.json({ linked: true, organization_id: keyRow.organization_id, email });
 });
 
+// POST /signup/login — authenticate with email + password, return API key.
+// Handles Supabase auth server-side so the CLI doesn't need credentials.
+signup.post("/login", async (c) => {
+  const body = await c.req.json<{ email?: string; password?: string }>().catch(() => ({} as Record<string, string>));
+  const email = body.email?.trim();
+  const password = body.password;
+
+  if (!email || !password) {
+    return c.json({ error: "invalid_request", message: "Email and password are required" }, 400);
+  }
+
+  const supabaseUrl = c.env.SUPABASE_URL;
+  const supabaseAnonKey = c.env.SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return c.json({ error: "server_misconfigured", message: "Supabase is not configured" }, 500);
+  }
+
+  // Authenticate with Supabase
+  const authRes = await fetch(
+    `${supabaseUrl}/auth/v1/token?grant_type=password`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        apikey: supabaseAnonKey,
+      },
+      body: JSON.stringify({ email, password }),
+    },
+  );
+
+  if (!authRes.ok) {
+    const err = (await authRes.json().catch(() => ({}))) as { error_description?: string };
+    return c.json(
+      { error: "auth_failed", message: err.error_description || "Invalid email or password" },
+      401,
+    );
+  }
+
+  // Find the org by email
+  const org = (await getOrganizationByEmail(c.env.DB, email)) as { id: string } | null;
+  if (!org) {
+    return c.json(
+      { error: "no_account", message: "No Engram account found for this email. Run 'engram signup' first." },
+      404,
+    );
+  }
+
+  // Check if org already has a key at limit
+  const orgRecord = (await getOrganizationById(c.env.DB, org.id)) as { tier?: string } | null;
+  const tier = (orgRecord?.tier as Tier) ?? "free";
+  const limits = TIER_LIMITS[tier];
+  const count = await getApiKeyCount(c.env.DB, org.id);
+  if (limits.api_keys !== -1 && (count?.count ?? 0) >= limits.api_keys) {
+    return c.json(
+      {
+        error: "api_key_limit_reached",
+        message: "Your account already has an API key. Use your existing key, or manage keys on the dashboard.",
+        organization_id: org.id,
+      },
+      409,
+    );
+  }
+
+  // Mint a new API key
+  const keyId = generateId("key");
+  const { raw, prefix } = generateApiKeyRaw();
+  const keyHash = await hashApiKey(raw);
+  await insertApiKey(c.env.DB, keyId, org.id, keyHash, prefix, "CLI login");
+
+  return c.json({
+    organization_id: org.id,
+    api_key: raw,
+    key_prefix: prefix,
+  });
+});
+
 export { signup };

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -15,6 +15,7 @@ export interface Env {
   // user's email from the claims.
   SUPABASE_JWT_SECRET: string;
   SUPABASE_URL: string;
+  SUPABASE_ANON_KEY: string;
 }
 
 export interface AuthContext {


### PR DESCRIPTION
## Summary
Move Supabase auth to the worker so CLI has zero hardcoded credentials.

## Changes
### Worker
- Add `POST /signup/login` — accepts email+password, authenticates via Supabase server-side, returns API key
- Add `SUPABASE_ANON_KEY` to Env type (needs to be set as wrangler secret)

### CLI
- `engram login` now calls `/signup/login` instead of Supabase directly
- `engram link` simplified — no longer needs password, just emails the worker
- All hardcoded Supabase URLs and anon keys removed

## After merge
- Set `SUPABASE_ANON_KEY` wrangler secret
- Deploy worker
- Publish CLI v0.3.4
- Update Homebrew

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)