### PR TITLE
chore: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 *.tsbuildinfo
 .env
 supabase/.temp/
+.claude/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore` to prevent Claude Code project files from being committed.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)