### PR TITLE
feat: /billing/verify-session endpoint for auto-sign-in after upgrade

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -9,7 +9,7 @@ import { seats } from "./routes/seats.js";
 import { webhooks } from "./routes/webhooks.js";
 import { usage } from "./routes/usage.js";
 import { signup } from "./routes/signup.js";
-import { billing, billingWebhook } from "./routes/billing.js";
+import { billing, billingSession, billingWebhook } from "./routes/billing.js";
 import { admin } from "./routes/admin.js";
 import { account } from "./routes/account.js";
 import { dataExport } from "./routes/export.js";
@@ -64,6 +64,18 @@ app.route("/signup", signup);
 // Stripe webhook — public, verified by HMAC signature instead of API key.
 // Mounted BEFORE the /api/* auth middleware so it isn't gated.
 app.route("/billing/webhook", billingWebhook);
+
+// Public session verification — lets the upgrade success page look up the
+// org after a Stripe checkout without needing an API key.
+app.use(
+  "/billing/verify-session",
+  cors({
+    origin: BROWSER_ORIGINS,
+    allowMethods: ["POST", "OPTIONS"],
+    allowHeaders: ["Content-Type"],
+  }),
+);
+app.route("/billing/verify-session", billingSession);
 
 // Admin routes — protected by ADMIN_SECRET, not API key auth.
 app.use("/admin/*", async (c, next) => {

--- a/apps/mcp-server/src/routes/billing.ts
+++ b/apps/mcp-server/src/routes/billing.ts
@@ -130,6 +130,69 @@ billing.post("/portal", async (c) => {
 export { billing };
 
 // ---------------------------------------------------------------------------
+// Public session verification — lets the success page look up org info from
+// a Stripe checkout session_id (unguessable). No API key needed.
+// ---------------------------------------------------------------------------
+
+export const billingSession = new Hono<{ Bindings: Env }>();
+
+interface StripeCheckoutSession {
+  id: string;
+  status: string;
+  metadata: Record<string, string>;
+  customer_details?: { email?: string };
+}
+
+billingSession.post("/", async (c) => {
+  const body = await c.req.json<{ session_id?: string }>().catch(() => ({}));
+  const sessionId = (body as { session_id?: string }).session_id;
+  if (!sessionId || !sessionId.startsWith("cs_")) {
+    return c.json({ error: "invalid_session_id" }, 400);
+  }
+
+  // Look up the checkout session from Stripe
+  const stripeKey = c.env.STRIPE_SECRET_KEY;
+  if (!stripeKey) {
+    return c.json({ error: "stripe_not_configured" }, 500);
+  }
+
+  const res = await fetch(
+    `https://api.stripe.com/v1/checkout/sessions/${sessionId}`,
+    {
+      headers: { Authorization: `Bearer ${stripeKey}` },
+    },
+  );
+  if (!res.ok) {
+    return c.json({ error: "session_not_found" }, 404);
+  }
+
+  const session = (await res.json()) as StripeCheckoutSession;
+  if (session.status !== "complete") {
+    return c.json({ error: "session_not_complete" }, 400);
+  }
+
+  const orgId = session.metadata?.organization_id;
+  if (!orgId) {
+    return c.json({ error: "no_organization" }, 400);
+  }
+
+  const org = (await getOrganizationById(c.env.DB, orgId)) as {
+    id: string;
+    email: string | null;
+    tier: string;
+  } | null;
+  if (!org) {
+    return c.json({ error: "organization_not_found" }, 404);
+  }
+
+  return c.json({
+    organization_id: org.id,
+    email: org.email,
+    tier: org.tier,
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Public webhook handler (NOT authed — verified by HMAC signature instead)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
New public endpoint `POST /billing/verify-session` that takes a Stripe `session_id` and returns the org's email and tier. This lets the upgrade success page on engram-web auto-create a Supabase account and sign the user in after payment.

- No API key auth needed — session IDs are unguessable Stripe-generated strings
- Only returns data for completed checkout sessions
- CORS enabled for the marketing site origins

Refs #145. Dashboard changes in get-engram/engram-web.

## Test plan
- [ ] `POST /billing/verify-session` with valid session_id returns org info
- [ ] Invalid/incomplete session_id returns appropriate error
- [ ] CORS headers present for getengram.app origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)