### PR TITLE
fix: redirect upgrade success, always mint key on signup

### DIFF
--- a/apps/mcp-server/src/routes/billing.ts
+++ b/apps/mcp-server/src/routes/billing.ts
@@ -78,7 +78,7 @@ billing.post("/checkout", async (c) => {
 
   const successUrl =
     body.success_url ||
-    `${c.env.APP_URL}/dashboard?upgrade=success&session_id={CHECKOUT_SESSION_ID}`;
+    `${c.env.APP_URL}/upgrade/success?session_id={CHECKOUT_SESSION_ID}`;
   const cancelUrl = body.cancel_url || `${c.env.APP_URL}/pricing?upgrade=cancelled`;
 
   const quantity = plan === "team" ? Math.max(1, body.quantity ?? 1) : 1;

--- a/apps/mcp-server/src/routes/signup.ts
+++ b/apps/mcp-server/src/routes/signup.ts
@@ -84,27 +84,9 @@ signup.post("/", async (c) => {
     created = true;
   }
 
-  // Only mint a key if the org doesn't already have one at its limit.
-  // Existing orgs that already have keys should use them (or the dashboard
-  // to manage keys) — minting on every login caused duplicate key bloat.
-  if (!created) {
-    const org = (await getOrganizationById(c.env.DB, orgId)) as { tier?: string } | null;
-    const tier = (org?.tier as Tier) ?? "free";
-    const limits = TIER_LIMITS[tier];
-    const count = await getApiKeyCount(c.env.DB, orgId);
-    if (limits.api_keys !== -1 && (count?.count ?? 0) >= limits.api_keys) {
-      return c.json(
-        {
-          error: "api_key_limit_reached",
-          message: "Your account already has an API key. Use your existing key, or manage keys on the dashboard.",
-          organization_id: orgId,
-          plan,
-        },
-        409,
-      );
-    }
-  }
-
+  // Always mint a key during the signup/provisioning flow. This endpoint
+  // is only called once per Supabase user (the dashboard caches the
+  // profile row). Manual key limits are enforced in /api/keys instead.
   const keyId = generateId("key");
   const { raw, prefix } = generateApiKeyRaw();
   const keyHash = await hashApiKey(raw);


### PR DESCRIPTION
## Summary
- Change Stripe checkout success URL from `/dashboard?upgrade=success` to `/upgrade/success?session_id=...` so it doesn't depend on an active Supabase session
- Remove key limit check from `/signup` provisioning flow — the dashboard's `getOrCreateProfile` only calls this once per user, and manual key limits are enforced in `/api/keys`

Closes #136 (worker-side changes). Dashboard changes in get-engram/engram-web#39.

## Test plan
- [ ] `engram upgrade pro` opens Stripe checkout and redirects to `/upgrade/success` on completion
- [ ] New Supabase user with an existing D1 org (from CLI) gets a key minted at first dashboard sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)