### PR TITLE
feat: named secrets manager + vault documentation

### DIFF
--- a/apps/cli/src/commands/vault.ts
+++ b/apps/cli/src/commands/vault.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { generateVaultKey } from "@getengram/sdk";
+import { generateVaultKey, type Engram } from "@getengram/sdk";
 import { bold, dim } from "../output.js";
 
 const VAULT_KEY_FILE = join(homedir(), ".engram", "vault-key");
@@ -68,4 +68,168 @@ export async function loadVaultKey(): Promise<string | undefined> {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Store a named secret. Follows GitHub Secrets pattern:
+ * - Reads value from stdin, --value flag, or positional arg (in that order)
+ * - Value is encrypted client-side before transmission
+ * - Shell history is avoided when using stdin
+ *
+ * Usage:
+ *   echo "postgres://..." | engram vault set DATABASE_URL
+ *   engram vault set DATABASE_URL --value "postgres://..."
+ *   engram vault set DATABASE_URL "postgres://..."
+ */
+export async function vaultSet(
+  client: Engram,
+  args: string[],
+  flags: Record<string, string>
+): Promise<void> {
+  const name = args[0];
+  if (!name) {
+    console.error("Usage: engram vault set <NAME> [value]");
+    console.error("       echo 'value' | engram vault set <NAME>");
+    process.exit(1);
+  }
+
+  let value: string | undefined;
+
+  // 1. Check --value flag
+  if (flags.value !== undefined) {
+    value = flags.value;
+  }
+  // 2. Check positional arg
+  else if (args[1]) {
+    value = args[1];
+  }
+  // 3. Check stdin (piped input)
+  else if (!process.stdin.isTTY) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk);
+    }
+    value = Buffer.concat(chunks).toString("utf-8").trim();
+  }
+
+  if (!value) {
+    console.error("No value provided.");
+    console.error("Usage: engram vault set <NAME> <value>");
+    console.error("       echo 'value' | engram vault set <NAME>");
+    process.exit(1);
+  }
+
+  await client.vault.set(name, value);
+  console.log(`${bold("Secret stored:")} ${name}`);
+  console.log(dim("Encrypted client-side. The server never sees the plaintext value."));
+}
+
+/**
+ * Retrieve a named secret. Decrypts locally with your vault key.
+ *
+ * Usage:
+ *   engram vault get DATABASE_URL
+ *   engram vault get DATABASE_URL --json
+ */
+export async function vaultGet(
+  client: Engram,
+  args: string[],
+  flags: Record<string, string>
+): Promise<void> {
+  const name = args[0];
+  if (!name) {
+    console.error("Usage: engram vault get <NAME>");
+    process.exit(1);
+  }
+
+  const value = await client.vault.get(name);
+  if (value === null) {
+    console.error(`Secret "${name}" not found.`);
+    process.exit(1);
+  }
+
+  if (flags.json !== undefined) {
+    console.log(JSON.stringify({ name, value }));
+  } else {
+    // Output raw value (suitable for piping)
+    process.stdout.write(value);
+    // Add newline only if stdout is a TTY
+    if (process.stdout.isTTY) {
+      console.log();
+    }
+  }
+}
+
+/**
+ * List all named secrets (names and metadata only, never values).
+ *
+ * Usage:
+ *   engram vault list
+ *   engram vault list --json
+ */
+export async function vaultList(
+  client: Engram,
+  _args: string[],
+  flags: Record<string, string>
+): Promise<void> {
+  const secrets = await client.vault.list();
+
+  if (flags.json !== undefined) {
+    console.log(JSON.stringify({ secrets, total: secrets.length }));
+    return;
+  }
+
+  if (secrets.length === 0) {
+    console.log(dim("No secrets stored."));
+    console.log(dim("Run 'engram vault set <NAME> <value>' to store one."));
+    return;
+  }
+
+  // Table header
+  const nameWidth = Math.max(4, ...secrets.map((s) => s.name.length)) + 2;
+  const typeWidth = Math.max(4, ...secrets.map((s) => s.secretType.length)) + 2;
+
+  console.log(
+    bold("NAME".padEnd(nameWidth)) +
+    bold("TYPE".padEnd(typeWidth)) +
+    bold("UPDATED")
+  );
+
+  for (const s of secrets) {
+    const updated = s.updatedAt.split("T")[0];
+    console.log(
+      s.name.padEnd(nameWidth) +
+      dim(s.secretType.padEnd(typeWidth)) +
+      dim(updated)
+    );
+  }
+
+  console.log();
+  console.log(dim(`${secrets.length} secret(s)`));
+}
+
+/**
+ * Delete a named secret permanently.
+ *
+ * Usage:
+ *   engram vault delete DATABASE_URL
+ */
+export async function vaultDelete(
+  client: Engram,
+  args: string[],
+  _flags: Record<string, string>
+): Promise<void> {
+  const name = args[0];
+  if (!name) {
+    console.error("Usage: engram vault delete <NAME>");
+    process.exit(1);
+  }
+
+  const deleted = await client.vault.delete(name);
+  if (!deleted) {
+    console.error(`Secret "${name}" not found.`);
+    process.exit(1);
+  }
+
+  console.log(`${bold("Deleted:")} ${name}`);
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -15,7 +15,7 @@ import { search } from "./commands/search.js";
 import { log as showLog } from "./commands/log.js";
 import { daemonStart, daemonStop, daemonStatus, daemonInstall, daemonUninstall } from "./daemon/index.js";
 import { upgrade } from "./commands/upgrade.js";
-import { vaultKeygen, vaultStatus, loadVaultKey } from "./commands/vault.js";
+import { vaultKeygen, vaultStatus, loadVaultKey, vaultSet, vaultGet, vaultList, vaultDelete } from "./commands/vault.js";
 import { bold, dim } from "./output.js";
 
 const VERSION = "0.3.4";
@@ -141,6 +141,10 @@ ${bold("COMMANDS")}
   ${bold("vault keygen")}             Generate a new vault encryption key
   ${bold("vault keygen --save")}      Generate and save key to ~/.engram/vault-key
   ${bold("vault status")}             Show vault configuration status
+  ${bold("vault set")} <name> [value] Store a named secret ${dim("(encrypted client-side)")}
+  ${bold("vault get")} <name>         Retrieve a named secret ${dim("(decrypted locally)")}
+  ${bold("vault list")}               List secret names ${dim("(never shows values)")}
+  ${bold("vault delete")} <name>      Delete a named secret permanently
 
   ${bold("start")}                    Start background daemon (auto-capture)
   ${bold("stop")}                     Stop the daemon
@@ -265,6 +269,24 @@ async function main(): Promise<void> {
       // Vault commands
       case "vault keygen":
         await vaultKeygen(args, flags);
+        break;
+
+      case "vault set":
+        await vaultSet(await getClient(), args, flags);
+        break;
+
+      case "vault get":
+        await vaultGet(await getClient(), args, flags);
+        break;
+
+      case "vault list":
+      case "vault ls":
+        await vaultList(await getClient(), args, flags);
+        break;
+
+      case "vault delete":
+      case "vault rm":
+        await vaultDelete(await getClient(), args, flags);
         break;
 
       case "vault status":

--- a/apps/mcp-server/src/__tests__/mcp-tools-contract.test.ts
+++ b/apps/mcp-server/src/__tests__/mcp-tools-contract.test.ts
@@ -9,6 +9,10 @@ import { registerGetConversation } from "../mcp/tools/get-conversation.js";
 import { registerListConversations } from "../mcp/tools/list-conversations.js";
 import { registerDeleteConversation } from "../mcp/tools/delete-conversation.js";
 import { registerResolveVault } from "../mcp/tools/resolve-vault.js";
+import { registerVaultSet } from "../mcp/tools/vault-set.js";
+import { registerVaultGet } from "../mcp/tools/vault-get.js";
+import { registerVaultList } from "../mcp/tools/vault-list.js";
+import { registerVaultDelete } from "../mcp/tools/vault-delete.js";
 import type { Env, AuthContext } from "../types.js";
 
 /**
@@ -286,6 +290,10 @@ describe("MCP tool contract — wire field names", () => {
         "list_conversations",
         "delete_conversation",
         "resolve_vault",
+        "vault_set",
+        "vault_get",
+        "vault_list",
+        "vault_delete",
       ].sort();
 
       const { server, tools } = createCaptureServer();
@@ -296,6 +304,10 @@ describe("MCP tool contract — wire field names", () => {
       registerListConversations(server, env, auth);
       registerDeleteConversation(server, env, auth);
       registerResolveVault(server, env, auth);
+      registerVaultSet(server, env, auth);
+      registerVaultGet(server, env, auth);
+      registerVaultList(server, env, auth);
+      registerVaultDelete(server, env, auth);
 
       const registered = Array.from(tools.keys()).sort();
       expect(registered).toEqual(EXPECTED_TOOL_NAMES);

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -6,6 +6,10 @@ import { registerGetConversation } from "./tools/get-conversation.js";
 import { registerListConversations } from "./tools/list-conversations.js";
 import { registerDeleteConversation } from "./tools/delete-conversation.js";
 import { registerResolveVault } from "./tools/resolve-vault.js";
+import { registerVaultSet } from "./tools/vault-set.js";
+import { registerVaultGet } from "./tools/vault-get.js";
+import { registerVaultList } from "./tools/vault-list.js";
+import { registerVaultDelete } from "./tools/vault-delete.js";
 import type { Env, AuthContext } from "../types.js";
 
 export function createMcpServer(env: Env, auth: AuthContext): McpServer {
@@ -21,6 +25,10 @@ export function createMcpServer(env: Env, auth: AuthContext): McpServer {
   registerListConversations(server, env, auth);
   registerDeleteConversation(server, env, auth);
   registerResolveVault(server, env, auth);
+  registerVaultSet(server, env, auth);
+  registerVaultGet(server, env, auth);
+  registerVaultList(server, env, auth);
+  registerVaultDelete(server, env, auth);
 
   return server;
 }

--- a/apps/mcp-server/src/mcp/tools/vault-delete.ts
+++ b/apps/mcp-server/src/mcp/tools/vault-delete.ts
@@ -1,0 +1,67 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { deleteNamedSecret, getNamedSecret } from "@getengram/db";
+import { audit } from "../../services/audit.js";
+import type { Env, AuthContext } from "../../types.js";
+
+export function registerVaultDelete(
+  server: McpServer,
+  env: Env,
+  auth: AuthContext
+) {
+  server.tool(
+    "vault_delete",
+    "Delete a named secret permanently. This action cannot be undone.",
+    {
+      name: z
+        .string()
+        .min(1)
+        .describe("Secret name to delete"),
+    },
+    async (params) => {
+      // Check existence first for audit
+      const existing = await getNamedSecret(
+        env.DB,
+        auth.organizationId,
+        params.name
+      );
+
+      if (!existing) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `Secret "${params.name}" not found`,
+              }),
+            },
+          ],
+        };
+      }
+
+      await deleteNamedSecret(env.DB, auth.organizationId, params.name);
+
+      audit(
+        env.DB,
+        auth.organizationId,
+        auth.apiKeyId,
+        "vault.delete",
+        "named_secret",
+        params.name,
+        {}
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              deleted: true,
+              name: params.name,
+            }),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/apps/mcp-server/src/mcp/tools/vault-get.ts
+++ b/apps/mcp-server/src/mcp/tools/vault-get.ts
@@ -1,0 +1,68 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getNamedSecret } from "@getengram/db";
+import { audit } from "../../services/audit.js";
+import type { Env, AuthContext } from "../../types.js";
+
+export function registerVaultGet(
+  server: McpServer,
+  env: Env,
+  auth: AuthContext
+) {
+  server.tool(
+    "vault_get",
+    "Retrieve a named secret's encrypted blob. Decryption happens client-side with your vault key.",
+    {
+      name: z
+        .string()
+        .min(1)
+        .describe("Secret name to retrieve (e.g. DATABASE_URL)"),
+    },
+    async (params) => {
+      const row = await getNamedSecret(
+        env.DB,
+        auth.organizationId,
+        params.name
+      );
+
+      audit(
+        env.DB,
+        auth.organizationId,
+        auth.apiKeyId,
+        "vault.get",
+        "named_secret",
+        params.name,
+        { found: !!row }
+      );
+
+      if (!row) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `Secret "${params.name}" not found`,
+              }),
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              name: row.name,
+              encrypted_value: row.encrypted_value,
+              iv: row.iv,
+              secret_type: row.secret_type,
+              created_at: row.created_at,
+              updated_at: row.updated_at,
+            }),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/apps/mcp-server/src/mcp/tools/vault-list.ts
+++ b/apps/mcp-server/src/mcp/tools/vault-list.ts
@@ -1,0 +1,48 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { listNamedSecrets } from "@getengram/db";
+import { audit } from "../../services/audit.js";
+import type { Env, AuthContext } from "../../types.js";
+
+export function registerVaultList(
+  server: McpServer,
+  env: Env,
+  auth: AuthContext
+) {
+  server.tool(
+    "vault_list",
+    "List all named secrets. Returns names and metadata only — never values or encrypted blobs.",
+    {},
+    async () => {
+      const result = await listNamedSecrets(env.DB, auth.organizationId);
+
+      const secrets = result.results.map((r: Record<string, unknown>) => ({
+        name: r.name,
+        secret_type: r.secret_type,
+        created_at: r.created_at,
+        updated_at: r.updated_at,
+      }));
+
+      audit(
+        env.DB,
+        auth.organizationId,
+        auth.apiKeyId,
+        "vault.list",
+        "named_secret",
+        undefined,
+        { count: secrets.length }
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              secrets,
+              total: secrets.length,
+            }),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/apps/mcp-server/src/mcp/tools/vault-set.ts
+++ b/apps/mcp-server/src/mcp/tools/vault-set.ts
@@ -1,0 +1,72 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { generateId } from "@getengram/shared";
+import { upsertNamedSecret } from "@getengram/db";
+import { audit } from "../../services/audit.js";
+import type { Env, AuthContext } from "../../types.js";
+
+export function registerVaultSet(
+  server: McpServer,
+  env: Env,
+  auth: AuthContext
+) {
+  server.tool(
+    "vault_set",
+    "Store a named secret. The value must be encrypted client-side before calling this tool. The server stores the encrypted blob — it never sees plaintext.",
+    {
+      name: z
+        .string()
+        .min(1)
+        .max(255)
+        .regex(/^[A-Za-z_][A-Za-z0-9_.-]*$/, "Name must be alphanumeric with underscores, dots, or hyphens")
+        .describe("Secret name (e.g. DATABASE_URL, OPENAI_KEY)"),
+      encrypted_value: z
+        .string()
+        .min(1)
+        .describe("Base64-encoded AES-256-GCM ciphertext"),
+      iv: z
+        .string()
+        .min(1)
+        .describe("Base64-encoded initialization vector"),
+      secret_type: z
+        .string()
+        .default("unknown")
+        .describe("Type of secret (e.g. api_key, connection_string, token)"),
+    },
+    async (params) => {
+      const id = generateId("vlt");
+
+      await upsertNamedSecret(env.DB, {
+        id,
+        organizationId: auth.organizationId,
+        name: params.name,
+        encryptedValue: params.encrypted_value,
+        iv: params.iv,
+        secretType: params.secret_type,
+      });
+
+      audit(
+        env.DB,
+        auth.organizationId,
+        auth.apiKeyId,
+        "vault.set",
+        "named_secret",
+        params.name,
+        { secret_type: params.secret_type }
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              stored: true,
+              name: params.name,
+              secret_type: params.secret_type,
+            }),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/apps/mcp-server/src/services/audit.ts
+++ b/apps/mcp-server/src/services/audit.ts
@@ -12,7 +12,12 @@ export type AuditAction =
   | "account.restore"
   | "data.export"
   | "auth.success"
-  | "auth.failure";
+  | "auth.failure"
+  | "vault.resolve"
+  | "vault.set"
+  | "vault.get"
+  | "vault.list"
+  | "vault.delete";
 
 /**
  * Fire-and-forget audit log entry. Never throws — audit logging

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Engram exposes 6 tools via the Model Context Protocol (MCP). All tools are accessed through the `/mcp` endpoint using Streamable HTTP transport.
+Engram exposes 11 tools via the Model Context Protocol (MCP). All tools are accessed through the `/mcp` endpoint using Streamable HTTP transport.
 
 All requests require an `Authorization: Bearer engram_sk_live_...` header.
 
@@ -49,6 +49,7 @@ Append messages to a conversation. Messages are stored verbatim and automaticall
 |------|------|----------|-------------|
 | `conversation_id` | string | Yes | The conversation to append to |
 | `messages` | MessageInput[] | Yes | One or more messages to append (min 1) |
+| `vault_entries` | VaultEntry[] | No | Encrypted secret entries from client-side vault |
 
 **MessageInput:**
 
@@ -93,9 +94,10 @@ append_messages
 ### What happens on append
 
 1. Messages are inserted into the database with sequential ordering
-2. New messages are grouped into overlapping chunks (window of 5 messages, stride of 3)
-3. Each chunk is embedded using `bge-base-en-v1.5` (768 dimensions)
-4. Vectors are upserted to the search index with conversation and organization metadata
+2. If `vault_entries` are provided, encrypted blobs are stored in the secrets vault
+3. New messages are grouped into overlapping chunks (window of 5 messages, stride of 3)
+4. Each chunk is embedded using `bge-base-en-v1.5` (768 dimensions)
+5. Vectors are upserted to the search index with conversation and organization metadata
 
 ---
 
@@ -257,6 +259,150 @@ Permanently delete a conversation and all its messages, chunks, and vector embed
 ```
 
 Returns an error if the conversation is not found or doesn't belong to your organization.
+
+---
+
+## resolve_vault
+
+Retrieve encrypted vault entries by ID. Returns encrypted blobs — decryption happens client-side with your vault key.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vault_ids` | string[] | Yes | Vault entry IDs to resolve (1–50) |
+
+### Response
+
+```json
+{
+  "entries": [
+    {
+      "id": "vlt_x7KdR4yLRaBcDeFgHiJkLm",
+      "encrypted_value": "base64-encoded-ciphertext",
+      "iv": "base64-encoded-iv",
+      "secret_type": "api_key",
+      "conversation_id": "conv_abc123",
+      "created_at": "2026-05-25T10:00:00Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+### Example
+
+```
+resolve_vault
+  vault_ids: ["vlt_x7KdR4yLRaBcDeFgHiJkLm", "vlt_9PqRsTuVwXyZaBcDeFgHi"]
+```
+
+The SDK's `resolveSecrets()` method handles this automatically — you typically don't call this tool directly. See [Secrets Vault](./vault.md) for details.
+
+---
+
+## vault_set
+
+Store a named secret. The value must be encrypted client-side before calling this tool. The server stores the encrypted blob — it never sees plaintext.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Secret name (e.g. `DATABASE_URL`). Must match `^[A-Za-z_][A-Za-z0-9_.-]*$` |
+| `encrypted_value` | string | Yes | Base64-encoded AES-256-GCM ciphertext |
+| `iv` | string | Yes | Base64-encoded initialization vector |
+| `secret_type` | string | No | Type hint (e.g. `api_key`, `connection_string`). Default: `unknown` |
+
+### Response
+
+```json
+{
+  "stored": true,
+  "name": "DATABASE_URL",
+  "secret_type": "connection_string"
+}
+```
+
+If a secret with the same name exists, it is overwritten.
+
+---
+
+## vault_get
+
+Retrieve a named secret's encrypted blob. Decryption happens client-side with your vault key.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Secret name to retrieve |
+
+### Response
+
+```json
+{
+  "name": "DATABASE_URL",
+  "encrypted_value": "base64-encoded-ciphertext",
+  "iv": "base64-encoded-iv",
+  "secret_type": "connection_string",
+  "created_at": "2026-05-25T10:00:00Z",
+  "updated_at": "2026-05-25T10:00:00Z"
+}
+```
+
+Returns `{ "error": "Secret \"NAME\" not found" }` if the secret doesn't exist.
+
+---
+
+## vault_list
+
+List all named secrets. Returns names and metadata only — never values or encrypted blobs.
+
+### Parameters
+
+None.
+
+### Response
+
+```json
+{
+  "secrets": [
+    {
+      "name": "DATABASE_URL",
+      "secret_type": "connection_string",
+      "created_at": "2026-05-25T10:00:00Z",
+      "updated_at": "2026-05-25T10:00:00Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+---
+
+## vault_delete
+
+Delete a named secret permanently. This action cannot be undone.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Secret name to delete |
+
+### Response
+
+```json
+{
+  "deleted": true,
+  "name": "DATABASE_URL"
+}
+```
+
+Returns `{ "error": "Secret \"NAME\" not found" }` if the secret doesn't exist.
+
+See [Secrets Vault](./vault.md) for the full vault guide including CLI usage and SDK integration.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,7 +155,7 @@ D1 is **SQLite running as a service on Cloudflare's network.** It's not Postgres
 
 ### How Engram uses D1
 
-Five tables, all scoped by `organization_id`:
+Six tables, all scoped by `organization_id`:
 
 ```sql
 organizations         ── Tenants
@@ -163,6 +163,7 @@ organizations         ── Tenants
   └── conversations   ── Containers for messages
         └── messages           ── Verbatim content, ordered by sequence
         └── conversation_chunks ── Text windows for embedding
+        └── secrets_vault      ── Encrypted secret blobs (zero-knowledge)
 ```
 
 Every query includes `WHERE organization_id = ?`. The org_id is **denormalized** — it's stored directly on messages and chunks, not just on the parent conversation. This means tenant-scoped queries never need JOINs:
@@ -186,6 +187,8 @@ Schema changes are standard SQL files in `packages/db/migrations/`:
 ```
 0001_initial_schema.sql  ── 5 tables with foreign keys + cascading deletes
 0002_add_indexes.sql     ── 7 indexes for query performance
+...
+0009_secrets_vault.sql   ── Zero-knowledge secrets vault table
 ```
 
 Applied via: `wrangler d1 migrations apply engram-db --remote`
@@ -405,25 +408,30 @@ MCP Client sends POST /mcp
   ├── 4b. Get max sequence
   │   Query D1: SELECT MAX(sequence) FROM messages WHERE conversation_id = ?
   │
-  ├── 4c. Insert messages
+  ├── 4c. Store vault entries (if present)
+  │   If vault_entries provided:
+  │   Batch insert into secrets_vault (id, encrypted_value, iv, secret_type, ...)
+  │   (Server stores opaque blobs — never decrypts)
+  │
+  ├── 4d. Insert messages
   │   Batch insert into D1: INSERT INTO messages (id, conversation_id, ..., sequence)
   │   Sequences: max_seq + 1, max_seq + 2, ...
   │
-  ├── 4d. Update count
+  ├── 4e. Update count
   │   D1: UPDATE conversations SET message_count = message_count + N
   │
-  ├── 4e. Chunk messages
+  ├── 4f. Chunk messages
   │   Sliding window: [msg1..msg5], [msg4..msg8], ...
   │   Format: "[role]: content\n..."
   │
-  ├── 4f. Generate embeddings
+  ├── 4g. Generate embeddings
   │   Workers AI: env.AI.run("@cf/baai/bge-base-en-v1.5", { text: chunk_texts })
   │   Returns: [[0.12, -0.45, ...], [0.34, ...], ...]
   │
-  ├── 4g. Store chunks in D1
+  ├── 4h. Store chunks in D1
   │   Batch insert: INSERT INTO conversation_chunks (id, chunk_text, vectorize_id, ...)
   │
-  └── 4h. Index in Vectorize
+  └── 4i. Index in Vectorize
       env.VECTORIZE.upsert([
         { id: "chk_abc", values: [0.12, ...], metadata: {org_id, conv_id} },
         ...

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -146,6 +146,95 @@ Output shows relevance score, conversation ID, and matched text:
   [user]: User wants npm and brew distribution...
 ```
 
+### engram vault keygen
+
+Generate a new AES-256 vault encryption key for client-side secret encryption.
+
+```bash
+# Print key to stdout
+engram vault keygen
+
+# Save to ~/.engram/vault-key (permissions 600)
+engram vault keygen --save
+```
+
+| Flag | Description |
+|------|-------------|
+| `--save` | Save key to `~/.engram/vault-key` |
+
+### engram vault set
+
+Store a named secret. Value is encrypted client-side before transmission.
+
+```bash
+# Pipe from stdin (recommended — avoids shell history)
+echo "postgres://admin:secret@db.example.com/prod" | engram vault set DATABASE_URL
+
+# Pass as argument
+engram vault set OPENAI_KEY "sk-abc123..."
+
+# Pass with flag
+engram vault set STRIPE_KEY --value "sk_live_..."
+```
+
+| Flag | Description |
+|------|-------------|
+| `--value <val>` | Secret value (alternative to positional arg or stdin) |
+
+### engram vault get
+
+Retrieve a named secret. Decrypted locally with your vault key.
+
+```bash
+engram vault get DATABASE_URL
+# → postgres://admin:secret@db.example.com/prod
+
+# Pipe to clipboard
+engram vault get DATABASE_URL | pbcopy
+
+# JSON output
+engram vault get DATABASE_URL --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output as JSON |
+
+### engram vault list
+
+List all named secrets. Shows names and metadata only — never values.
+
+```bash
+engram vault list
+# NAME            TYPE                 UPDATED
+# DATABASE_URL    connection_string    2026-05-25
+# OPENAI_KEY      api_key              2026-05-25
+
+engram vault list --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output as JSON |
+
+### engram vault delete
+
+Delete a named secret permanently.
+
+```bash
+engram vault delete DATABASE_URL
+```
+
+### engram vault status
+
+Check vault configuration status.
+
+```bash
+engram vault status
+# Vault: configured (key at /Users/you/.engram/vault-key)
+# Key prefix: dGhpcyBp...
+```
+
 ### engram help
 
 Show help text with all commands and options.
@@ -167,6 +256,7 @@ engram version
 |----------|-------------|---------|
 | `ENGRAM_API_KEY` | API key (overrides `~/.engram/config.json`) | — |
 | `ENGRAM_BASE_URL` | Custom Engram endpoint | `https://mcp.getengram.app` |
+| `ENGRAM_VAULT_KEY` | Vault encryption key (base64, 32 bytes) | — |
 
 ## Configuration File
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,6 +32,8 @@ If you self-host, data stays on your own Cloudflare account.
 
 Data is encrypted at rest and in transit by Cloudflare. API keys are hashed with SHA-256 before storage — the raw key is never stored.
 
+For sensitive data in conversations, Engram's [Secrets Vault](./vault.md) adds client-side AES-256-GCM encryption — secrets are encrypted before they leave your machine, and the server never sees plaintext.
+
 ### Can one organization see another's data?
 
 No. Every query is scoped by `organization_id`. The ID is determined by the API key used, and all database queries and vector searches filter by it. There is no API to query across organizations.
@@ -75,6 +77,18 @@ The MCP transport uses Streamable HTTP, which supports server-sent events. Howev
 ### Can I use Engram without MCP?
 
 Not yet. The current MVP only exposes MCP tools. A REST API is planned for Phase 2.
+
+### How do I protect secrets and credentials in my conversations?
+
+Enable the [Secrets Vault](./vault.md). Generate a vault key with `engram vault keygen --save`, then set `ENGRAM_VAULT_KEY` or pass it in the SDK config. The SDK automatically detects API keys, passwords, connection strings, PII, and other sensitive patterns, encrypts them client-side, and replaces them with `[VAULT:vlt_...]` tokens.
+
+### What types of secrets are detected?
+
+API keys (OpenAI, AWS, GitHub, Stripe, Slack, etc.), PEM private keys, JWTs, database connection strings, secret assignments (`password=`, `token=`), SSNs, credit card numbers, emails, phone numbers, and high-entropy tokens. See the [full list](./vault.md#what-gets-detected).
+
+### What happens if I lose my vault key?
+
+Vaulted secrets are permanently unrecoverable. Engram never has your key — that's the point of zero-knowledge encryption. Back up your key securely.
 
 ## Pricing
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -197,16 +197,40 @@ No re-explaining. No lost context. The agent just knows.
 
 ---
 
+## Protecting Secrets
+
+If your agents handle sensitive data (API keys, credentials, PII), enable the **Secrets Vault** for client-side encryption:
+
+```bash
+# Generate and save a vault key
+engram vault keygen --save
+```
+
+Then configure the SDK:
+
+```typescript
+const engram = new Engram({
+  apiKey: process.env.ENGRAM_API_KEY!,
+  vault: { encryptionKey: process.env.ENGRAM_VAULT_KEY! },
+})
+```
+
+Secrets in message content are automatically detected, encrypted on your machine, and replaced with `[VAULT:vlt_...]` tokens before being sent to Engram. The server never sees plaintext secrets.
+
+See [Secrets Vault](./vault.md) for the full guide.
+
 ## Concepts
 
 - **Conversations** — A container for messages. Has a title, optional tags, and metadata.
 - **Messages** — Verbatim records of what was said. Roles: `user`, `assistant`, `system`, `tool`.
 - **Chunks** — Sliding windows of messages, automatically created and embedded for search.
+- **Vault** — Client-side secret encryption. Detects and encrypts sensitive data before it leaves your machine.
 - **Organizations** — Tenant isolation. Each API key belongs to one org. Data never leaks across orgs.
 
 ## Next Steps
 
-- [API Reference](./api-reference.md) — All 6 MCP tools with parameters and examples
+- [Secrets Vault](./vault.md) — Client-side encryption for sensitive data
+- [API Reference](./api-reference.md) — All 7 MCP tools with parameters and examples
 - [Integrations](./integrations.md) — Claude Desktop, Cursor, Windsurf, custom clients
 - [Concepts](./concepts.md) — How storage and search work under the hood
 - [Architecture](./architecture.md) — Deep dive into how everything works

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -17,6 +17,7 @@ const engram = new Engram({
   apiKey: process.env.ENGRAM_API_KEY!,
   // baseUrl: 'http://localhost:8787',  // optional — for local dev
   // timeout: 30000,                     // optional — request timeout (ms)
+  // vault: { encryptionKey: '...' },   // optional — client-side secret encryption
 })
 ```
 
@@ -126,6 +127,47 @@ Delete a conversation and all associated data (messages, chunks, embeddings).
 await engram.deleteConversation('conv_abc')
 ```
 
+### resolveSecrets
+
+Decrypt vault tokens in messages back to plaintext secrets. Requires vault to be configured.
+
+```typescript
+const { messages } = await engram.getConversation('conv_abc')
+
+// Messages may contain [VAULT:vlt_...] tokens where secrets were encrypted
+const decrypted = await engram.resolveSecrets(messages)
+// Tokens are replaced with the original plaintext secrets
+```
+
+### Engram.generateVaultKey (static)
+
+Generate a new AES-256 vault encryption key.
+
+```typescript
+const key = await Engram.generateVaultKey()
+// → base64-encoded 32-byte key (e.g., "dGhpcyBpcyBhIDMyLWJ5dGUga2V5ISEh...")
+```
+
+### vault (named secrets manager)
+
+Store, retrieve, list, and delete named secrets. Accessed via `engram.vault`.
+
+```typescript
+// Store a named secret (encrypted client-side)
+await engram.vault.set('DATABASE_URL', 'postgres://admin:secret@db.example.com/prod')
+
+// Retrieve (decrypted locally)
+const url = await engram.vault.get('DATABASE_URL')
+
+// List all secrets (names and metadata only)
+const secrets = await engram.vault.list()
+
+// Delete
+await engram.vault.delete('DATABASE_URL')
+```
+
+See [Secrets Vault](./vault.md) for the full vault guide.
+
 ## Error Handling
 
 ```typescript
@@ -174,6 +216,10 @@ import type {
   ListConversationsResponse,
   DeleteConversationResponse,
 } from '@getengram/sdk'
+
+// Vault types
+import { generateVaultKey } from '@getengram/sdk'
+import type { VaultConfig, VaultEntry, ProcessedContent } from '@getengram/sdk'
 ```
 
 ## Architecture

--- a/docs/security.md
+++ b/docs/security.md
@@ -91,9 +91,28 @@ Cloudflare Workers terminate TLS at the edge, so traffic between the client and 
 
 Cloudflare D1 and Vectorize encrypt data at rest. Engram does not add application-level encryption on top of this.
 
+### Client-Side Secret Encryption (Vault)
+
+Engram includes a **Secrets Vault** that encrypts sensitive data before it leaves your machine:
+
+- **Detection:** The SDK scans message content for API keys, private keys, JWTs, connection strings, PII, and other secret patterns
+- **Encryption:** Each detected secret is encrypted with **AES-256-GCM** using a key that only you hold
+- **Tokenization:** Secrets are replaced with `[VAULT:vlt_...]` tokens in the message content
+- **Zero-knowledge storage:** The server stores encrypted blobs alongside the tokens — it never sees plaintext secrets
+- **Client-side decryption:** On retrieval, the SDK decrypts vault entries locally with your key
+
+This provides **three layers** of protection:
+1. **TLS** — encrypts data in transit
+2. **Client-side vault encryption** — encrypts secrets before they leave your machine
+3. **Cloudflare at-rest encryption** — encrypts the database on disk
+
+Even if the database were fully compromised, vaulted secrets remain encrypted with a key the server never had.
+
+See [Secrets Vault](./vault.md) for setup and configuration.
+
 ### Content Storage
 
-Message content is stored **verbatim** — exactly as sent by the client. Engram does not:
+Message content is stored **verbatim** — exactly as sent by the client (with vault tokens replacing any detected secrets when vault is enabled). Engram does not:
 - Inspect or filter message content
 - Send content to third-party services (embeddings are generated on Cloudflare's own Workers AI)
 - Log message content outside of D1 storage
@@ -112,10 +131,11 @@ Worker → Workers AI (same network) → Vectorize (same network)
 
 When a conversation is deleted:
 
-1. All vector embeddings are removed from Vectorize
-2. All chunk records are deleted from D1
-3. All message records are deleted from D1
-4. The conversation record is deleted from D1
+1. All vault entries are deleted from D1 (cascade)
+2. All vector embeddings are removed from Vectorize
+3. All chunk records are deleted from D1
+4. All message records are deleted from D1
+5. The conversation record is deleted from D1
 
 Foreign key constraints with `ON DELETE CASCADE` ensure database-level integrity. The Vectorize cleanup happens in application code before the D1 delete.
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -1,0 +1,473 @@
+# Secrets Vault
+
+Engram's Secrets Vault provides two layers of secret protection:
+
+1. **Automatic detection** — Secrets in conversation messages are detected, encrypted client-side, and replaced with vault tokens before transmission
+2. **Named secrets manager** — Explicitly store and retrieve secrets by name, like GitHub Secrets or HashiCorp Vault
+
+All secrets are encrypted **client-side** with AES-256-GCM before they ever leave your machine. Engram's server never sees plaintext.
+
+## Why it matters
+
+AI agents handle sensitive data constantly: API keys, database credentials, tokens, PII. Without protection, these end up stored in plain text in conversation history — searchable, readable, and one breach away from exposure.
+
+Engram's vault solves this with **zero-knowledge encryption**: your secrets are encrypted with a key only you hold. The server stores opaque blobs. Even if the database were compromised, secrets remain encrypted.
+
+## How it works
+
+```
+Your machine                              Engram server
+─────────────                             ─────────────
+Message: "Deploy with                     Receives:
+  sk-ant-abc123... key"                     "Deploy with [VAULT:vlt_x7Kd...] key"
+        │                                          │
+        ▼                                          ▼
+  1. Detect secrets                         Stores vault token
+     (sk-ant-abc123...)                     + encrypted blob
+  2. Encrypt with YOUR key                  (cannot decrypt)
+     (AES-256-GCM)
+  3. Replace with token
+     [VAULT:vlt_x7Kd...]
+  4. Send to Engram
+```
+
+On retrieval, the SDK fetches the encrypted blobs and decrypts them locally with your key.
+
+## Quick start
+
+### 1. Generate a vault key
+
+```bash
+# Generate and save to ~/.engram/vault-key
+engram vault keygen --save
+
+# Or generate and manage yourself
+engram vault keygen
+```
+
+The key is a base64-encoded 32-byte AES-256 key. **Store it securely. If you lose it, vaulted secrets cannot be recovered.**
+
+### 2. Configure the SDK
+
+```typescript
+import { Engram } from '@getengram/sdk'
+
+const engram = new Engram({
+  apiKey: process.env.ENGRAM_API_KEY!,
+  vault: {
+    encryptionKey: process.env.ENGRAM_VAULT_KEY!,
+  },
+})
+```
+
+### 3. Use normally — secrets are protected automatically
+
+```typescript
+// Secrets in message content are auto-detected and encrypted
+await engram.store({
+  conversationId: 'conv_abc',
+  messages: [
+    {
+      role: 'user',
+      content: 'Connect to postgres://admin:s3cret@db.example.com/prod',
+    },
+  ],
+})
+// Server receives: "Connect to [VAULT:vlt_x7Kd...]"
+// The connection string is encrypted client-side
+```
+
+### 4. Decrypt on retrieval
+
+```typescript
+const { conversation, messages } = await engram.getConversation('conv_abc')
+
+// Messages contain vault tokens: [VAULT:vlt_x7Kd...]
+// Decrypt them back to plaintext:
+const decrypted = await engram.resolveSecrets(messages)
+// → "Connect to postgres://admin:s3cret@db.example.com/prod"
+```
+
+## Named secrets manager
+
+Store, retrieve, and manage secrets by name — like GitHub Secrets or HashiCorp Vault, but with client-side encryption. Designed for AI agents that need access to credentials without exposing them.
+
+### CLI usage (recommended)
+
+Following GitHub Secrets' pattern, values can be piped via stdin to avoid shell history exposure:
+
+```bash
+# Store a secret (pipe from stdin — avoids shell history)
+echo "postgres://admin:s3cret@db.example.com/prod" | engram vault set DATABASE_URL
+
+# Or pass directly (appears in shell history)
+engram vault set OPENAI_KEY "sk-abc123..."
+
+# Or use --value flag
+engram vault set STRIPE_KEY --value "sk_live_..."
+
+# Retrieve a secret (decrypted locally)
+engram vault get DATABASE_URL
+# → postgres://admin:s3cret@db.example.com/prod
+
+# Pipe to another command
+engram vault get DATABASE_URL | pbcopy
+
+# List all secrets (names only — never values)
+engram vault list
+# NAME            TYPE                 UPDATED
+# DATABASE_URL    connection_string    2026-05-25
+# OPENAI_KEY      api_key              2026-05-25
+# STRIPE_KEY      api_key              2026-05-25
+#
+# 3 secret(s)
+
+# Delete a secret permanently
+engram vault delete DATABASE_URL
+```
+
+### SDK usage
+
+```typescript
+const engram = new Engram({
+  apiKey: process.env.ENGRAM_API_KEY!,
+  vault: { encryptionKey: process.env.ENGRAM_VAULT_KEY! },
+})
+
+// Store
+await engram.vault.set('DATABASE_URL', 'postgres://admin:s3cret@db.example.com/prod')
+
+// Retrieve (decrypted locally)
+const url = await engram.vault.get('DATABASE_URL')
+// → "postgres://admin:s3cret@db.example.com/prod"
+
+// List (names and metadata only, never values)
+const secrets = await engram.vault.list()
+// → [{ name: 'DATABASE_URL', secretType: 'connection_string', ... }]
+
+// Delete
+await engram.vault.delete('DATABASE_URL')
+```
+
+### Using with Claude Code as a secrets manager
+
+Add secrets to the vault:
+
+```bash
+echo "sk-abc123..." | engram vault set OPENAI_KEY
+echo "postgres://..." | engram vault set DATABASE_URL
+```
+
+Then in your `CLAUDE.md`:
+
+```markdown
+## Secrets
+
+Project secrets are stored in Engram's vault. When you need a credential:
+
+1. Run `engram vault list` to see available secrets
+2. Run `engram vault get SECRET_NAME` to retrieve a specific secret
+3. NEVER hardcode secrets in code — always use the vault
+4. NEVER store retrieved secrets in files — use them ephemerally
+
+The vault decrypts secrets locally with ENGRAM_VAULT_KEY.
+Secrets are never sent to or stored on remote servers in plaintext.
+```
+
+Claude Code will then use `engram vault get` to retrieve secrets on demand, keeping them out of the conversation history and codebase.
+
+### MCP tools for agents
+
+Agents can also manage secrets via MCP tools:
+
+| Tool | Description |
+|------|-------------|
+| `vault_set` | Store a named secret (encrypted blob) |
+| `vault_get` | Retrieve a named secret (encrypted blob — decrypted by SDK) |
+| `vault_list` | List secret names and metadata (never values) |
+| `vault_delete` | Delete a named secret permanently |
+
+### Secret naming conventions
+
+Follow environment variable naming conventions:
+
+```
+DATABASE_URL          # connection strings
+OPENAI_KEY            # API keys
+STRIPE_SECRET_KEY     # provider-specific keys
+JWT_SIGNING_SECRET    # application secrets
+AWS_ACCESS_KEY_ID     # cloud credentials
+```
+
+Names must match `^[A-Za-z_][A-Za-z0-9_.-]*$` (letters, numbers, underscores, dots, hyphens; must start with letter or underscore).
+
+---
+
+## Automatic secret detection in conversations
+
+The vault also auto-detects and encrypts secrets found in conversation messages. This protects against accidental leakage — even if a user pastes a secret into a conversation, it's encrypted before transmission.
+
+## CLI — key management
+
+### Generate a key
+
+```bash
+# Print key to stdout
+engram vault keygen
+
+# Save to ~/.engram/vault-key (permissions 600)
+engram vault keygen --save
+```
+
+### Check vault status
+
+```bash
+engram vault status
+# Vault: configured (key at ~/.engram/vault-key)
+# Key prefix: dGhpcyBp...
+```
+
+### Environment variable
+
+```bash
+export ENGRAM_VAULT_KEY="your-base64-key-here"
+```
+
+The CLI and SDK check `ENGRAM_VAULT_KEY` first, then fall back to `~/.engram/vault-key`.
+
+### Automatic protection with CLI
+
+When a vault key is configured, `engram store` automatically encrypts detected secrets:
+
+```bash
+# Secrets in the message are encrypted before sending
+engram store -c conv_abc "Deploy key: sk-ant-api-abc123xyz..."
+# Server receives: "Deploy key: [VAULT:vlt_...]"
+```
+
+## What gets detected
+
+The vault detects and encrypts these secret types:
+
+| Type | Examples |
+|------|----------|
+| **API keys** | OpenAI (`sk-...`), Anthropic (`sk-ant-...`), AWS (`AKIA...`), GitHub (`ghp_...`), Stripe (`sk_live_...`), Slack (`xoxb-...`), SendGrid (`SG....`), Twilio (`SK...`), npm (`npm_...`) |
+| **Private keys** | PEM-encoded RSA, EC, DSA, OpenSSH private keys |
+| **JWTs** | `eyJ...` tokens with header.payload.signature |
+| **Connection strings** | `postgres://`, `mysql://`, `redis://`, `mongodb://`, `amqp://` |
+| **Secret assignments** | `password=`, `secret=`, `api_key=`, `token=`, `client_secret=` patterns |
+| **SSNs** | `123-45-6789` format |
+| **Credit cards** | 13–19 digit card numbers |
+| **Emails** | `user@example.com` |
+| **Phone numbers** | US format with optional country code |
+| **High-entropy tokens** | Hex strings (32+ chars), base64 strings (40+ chars) |
+
+Detection runs from most specific to most generic, with deduplication to prevent overlapping matches.
+
+## Architecture
+
+### Encryption
+
+- **Algorithm:** AES-256-GCM (authenticated encryption)
+- **Key:** 32-byte key, base64-encoded (you generate and hold this)
+- **IV:** Random 12-byte initialization vector per secret (stored alongside ciphertext)
+- **Runtime:** Web Crypto API — works in Node.js 18+, browsers, and Cloudflare Workers
+
+### Zero-knowledge server
+
+The server stores:
+- `id` — vault entry identifier (`vlt_...`)
+- `encrypted_value` — base64-encoded ciphertext
+- `iv` — base64-encoded initialization vector
+- `secret_type` — what type of secret was detected (for analytics, not the value)
+- `conversation_id` — which conversation owns this entry
+- `organization_id` — tenant isolation
+
+The server **never** stores or sees:
+- The plaintext secret
+- Your encryption key
+- Any way to decrypt the data
+
+### Data flow
+
+**Write path (store):**
+
+```
+SDK detectSecrets(content)
+  → For each secret:
+      Generate vlt_ ID
+      Encrypt with AES-256-GCM + random IV
+      Replace in content with [VAULT:vlt_xxx]
+  → Send to server:
+      Modified content (with tokens)
+      Encrypted vault entries (opaque blobs)
+  → Server stores both
+```
+
+**Read path (resolve):**
+
+```
+SDK receives message with [VAULT:vlt_xxx] tokens
+  → Extract vault IDs from content
+  → Call resolve_vault tool to get encrypted blobs
+  → Decrypt each blob locally with your key
+  → Replace tokens with plaintext
+  → Return decrypted content
+```
+
+## MCP tools
+
+### append_messages (updated)
+
+The `append_messages` tool now accepts an optional `vault_entries` parameter:
+
+```json
+{
+  "conversation_id": "conv_abc",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Use [VAULT:vlt_x7Kd...] for auth"
+    }
+  ],
+  "vault_entries": [
+    {
+      "id": "vlt_x7Kd...",
+      "encrypted_value": "base64-ciphertext",
+      "iv": "base64-iv",
+      "secret_type": "api_key"
+    }
+  ]
+}
+```
+
+The SDK handles this automatically when vault is configured.
+
+### resolve_vault
+
+Retrieve encrypted vault entries by ID. Returns encrypted blobs — decryption happens client-side.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `vault_ids` | string[] | Yes | Vault entry IDs (max 50) |
+
+**Response:**
+
+```json
+{
+  "entries": [
+    {
+      "id": "vlt_x7Kd...",
+      "encrypted_value": "base64-ciphertext",
+      "iv": "base64-iv",
+      "secret_type": "api_key",
+      "conversation_id": "conv_abc",
+      "created_at": "2026-05-25T10:00:00Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+All vault access is audit-logged.
+
+## Key management
+
+### Generating keys
+
+```bash
+# CLI
+engram vault keygen --save
+
+# SDK
+import { generateVaultKey } from '@getengram/sdk'
+const key = await generateVaultKey()
+```
+
+### Storing keys
+
+| Method | Best for |
+|--------|----------|
+| `~/.engram/vault-key` | Local development, single machine |
+| `ENGRAM_VAULT_KEY` env var | CI/CD, containers, cloud deployments |
+| Secrets manager (AWS SSM, 1Password, etc.) | Production, team environments |
+
+### Key rotation
+
+Currently, key rotation requires re-encrypting existing vault entries. A built-in rotation command is planned for a future release.
+
+### Recovery
+
+**There is no recovery mechanism.** Engram never has your key. If you lose the key, all vaulted secrets in your conversations are permanently unrecoverable. The conversation content still contains `[VAULT:vlt_...]` tokens, but they cannot be decrypted.
+
+Back up your vault key in a secure location.
+
+## Integration examples
+
+### Claude Code
+
+In `~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "engram": {
+      "type": "http",
+      "url": "https://mcp.getengram.app/mcp",
+      "headers": {
+        "Authorization": "Bearer engram_sk_live_your_key"
+      }
+    }
+  }
+}
+```
+
+In your `CLAUDE.md`:
+
+```markdown
+## Engram Memory
+
+You have access to Engram for persistent memory. When storing conversations
+that contain secrets (API keys, credentials, connection strings), the SDK
+encrypts them client-side before sending.
+
+Environment: ENGRAM_VAULT_KEY is set — secrets are automatically protected.
+```
+
+### Custom agent with SDK
+
+```typescript
+import { Engram } from '@getengram/sdk'
+
+const engram = new Engram({
+  apiKey: process.env.ENGRAM_API_KEY!,
+  vault: { encryptionKey: process.env.ENGRAM_VAULT_KEY! },
+})
+
+// Agent stores conversation — secrets auto-encrypted
+await engram.store({
+  conversationId,
+  messages: agentMessages,
+})
+
+// Agent retrieves conversation — decrypt secrets
+const { messages } = await engram.getConversation(conversationId)
+const decrypted = await engram.resolveSecrets(messages)
+```
+
+## FAQ
+
+**Q: What happens if I don't configure a vault key?**
+Messages are stored as-is, with no secret detection or encryption. The server-side redaction fallback will mask obvious patterns, but client-side encryption is strongly recommended.
+
+**Q: Does vault encryption slow things down?**
+Negligibly. AES-256-GCM via Web Crypto is hardware-accelerated on modern systems. Encrypting a typical message adds < 1ms.
+
+**Q: Can I use different vault keys for different conversations?**
+Not with a single SDK instance. You'd need to create separate `Engram` clients with different vault configs.
+
+**Q: Are vault entries deleted when I delete a conversation?**
+Yes. Vault entries have a foreign key to conversations with `ON DELETE CASCADE`.
+
+**Q: What about secrets in search results?**
+Search results return chunk text which may contain `[VAULT:vlt_...]` tokens. Use `resolveSecrets()` to decrypt them.

--- a/packages/db/migrations/0010_named_secrets.sql
+++ b/packages/db/migrations/0010_named_secrets.sql
@@ -1,0 +1,19 @@
+-- Named secrets: explicit key-value secret storage with client-side encryption.
+-- Secrets are encrypted by the client (AES-256-GCM) before transmission.
+-- Server stores opaque blobs — zero-knowledge.
+
+CREATE TABLE IF NOT EXISTS named_secrets (
+  id TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  encrypted_value TEXT NOT NULL,
+  iv TEXT NOT NULL,
+  secret_type TEXT NOT NULL DEFAULT 'unknown',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+  UNIQUE(organization_id, name)
+);
+
+CREATE INDEX idx_named_secrets_org ON named_secrets(organization_id);
+CREATE INDEX idx_named_secrets_org_name ON named_secrets(organization_id, name);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8,3 +8,4 @@ export * from "./queries/seats.js";
 export * from "./queries/webhooks.js";
 export * from "./queries/audit-log.js";
 export * from "./queries/vault.js";
+export * from "./queries/named-secrets.js";

--- a/packages/db/src/queries/named-secrets.ts
+++ b/packages/db/src/queries/named-secrets.ts
@@ -1,0 +1,69 @@
+export function upsertNamedSecret(
+  db: D1Database,
+  params: {
+    id: string;
+    organizationId: string;
+    name: string;
+    encryptedValue: string;
+    iv: string;
+    secretType: string;
+  }
+) {
+  return db
+    .prepare(
+      `INSERT INTO named_secrets (id, organization_id, name, encrypted_value, iv, secret_type)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(organization_id, name) DO UPDATE SET
+         encrypted_value = excluded.encrypted_value,
+         iv = excluded.iv,
+         secret_type = excluded.secret_type,
+         updated_at = datetime('now')`
+    )
+    .bind(
+      params.id,
+      params.organizationId,
+      params.name,
+      params.encryptedValue,
+      params.iv,
+      params.secretType
+    )
+    .run();
+}
+
+export function getNamedSecret(
+  db: D1Database,
+  organizationId: string,
+  name: string
+) {
+  return db
+    .prepare(
+      "SELECT id, name, encrypted_value, iv, secret_type, created_at, updated_at FROM named_secrets WHERE organization_id = ? AND name = ?"
+    )
+    .bind(organizationId, name)
+    .first();
+}
+
+export function listNamedSecrets(
+  db: D1Database,
+  organizationId: string
+) {
+  return db
+    .prepare(
+      "SELECT id, name, secret_type, created_at, updated_at FROM named_secrets WHERE organization_id = ? ORDER BY name ASC"
+    )
+    .bind(organizationId)
+    .all();
+}
+
+export function deleteNamedSecret(
+  db: D1Database,
+  organizationId: string,
+  name: string
+) {
+  return db
+    .prepare(
+      "DELETE FROM named_secrets WHERE organization_id = ? AND name = ?"
+    )
+    .bind(organizationId, name)
+    .run();
+}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -7,6 +7,7 @@ import {
   type VaultConfig,
   type VaultEntry,
 } from "./vault.js";
+import { VaultManager } from "./vault-manager.js";
 import type {
   EngramConfig,
   CreateConversationParams,
@@ -51,6 +52,29 @@ const DEFAULT_TIMEOUT = 30_000;
 export class Engram {
   private transport: McpTransport;
   private vaultConfig: VaultConfig | null;
+
+  /**
+   * Named secrets manager. Store, retrieve, list, and delete
+   * named secrets with client-side encryption.
+   *
+   * Requires vault to be configured. Access via `engram.vault`.
+   *
+   * @example
+   * ```typescript
+   * await engram.vault.set('DATABASE_URL', 'postgres://...')
+   * const url = await engram.vault.get('DATABASE_URL')
+   * const secrets = await engram.vault.list()
+   * await engram.vault.delete('DATABASE_URL')
+   * ```
+   */
+  get vault(): VaultManager {
+    if (!this.vaultConfig) {
+      throw new EngramError(
+        "Vault is not configured. Pass vault.encryptionKey in the Engram constructor."
+      );
+    }
+    return new VaultManager(this.transport, this.vaultConfig);
+  }
 
   /**
    * Generate a new AES-256 vault encryption key.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export { Engram } from "./client.js";
+export { VaultManager } from "./vault-manager.js";
 export { EngramError, AuthenticationError, NotFoundError, TimeoutError } from "./errors.js";
 export { generateVaultKey } from "./vault.js";
 export type {
@@ -19,4 +20,5 @@ export type {
   ListConversationsParams,
   ListConversationsResponse,
   DeleteConversationResponse,
+  NamedSecretMetadata,
 } from "./types.js";

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -146,3 +146,12 @@ export interface ListConversationsResponse {
 export interface DeleteConversationResponse {
   deleted: boolean;
 }
+
+// ── Named Secrets ──
+
+export interface NamedSecretMetadata {
+  name: string;
+  secretType: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/sdk/src/vault-manager.ts
+++ b/packages/sdk/src/vault-manager.ts
@@ -1,0 +1,177 @@
+/**
+ * Named secrets manager. Provides explicit key-value secret storage
+ * with client-side encryption. Follows patterns from GitHub Secrets
+ * and HashiCorp Vault:
+ *
+ * - Values are encrypted client-side before transmission (zero-knowledge)
+ * - List only returns names and metadata, never values
+ * - All operations are audit-logged server-side
+ */
+
+import { McpTransport } from "./transport.js";
+import { EngramError } from "./errors.js";
+import type { VaultConfig } from "./vault.js";
+import type { NamedSecretMetadata } from "./types.js";
+
+// Import the crypto helpers from vault.ts
+// We need encrypt/decrypt but they're not exported — inline them here
+// to keep vault.ts unchanged.
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+async function importKey(base64Key: string): Promise<CryptoKey> {
+  const keyBytes = base64ToBytes(base64Key);
+  if (keyBytes.length !== 32) {
+    throw new Error(
+      `Vault encryption key must be 32 bytes (AES-256). Got ${keyBytes.length} bytes.`
+    );
+  }
+  return crypto.subtle.importKey(
+    "raw",
+    keyBytes.buffer as ArrayBuffer,
+    "AES-GCM",
+    false,
+    ["encrypt", "decrypt"]
+  );
+}
+
+async function encrypt(
+  key: CryptoKey,
+  plaintext: string
+): Promise<{ encrypted: string; iv: string }> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encoded = new TextEncoder().encode(plaintext);
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: iv.buffer as ArrayBuffer },
+    key,
+    encoded
+  );
+  return {
+    encrypted: bytesToBase64(new Uint8Array(ciphertext)),
+    iv: bytesToBase64(iv),
+  };
+}
+
+async function decrypt(
+  key: CryptoKey,
+  encryptedB64: string,
+  ivB64: string
+): Promise<string> {
+  const ciphertext = base64ToBytes(encryptedB64);
+  const iv = base64ToBytes(ivB64);
+  const plainBytes = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: iv.buffer as ArrayBuffer },
+    key,
+    ciphertext.buffer as ArrayBuffer
+  );
+  return new TextDecoder().decode(plainBytes);
+}
+
+// Simple secret type detection for named secrets
+function detectSecretType(value: string): string {
+  if (/-----BEGIN\s+(RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/.test(value)) return "private_key";
+  if (/\bsk-[A-Za-z0-9]{20,}\b/.test(value)) return "api_key";
+  if (/\bsk-ant-[A-Za-z0-9_-]{20,}\b/.test(value)) return "api_key";
+  if (/\bAKIA[0-9A-Z]{16}\b/.test(value)) return "api_key";
+  if (/\b(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}\b/.test(value)) return "api_key";
+  if (/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/.test(value)) return "jwt";
+  if (/\b(postgres|postgresql|mysql|redis|mongodb)(:\/\/|%3A%2F%2F)/i.test(value)) return "connection_string";
+  if (/\b\d{3}-\d{2}-\d{4}\b/.test(value)) return "ssn";
+  return "secret";
+}
+
+export class VaultManager {
+  constructor(
+    private transport: McpTransport,
+    private vaultConfig: VaultConfig
+  ) {}
+
+  /**
+   * Store a named secret. The value is encrypted client-side before
+   * being sent to the server. If a secret with this name already exists,
+   * it is overwritten.
+   *
+   * @param name - Secret name (e.g. DATABASE_URL, OPENAI_KEY)
+   * @param value - Plaintext secret value (encrypted before transmission)
+   */
+  async set(name: string, value: string): Promise<void> {
+    const key = await importKey(this.vaultConfig.encryptionKey);
+    const { encrypted, iv } = await encrypt(key, value);
+    const secretType = detectSecretType(value);
+
+    const raw = await this.transport.callTool("vault_set", {
+      name,
+      encrypted_value: encrypted,
+      iv,
+      secret_type: secretType,
+    });
+
+    const data = JSON.parse(raw);
+    if (data.error) {
+      throw new EngramError(data.error);
+    }
+  }
+
+  /**
+   * Retrieve a named secret. The encrypted blob is fetched from the
+   * server and decrypted locally with your vault key.
+   *
+   * @param name - Secret name to retrieve
+   * @returns The plaintext secret value, or null if not found
+   */
+  async get(name: string): Promise<string | null> {
+    const raw = await this.transport.callTool("vault_get", { name });
+    const data = JSON.parse(raw);
+
+    if (data.error) {
+      return null;
+    }
+
+    const key = await importKey(this.vaultConfig.encryptionKey);
+    return decrypt(key, data.encrypted_value, data.iv);
+  }
+
+  /**
+   * List all named secrets. Returns names and metadata only —
+   * never values or encrypted blobs.
+   */
+  async list(): Promise<NamedSecretMetadata[]> {
+    const raw = await this.transport.callTool("vault_list", {});
+    const data = JSON.parse(raw);
+
+    return (data.secrets ?? []).map((s: Record<string, unknown>) => ({
+      name: s.name as string,
+      secretType: s.secret_type as string,
+      createdAt: s.created_at as string,
+      updatedAt: s.updated_at as string,
+    }));
+  }
+
+  /**
+   * Delete a named secret permanently. This cannot be undone.
+   *
+   * @param name - Secret name to delete
+   * @returns true if deleted, false if not found
+   */
+  async delete(name: string): Promise<boolean> {
+    const raw = await this.transport.callTool("vault_delete", { name });
+    const data = JSON.parse(raw);
+
+    if (data.error) {
+      return false;
+    }
+
+    return data.deleted === true;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds **named secrets manager** — explicit key-value secret storage with client-side encryption, following patterns from GitHub Secrets (stdin input, list shows names only) and HashiCorp Vault (set/get/list/delete verbs, audit logging)
- Adds comprehensive **vault documentation** across all doc pages (previously the vault feature was completely undocumented)

## Named Secrets Manager

| Layer | What's new |
|-------|-----------|
| **CLI** | `vault set`, `vault get`, `vault list`, `vault delete` — supports stdin, `--value` flag, and positional args |
| **SDK** | `engram.vault.set()`, `.get()`, `.list()`, `.delete()` via new `VaultManager` class |
| **MCP** | `vault_set`, `vault_get`, `vault_list`, `vault_delete` tools (11 tools total now) |
| **DB** | `named_secrets` table with `UPSERT` support + org-scoped unique name constraint |

### Key design decisions

- **Stdin input** (like `gh secret set`) — `echo "value" | engram vault set NAME` avoids shell history exposure
- **List never shows values** — only names, types, and timestamps
- **Auto type detection** — secret type (api_key, connection_string, etc.) inferred from value patterns
- **All operations audit-logged** — vault.set, vault.get, vault.list, vault.delete
- **Client-side encryption** — AES-256-GCM, server stores opaque blobs, zero-knowledge

### Claude Code integration

```bash
echo "sk-abc123..." | engram vault set OPENAI_KEY
engram vault get OPENAI_KEY  # used by agents via shell
```

## Documentation

| File | Status |
|------|--------|
| `docs/vault.md` | **New** — dedicated vault guide with both auto-detection and named secrets |
| `docs/sdk.md` | Updated — vault config, resolveSecrets, generateVaultKey, vault manager |
| `docs/cli.md` | Updated — all vault commands with examples |
| `docs/security.md` | Updated — client-side encryption, three-layer security model |
| `docs/api-reference.md` | Updated — all 11 MCP tools documented |
| `docs/getting-started.md` | Updated — protecting secrets section |
| `docs/faq.md` | Updated — vault Q&As |
| `docs/architecture.md` | Updated — named_secrets table, vault in write path |

## Test plan

- [x] All 238 tests pass (5/5 packages)
- [x] Build passes (5/5 packages)
- [x] MCP contract test updated — 11 tools registered
- [x] Migration: `0010_named_secrets.sql`

Closes #142, closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)