### PR TITLE
fix: prevent duplicate subscriptions, add email update

### DIFF
--- a/apps/mcp-server/src/routes/account.ts
+++ b/apps/mcp-server/src/routes/account.ts
@@ -4,6 +4,7 @@ import {
   getOrganizationStats,
   softDeleteOrganization,
   restoreOrganization,
+  setOrganizationEmail,
 } from "@getengram/db";
 import { audit } from "../services/audit.js";
 import type { Env, AuthContext } from "../types.js";
@@ -11,6 +12,23 @@ import type { Env, AuthContext } from "../types.js";
 type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
 
 const account = new Hono<HonoEnv>();
+
+// PATCH /api/account — update organization settings (email)
+account.patch("/", async (c) => {
+  const auth = c.get("auth");
+  const orgId = auth.organizationId;
+  const body = await c.req.json<{ email?: string }>().catch(() => ({}));
+  const email = (body as { email?: string }).email?.trim();
+
+  if (!email || !email.includes("@")) {
+    return c.json({ error: "invalid_email", message: "A valid email is required" }, 400);
+  }
+
+  await setOrganizationEmail(c.env.DB, orgId, email);
+  audit(c.env.DB, orgId, auth.apiKeyId, "account.update_email");
+
+  return c.json({ updated: true, email });
+});
 
 // DELETE /api/account — soft-delete the organization (30-day grace period)
 account.delete("/", async (c) => {

--- a/apps/mcp-server/src/routes/billing.ts
+++ b/apps/mcp-server/src/routes/billing.ts
@@ -76,6 +76,25 @@ billing.post("/checkout", async (c) => {
     await setOrganizationStripeCustomer(c.env.DB, org.id, customerId);
   }
 
+  // If the customer already has an active subscription for this price,
+  // send them to the billing portal instead of creating a duplicate.
+  if (customerId) {
+    const subsRes = await fetch(
+      `https://api.stripe.com/v1/subscriptions?customer=${customerId}&status=active&price=${priceId}&limit=1`,
+      { headers: { Authorization: `Bearer ${c.env.STRIPE_SECRET_KEY}` } },
+    );
+    if (subsRes.ok) {
+      const subs = (await subsRes.json()) as { data: unknown[] };
+      if (subs.data.length > 0) {
+        const portal = await createPortalSession(c.env.STRIPE_SECRET_KEY, {
+          customerId,
+          returnUrl: `${c.env.APP_URL}/dashboard`,
+        });
+        return c.json({ url: portal.url, already_subscribed: true, plan });
+      }
+    }
+  }
+
   const successUrl =
     body.success_url ||
     `${c.env.APP_URL}/upgrade/success?session_id={CHECKOUT_SESSION_ID}`;

--- a/apps/mcp-server/src/services/audit.ts
+++ b/apps/mcp-server/src/services/audit.ts
@@ -8,6 +8,7 @@ export type AuditAction =
   | "conversation.list"
   | "conversation.delete"
   | "messages.append"
+  | "account.update_email"
   | "account.delete"
   | "account.restore"
   | "data.export"


### PR DESCRIPTION
## Summary

- Checkout endpoint checks for active subscription before creating a new one — returns billing portal URL if already subscribed
- Added `PATCH /api/account` for updating organization email
- Already deployed

## Test plan

- [ ] `engram upgrade pro` when already subscribed → opens billing portal
- [ ] `PATCH /api/account` with `{"email":"new@example.com"}` updates org email

🤖 Generated with [Claude Code](https://claude.com/claude-code)