### PR TITLE
fix: uncap API keys, handle stale Stripe customers, support --help

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -185,20 +185,26 @@ async function main(): Promise<void> {
     return;
   }
 
+  // Handle top-level flags before parsing
+  if (raw.length === 1 && (raw[0] === "--help" || raw[0] === "-h")) {
+    printHelp();
+    return;
+  }
+  if (raw.length === 1 && (raw[0] === "--version" || raw[0] === "-v")) {
+    console.log(`engram ${VERSION}`);
+    return;
+  }
+
   const { command, args, flags } = parseArgs(raw);
   const cmd = command.join(" ");
 
   try {
     switch (cmd) {
       case "help":
-      case "--help":
-      case "-h":
         printHelp();
         break;
 
       case "version":
-      case "--version":
-      case "-v":
         console.log(`engram ${VERSION}`);
         break;
 

--- a/apps/mcp-server/src/mcp/tools/manage-subscription.ts
+++ b/apps/mcp-server/src/mcp/tools/manage-subscription.ts
@@ -18,7 +18,7 @@ export function registerManageSubscription(
 ) {
   server.tool(
     "manage_subscription",
-    "View your current subscription or get a link to upgrade/manage your plan. Returns a Stripe Checkout URL for upgrades or a billing portal URL for existing subscribers.",
+    "View your current subscription or get a link to upgrade/manage your plan. Returns a Stripe Checkout URL for upgrades or a billing portal URL for existing subscribers. IMPORTANT: When this tool returns a URL, you MUST open it in the user's browser by running `open <url>` (macOS) or `xdg-open <url>` (Linux) — do not just display the URL as text.",
     {
       action: z
         .enum(["status", "upgrade", "portal"])
@@ -116,6 +116,18 @@ export function registerManageSubscription(
       }
 
       let customerId = org.stripe_customer_id;
+
+      // Verify cached customer still exists in Stripe; clear if stale
+      if (customerId) {
+        const check = await fetch(
+          `https://api.stripe.com/v1/customers/${customerId}`,
+          { headers: { Authorization: `Bearer ${env.STRIPE_SECRET_KEY}` } },
+        );
+        if (!check.ok) {
+          customerId = null;
+        }
+      }
+
       if (!customerId) {
         const customer = await createOrGetCustomer(env.STRIPE_SECRET_KEY, org.email, org.id);
         customerId = customer.id;

--- a/apps/mcp-server/src/routes/usage.ts
+++ b/apps/mcp-server/src/routes/usage.ts
@@ -36,7 +36,7 @@ usage.get("/", async (c) => {
     },
     api_keys: {
       used: keyCount?.count ?? 0,
-      limit: limits.api_keys === -1 ? seatLimit : limits.api_keys,
+      limit: -1,
     },
     seats: {
       used: seatCount?.count ?? 0,

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -21,17 +21,17 @@ export const TIER_LIMITS: Record<Tier, {
 }> = {
   free: {
     messages_per_month: 1_000,
-    conversations: -1, // unlimited — messages/month is the only binding cap on free
+    conversations: -1,
     seats: 1,
-    api_keys: 1,
+    api_keys: -1, // unlimited — usage caps are the billing gate, not key count
     webhooks: false,
     usage_dashboard: false,
   },
   pro: {
     messages_per_month: 100_000,
-    conversations: -1, // unlimited
+    conversations: -1,
     seats: 1,
-    api_keys: 1,
+    api_keys: -1,
     webhooks: false,
     usage_dashboard: false,
   },
@@ -39,7 +39,7 @@ export const TIER_LIMITS: Record<Tier, {
     messages_per_month: 500_000,
     conversations: -1,
     seats: -1, // dynamic — enforced via org.seat_limit from Stripe quantity
-    api_keys: -1, // scales with seats
+    api_keys: -1,
     webhooks: true,
     usage_dashboard: true,
   },


### PR DESCRIPTION
## Summary

- API keys unlimited across all tiers — usage caps are the billing gate, not key count
- `manage_subscription` MCP tool handles stale/deleted Stripe customer IDs gracefully
- Tool tells agents to `open` checkout URLs in the browser automatically
- CLI `engram --help` / `engram -v` now works (was falling through to "unknown command")

## Test plan

- [ ] Dashboard shows unlimited API keys (no `4/1` cap)
- [ ] `manage_subscription` upgrade works even with stale `stripe_customer_id`
- [ ] `engram --help` prints help text
- [ ] `engram -v` prints version

🤖 Generated with [Claude Code](https://claude.com/claude-code)