### PR TITLE
feat(mcp): tool annotations + server instructions (App Directory prep)

### DIFF
--- a/apps/mcp-server/src/__tests__/mcp-tools-contract.test.ts
+++ b/apps/mcp-server/src/__tests__/mcp-tools-contract.test.ts
@@ -41,6 +41,7 @@ interface CapturedTool {
   name: string;
   description: string;
   schema: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
   handler: ToolHandler;
 }
 
@@ -50,8 +51,14 @@ function createCaptureServer(): {
 } {
   const tools = new Map<string, CapturedTool>();
   const server = {
-    tool: (name: string, description: string, schema: Record<string, unknown>, handler: ToolHandler) => {
-      tools.set(name, { name, description, schema, handler });
+    // tool() is variadic: (name, description, schema, [annotations], handler).
+    // The handler is always the last argument.
+    tool: (name: string, description: string, ...rest: unknown[]) => {
+      const handler = rest[rest.length - 1] as ToolHandler;
+      const schema = (rest.length >= 2 ? rest[0] : {}) as Record<string, unknown>;
+      const annotations =
+        rest.length >= 3 ? (rest[1] as Record<string, unknown>) : undefined;
+      tools.set(name, { name, description, schema, annotations, handler });
     },
   } as unknown as McpServer;
   return { server, tools };
@@ -311,6 +318,49 @@ describe("MCP tool contract — wire field names", () => {
 
       const registered = Array.from(tools.keys()).sort();
       expect(registered).toEqual(EXPECTED_TOOL_NAMES);
+    });
+
+    it("declares accurate tool annotations (App Directory requirement)", () => {
+      const { server, tools } = createCaptureServer();
+      registerCreateConversation(server, env, auth);
+      registerAppendMessages(server, env, auth);
+      registerSearch(server, env, auth);
+      registerGetConversation(server, env, auth);
+      registerListConversations(server, env, auth);
+      registerDeleteConversation(server, env, auth);
+      registerResolveVault(server, env, auth);
+      registerVaultSet(server, env, auth);
+      registerVaultGet(server, env, auth);
+      registerVaultList(server, env, auth);
+      registerVaultDelete(server, env, auth);
+
+      // read-only tools
+      for (const name of [
+        "search",
+        "get_conversation",
+        "list_conversations",
+        "resolve_vault",
+        "vault_get",
+        "vault_list",
+      ]) {
+        const a = tools.get(name)!.annotations;
+        expect(a, name).toBeDefined();
+        expect(a!.readOnlyHint, name).toBe(true);
+      }
+
+      // write (non-destructive) tools
+      for (const name of ["create_conversation", "append_messages", "vault_set"]) {
+        const a = tools.get(name)!.annotations;
+        expect(a!.readOnlyHint, name).toBe(false);
+        expect(a!.destructiveHint, name).toBe(false);
+      }
+
+      // destructive tools
+      for (const name of ["delete_conversation", "vault_delete"]) {
+        const a = tools.get(name)!.annotations;
+        expect(a!.readOnlyHint, name).toBe(false);
+        expect(a!.destructiveHint, name).toBe(true);
+      }
     });
   });
 });

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -13,11 +13,23 @@ import { registerVaultDelete } from "./tools/vault-delete.js";
 import { registerManageSubscription } from "./tools/manage-subscription.js";
 import type { Env, AuthContext } from "../types.js";
 
+// Surfaced to clients (ChatGPT, Claude, …) in the MCP `initialize` response so
+// the model knows to use Engram for memory proactively, without being asked —
+// and that it owns the conversation_id rather than asking the user for one.
+const SERVER_INSTRUCTIONS = `Engram is persistent, searchable memory for AI agents. Use it proactively, without waiting to be asked.
+
+- At the start of a task or session, call \`search\` with a short summary of the user's request to recall relevant prior context, and use what you find.
+- When something worth remembering is established — decisions, preferences, facts, project or personal context — persist it: call \`create_conversation\` once to get a conversation_id (you own this id; never ask the user for it), then \`append_messages\` to store the user's message and your reply verbatim. Reuse that same conversation_id for the rest of the session.
+- Do not store trivial chatter (greetings, acknowledgements). Storage is verbatim and searchable by meaning.`;
+
 export function createMcpServer(env: Env, auth: AuthContext): McpServer {
-  const server = new McpServer({
-    name: "Engram",
-    version: "0.1.0",
-  });
+  const server = new McpServer(
+    {
+      name: "Engram",
+      version: "0.1.0",
+    },
+    { instructions: SERVER_INSTRUCTIONS },
+  );
 
   registerCreateConversation(server, env, auth);
   registerAppendMessages(server, env, auth);

--- a/apps/mcp-server/src/mcp/tools/append-messages.ts
+++ b/apps/mcp-server/src/mcp/tools/append-messages.ts
@@ -13,9 +13,11 @@ export function registerAppendMessages(
 ) {
   server.tool(
     "append_messages",
-    "Append messages to a conversation. Messages are stored verbatim and automatically chunked + embedded for search. Optionally accepts client-encrypted vault entries for secrets detected client-side.",
+    "Append messages to a conversation, stored verbatim and automatically chunked + embedded for search. If you don't have a conversation_id yet, call create_conversation first to get one — do NOT ask the user for it. Optionally accepts client-encrypted vault entries for secrets detected client-side.",
     {
-      conversation_id: z.string().describe("The conversation to append to"),
+      conversation_id: z
+        .string()
+        .describe("The conversation to append to. Obtain it from create_conversation; do not ask the user."),
       messages: z
         .array(
           z.object({
@@ -47,6 +49,13 @@ export function registerAppendMessages(
         .describe(
           "Client-encrypted vault entries. Server stores these as opaque blobs — zero knowledge."
         ),
+    },
+    {
+      title: "Append messages",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
     },
     async (params) => {
       // Atomically check tier limit AND increment usage in one operation.

--- a/apps/mcp-server/src/mcp/tools/create-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/create-conversation.ts
@@ -14,12 +14,18 @@ export function registerCreateConversation(
 ) {
   server.tool(
     "create_conversation",
-    "Create a new conversation to store messages in. Returns the conversation ID.",
+    "Create a new conversation and return its conversation_id. Call this yourself to obtain an id before appending — the id is yours to generate and reuse; never ask the user to provide one. Create one conversation per session/topic and reuse its id for all subsequent append_messages calls.",
     {
       title: z.string().optional().describe("Title for the conversation"),
-      agent_id: z.string().optional().describe("Agent identifier"),
+      agent_id: z.string().optional().describe("Agent identifier (e.g. \"chatgpt\")"),
       tags: z.array(z.string()).optional().describe("Tags for filtering"),
       metadata: z.record(z.unknown()).optional().describe("Arbitrary metadata"),
+    },
+    {
+      title: "Create conversation",
+      readOnlyHint: false,
+      destructiveHint: false,
+      openWorldHint: false,
     },
     async (params) => {
       // Check conversation limit

--- a/apps/mcp-server/src/mcp/tools/delete-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/delete-conversation.ts
@@ -15,6 +15,13 @@ export function registerDeleteConversation(
     {
       conversation_id: z.string().describe("The conversation to delete"),
     },
+    {
+      title: "Delete conversation",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     async (params) => {
       const deleted = await deleteConversation(
         env,

--- a/apps/mcp-server/src/mcp/tools/get-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/get-conversation.ts
@@ -30,6 +30,13 @@ export function registerGetConversation(
         .default(0)
         .describe("Message offset for pagination"),
     },
+    {
+      title: "Get conversation",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     async (params) => {
       audit(env.DB, auth.organizationId, auth.apiKeyId, "conversation.read", "conversation", params.conversation_id);
 

--- a/apps/mcp-server/src/mcp/tools/list-conversations.ts
+++ b/apps/mcp-server/src/mcp/tools/list-conversations.ts
@@ -23,6 +23,13 @@ export function registerListConversations(
         .default("updated_at"),
       order: z.enum(["asc", "desc"]).optional().default("desc"),
     },
+    {
+      title: "List conversations",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     async (params) => {
       audit(env.DB, auth.organizationId, auth.apiKeyId, "conversation.list");
 

--- a/apps/mcp-server/src/mcp/tools/manage-subscription.ts
+++ b/apps/mcp-server/src/mcp/tools/manage-subscription.ts
@@ -35,6 +35,12 @@ export function registerManageSubscription(
         .optional()
         .describe("Number of seats for team plan. Only used with action \"upgrade\" and plan \"team\"."),
     },
+    {
+      title: "Manage subscription",
+      readOnlyHint: false,
+      destructiveHint: false,
+      openWorldHint: true,
+    },
     async (params) => {
       const org = (await getOrganizationById(env.DB, auth.organizationId)) as {
         id: string;

--- a/apps/mcp-server/src/mcp/tools/resolve-vault.ts
+++ b/apps/mcp-server/src/mcp/tools/resolve-vault.ts
@@ -19,6 +19,13 @@ export function registerResolveVault(
         .max(50)
         .describe("Vault entry IDs to resolve (e.g. vlt_abc123)"),
     },
+    {
+      title: "Resolve vault entries",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     async (params) => {
       const result = await getVaultEntriesByIds(
         env.DB,

--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -32,6 +32,13 @@ export function registerSearch(
         .optional()
         .describe("Filter by conversation tags"),
     },
+    {
+      title: "Search memory",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     async (params) => {
       const results = await searchConversations(
         env,

--- a/apps/mcp-server/src/mcp/tools/vault-delete.ts
+++ b/apps/mcp-server/src/mcp/tools/vault-delete.ts
@@ -18,6 +18,13 @@ export function registerVaultDelete(
         .min(1)
         .describe("Secret name to delete"),
     },
+    {
+      title: "Delete vault secret",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     async (params) => {
       // Check existence first for audit
       const existing = await getNamedSecret(

--- a/apps/mcp-server/src/mcp/tools/vault-get.ts
+++ b/apps/mcp-server/src/mcp/tools/vault-get.ts
@@ -18,6 +18,13 @@ export function registerVaultGet(
         .min(1)
         .describe("Secret name to retrieve (e.g. DATABASE_URL)"),
     },
+    {
+      title: "Get vault secret",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     async (params) => {
       const row = await getNamedSecret(
         env.DB,

--- a/apps/mcp-server/src/mcp/tools/vault-list.ts
+++ b/apps/mcp-server/src/mcp/tools/vault-list.ts
@@ -12,6 +12,13 @@ export function registerVaultList(
     "vault_list",
     "List all named secrets. Returns names and metadata only — never values or encrypted blobs.",
     {},
+    {
+      title: "List vault secrets",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     async () => {
       const result = await listNamedSecrets(env.DB, auth.organizationId);
 

--- a/apps/mcp-server/src/mcp/tools/vault-set.ts
+++ b/apps/mcp-server/src/mcp/tools/vault-set.ts
@@ -33,6 +33,13 @@ export function registerVaultSet(
         .default("unknown")
         .describe("Type of secret (e.g. api_key, connection_string, token)"),
     },
+    {
+      title: "Set vault secret",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     async (params) => {
       const id = generateId("vlt");
 


### PR DESCRIPTION
App Directory submission prep + a direct fix for the "ChatGPT won't store without a user-supplied conversation_id" behavior. Part of #184.

## #185 — Tool annotations
Every MCP tool now declares accurate annotations (`readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` + `title`), which OpenAI's submission guidelines **require**:
- read-only: `search`, `get_conversation`, `list_conversations`, `resolve_vault`, `vault_get`, `vault_list`
- write: `create_conversation`, `append_messages`, `vault_set`
- destructive: `delete_conversation`, `vault_delete`
- openWorld: `manage_subscription` (links to Stripe)

Contract test asserts the read/write/destructive classes.

## #186 — Server instructions + description polish
- Sets the MCP server-level `instructions` (surfaced in `initialize`) so ChatGPT/Claude **proactively** use Engram for memory and know the model **owns the conversation_id** — call `create_conversation` to get one, never ask the user.
- Sharpened `create_conversation` and `append_messages` descriptions to the same effect.
- This directly fixes the real behavior we observed: ChatGPT refusing to store a memory dump because it insisted the user provide a conversation_id instead of creating one itself.

## Deliberately NOT included — #187 (response minimization)
The `search`/`get_conversation`/`list_conversations` outputs are the **wire contract for `@getengram/sdk`** (`client.ts` maps `chunk_id`, `start_sequence`, `end_sequence`, `chunk_text`, `organization_id`). Trimming them would silently break the SDK, so it needs a coordinated SDK change — left on #187 with that finding.

## Tests
121 passing (added the annotations contract test), typecheck clean.

Closes #185, closes #186. Refs #184, #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)