### PR TITLE
feat(oauth): connected-apps list + revoke API

### DIFF
--- a/apps/mcp-server/src/__tests__/oauth-helpers.ts
+++ b/apps/mcp-server/src/__tests__/oauth-helpers.ts
@@ -80,6 +80,13 @@ export function createOAuthD1(): D1Database {
         }
         return { results: [], success: true, meta: {} };
       }
+      const del = sql.match(/DELETE\s+FROM\s+(\w+)\s+WHERE\s/is);
+      if (del) {
+        const name = del[1];
+        const w = parseWhere(sql, args);
+        tables[name] = table(name).filter((r) => !matches(r, w));
+        return { results: [], success: true, meta: {} };
+      }
       return { results: [], success: true, meta: {} };
     }),
     first: vi.fn(async () => {
@@ -99,7 +106,27 @@ export function createOAuthD1(): D1Database {
       const from = sql.match(/FROM\s+(\w+)/i);
       if (!from) return { results: [], success: true, meta: {} };
       const w = parseWhere(sql, args);
-      return { results: table(from[1]).filter((r) => matches(r, w)), success: true, meta: {} };
+      const rows = table(from[1]).filter((r) => matches(r, w));
+      // Connected-apps query: JOIN oauth_clients + GROUP BY client. Shape the
+      // rows like the real SELECT (client_id, client_name, authorized_at) and
+      // dedup by client_id to mimic GROUP BY.
+      if (/JOIN\s+oauth_clients/i.test(sql)) {
+        const byClient = new Map<string, Row>();
+        for (const r of rows) {
+          const client = table("oauth_clients").find((c) => c.id === r.client_id);
+          const existing = byClient.get(r.client_id as string);
+          if (!existing || String(r.created_at) > String(existing.authorized_at)) {
+            byClient.set(r.client_id as string, {
+              client_id: r.client_id,
+              client_name: client?.client_name ?? "Application",
+              authorized_at: r.created_at,
+              expires_at: r.expires_at,
+            });
+          }
+        }
+        return { results: [...byClient.values()], success: true, meta: {} };
+      }
+      return { results: rows, success: true, meta: {} };
     }),
   });
 

--- a/apps/mcp-server/src/__tests__/oauth.test.ts
+++ b/apps/mcp-server/src/__tests__/oauth.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import app from "../index.js";
-import { verifyPkceS256, sha256Base64Url } from "@getengram/shared";
+import {
+  verifyPkceS256,
+  sha256Base64Url,
+  hashApiKey,
+  generateApiKeyRaw,
+} from "@getengram/shared";
 import {
   createOAuthD1,
   createOAuthEnv,
@@ -9,6 +14,14 @@ import {
 } from "./oauth-helpers.js";
 
 const REDIRECT = "https://chatgpt.com/connector/callback";
+
+// API-key auth updates last_used_at via executionCtx.waitUntil; tests must
+// supply a mock context (the OAuth-token path doesn't need it).
+const MOCK_CTX = {
+  waitUntil: () => {},
+  passThroughOnException: () => {},
+  props: {},
+} as unknown as ExecutionContext;
 
 function form(fields: Record<string, string>): Request {
   return new Request("http://mcp.test/oauth/token", {
@@ -36,13 +49,14 @@ async function getAuthCode(
   env: ReturnType<typeof createOAuthEnv>,
   clientId: string,
   challenge: string,
+  email = "alice@example.com",
 ): Promise<string> {
   const approve = await app.fetch(
     new Request("http://mcp.test/oauth/authorize/approve", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        supabase_token: await signSupabaseJwt("alice@example.com"),
+        supabase_token: await signSupabaseJwt(email),
         client_id: clientId,
         redirect_uri: REDIRECT,
         code_challenge: challenge,
@@ -336,5 +350,92 @@ describe("Access token authenticates the MCP endpoint", () => {
     );
     expect(bad.status).toBe(401);
     expect(bad.headers.get("WWW-Authenticate")).toContain("resource_metadata");
+  });
+});
+
+describe("Connected apps management (/api/oauth/connections)", () => {
+  // Seed an org + API key, then connect an app (OAuth) to the same org so the
+  // API-key-authenticated dashboard can list and revoke it.
+  async function setup() {
+    const db = createOAuthD1();
+    const env = createOAuthEnv(db);
+    const { raw: apiKey, prefix } = generateApiKeyRaw();
+    const email = "apps@example.com";
+
+    await db.prepare("INSERT INTO organizations (id, name, email, tier) VALUES (?, ?, ?, ?)")
+      .bind("org_ca", "Apps Org", email, "free").run();
+    await db.prepare("INSERT INTO api_keys (id, organization_id, key_hash, key_prefix, name, expires_at) VALUES (?, ?, ?, ?, ?, ?)")
+      .bind("key_ca", "org_ca", await hashApiKey(apiKey), prefix, "Default", "2999-01-01 00:00:00").run();
+
+    // Connect an app via the full OAuth flow (same email → same org).
+    const clientId = await registerClient(env);
+    const { verifier, challenge } = await pkcePair();
+    const code = await getAuthCode(env, clientId, challenge, email);
+    const tok = (await (await app.fetch(
+      form({ grant_type: "authorization_code", client_id: clientId, code, redirect_uri: REDIRECT, code_verifier: verifier }),
+      env,
+    )).json()) as { access_token: string };
+
+    return { env, apiKey, clientId, accessToken: tok.access_token };
+  }
+
+  const listReq = (apiKey: string) =>
+    new Request("http://mcp.test/api/oauth/connections", { headers: { Authorization: `Bearer ${apiKey}` } });
+
+  it("lists a connected app for the org", async () => {
+    const { env, apiKey, clientId } = await setup();
+    const res = await app.fetch(listReq(apiKey), env, MOCK_CTX);
+    expect(res.status).toBe(200);
+    const { connections } = (await res.json()) as { connections: Array<{ client_id: string; client_name: string }> };
+    expect(connections).toHaveLength(1);
+    expect(connections[0].client_id).toBe(clientId);
+    expect(connections[0].client_name).toBe("ChatGPT");
+  });
+
+  it("revokes a connection and drops it from the list", async () => {
+    const { env, apiKey, clientId } = await setup();
+    const del = await app.fetch(
+      new Request(`http://mcp.test/api/oauth/connections/${clientId}`, {
+        method: "DELETE", headers: { Authorization: `Bearer ${apiKey}` },
+      }),
+      env,
+      MOCK_CTX,
+    );
+    expect(del.status).toBe(200);
+    expect(((await del.json()) as { revoked: boolean }).revoked).toBe(true);
+
+    const after = (await (await app.fetch(listReq(apiKey), env, MOCK_CTX)).json()) as { connections: unknown[] };
+    expect(after.connections).toHaveLength(0);
+  });
+
+  it("revoking invalidates the app's access token on /mcp", async () => {
+    const { env, apiKey, clientId, accessToken } = await setup();
+    // Token works before revoke.
+    const before = await app.fetch(
+      new Request("http://mcp.test/mcp", { method: "POST", headers: { Authorization: `Bearer ${accessToken}` } }),
+      env,
+    );
+    expect(before.status).not.toBe(401);
+
+    await app.fetch(
+      new Request(`http://mcp.test/api/oauth/connections/${clientId}`, {
+        method: "DELETE", headers: { Authorization: `Bearer ${apiKey}` },
+      }),
+      env,
+      MOCK_CTX,
+    );
+
+    // Access token deleted → 401.
+    const after = await app.fetch(
+      new Request("http://mcp.test/mcp", { method: "POST", headers: { Authorization: `Bearer ${accessToken}` } }),
+      env,
+    );
+    expect(after.status).toBe(401);
+  });
+
+  it("requires authentication", async () => {
+    const { env } = await setup();
+    const res = await app.fetch(new Request("http://mcp.test/api/oauth/connections"), env);
+    expect(res.status).toBe(401);
   });
 });

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -13,6 +13,7 @@ import { billing, billingSession, billingWebhook } from "./routes/billing.js";
 import { admin } from "./routes/admin.js";
 import { account } from "./routes/account.js";
 import { dataExport } from "./routes/export.js";
+import { oauthConnections } from "./routes/oauth-connections.js";
 import { purgeDeletedOrganizations } from "./cron/purge-deleted.js";
 import { oauth } from "./oauth/router.js";
 import {
@@ -129,6 +130,7 @@ app.route("/api/webhooks", webhooks);
 app.route("/api/usage", usage);
 app.route("/api/account", account);
 app.route("/api/export", dataExport);
+app.route("/api/oauth/connections", oauthConnections);
 
 export default {
   fetch: app.fetch,

--- a/apps/mcp-server/src/routes/oauth-connections.ts
+++ b/apps/mcp-server/src/routes/oauth-connections.ts
@@ -1,0 +1,51 @@
+import { Hono } from "hono";
+import { getConnectedAppsByOrg, revokeOAuthConnection } from "@getengram/db";
+import { audit } from "../services/audit.js";
+import type { Env, AuthContext } from "../types.js";
+
+type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
+
+// Dashboard-facing management of OAuth connections (e.g. ChatGPT). Mounted
+// under /api/* so it's gated by the standard API-key auth middleware.
+const oauthConnections = new Hono<HonoEnv>();
+
+interface ConnectionRow {
+  client_id: string;
+  client_name: string;
+  authorized_at: string;
+  expires_at: string;
+}
+
+// List the apps connected to this org via OAuth.
+oauthConnections.get("/", async (c) => {
+  const auth = c.get("auth");
+  const result = await getConnectedAppsByOrg(c.env.DB, auth.organizationId);
+  const connections = (result.results as unknown as ConnectionRow[]).map((r) => ({
+    client_id: r.client_id,
+    client_name: r.client_name,
+    authorized_at: r.authorized_at,
+  }));
+  return c.json({ connections });
+});
+
+// Revoke this org's connection to a client — deletes its access tokens and
+// revokes its refresh tokens. The app must re-authorize to reconnect.
+oauthConnections.delete("/:clientId", async (c) => {
+  const auth = c.get("auth");
+  const clientId = c.req.param("clientId");
+
+  await revokeOAuthConnection(c.env.DB, auth.organizationId, clientId);
+
+  audit(
+    c.env.DB,
+    auth.organizationId,
+    auth.apiKeyId,
+    "oauth.connection.revoked",
+    "oauth_client",
+    clientId,
+  );
+
+  return c.json({ revoked: true });
+});
+
+export { oauthConnections };

--- a/apps/mcp-server/src/services/audit.ts
+++ b/apps/mcp-server/src/services/audit.ts
@@ -22,7 +22,8 @@ export type AuditAction =
   | "subscription.status"
   | "subscription.portal"
   | "subscription.checkout"
-  | "subscription.upgrade_redirect";
+  | "subscription.upgrade_redirect"
+  | "oauth.connection.revoked";
 
 /**
  * Fire-and-forget audit log entry. Never throws — audit logging

--- a/packages/db/src/queries/oauth.ts
+++ b/packages/db/src/queries/oauth.ts
@@ -217,3 +217,54 @@ export function revokeRefreshTokenChain(
     .bind(clientId, organizationId)
     .run();
 }
+
+// ---------------------------------------------------------------------------
+// Connected apps (dashboard "manage access")
+// ---------------------------------------------------------------------------
+
+/**
+ * List the OAuth apps an org has an active connection to. A connection is a
+ * live (non-revoked, unexpired) refresh token — the durable grant that
+ * outlives the 1-hour access tokens. One row per client.
+ */
+export function getConnectedAppsByOrg(db: D1Database, organizationId: string) {
+  return db
+    .prepare(
+      `SELECT c.id AS client_id,
+              COALESCE(c.client_name, 'Application') AS client_name,
+              MAX(r.created_at) AS authorized_at,
+              MAX(r.expires_at) AS expires_at
+       FROM oauth_refresh_tokens r
+       JOIN oauth_clients c ON c.id = r.client_id
+       WHERE r.organization_id = ?
+         AND r.revoked_at IS NULL
+         AND r.expires_at > datetime('now')
+       GROUP BY c.id, c.client_name
+       ORDER BY authorized_at DESC`,
+    )
+    .bind(organizationId)
+    .all();
+}
+
+/**
+ * Revoke an org's connection to a client: delete its access tokens and revoke
+ * its refresh tokens. The app must re-run the OAuth flow to reconnect.
+ */
+export function revokeOAuthConnection(
+  db: D1Database,
+  organizationId: string,
+  clientId: string,
+) {
+  return db.batch([
+    db
+      .prepare(
+        "DELETE FROM oauth_access_tokens WHERE organization_id = ? AND client_id = ?",
+      )
+      .bind(organizationId, clientId),
+    db
+      .prepare(
+        "UPDATE oauth_refresh_tokens SET revoked_at = datetime('now') WHERE organization_id = ? AND client_id = ? AND revoked_at IS NULL",
+      )
+      .bind(organizationId, clientId),
+  ]);
+}


### PR DESCRIPTION
Worker side of Connected Apps management (#181) — lets users see and revoke the OAuth apps connected to their org (e.g. ChatGPT).

## Endpoints (under `/api/*`, API-key auth)
- `GET /api/oauth/connections` — list connected apps (one row per client with a live, non-revoked, unexpired refresh token). Returns `{ connections: [{ client_id, client_name, authorized_at }] }`.
- `DELETE /api/oauth/connections/:clientId` — delete the client's access tokens + revoke its refresh tokens; audit-logged as `oauth.connection.revoked`. The app must re-run the OAuth flow to reconnect.

## DB
`getConnectedAppsByOrg` / `revokeOAuthConnection` (batched delete + revoke).

## Tests (+4, 120 total)
list shows a connected app · revoke drops it from the list · revoke invalidates the app's access token on `/mcp` · endpoint requires auth. Typecheck clean.

The engram-web dashboard UI that consumes these lands in a companion PR.

Refs #168. Part of #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)