### PR TITLE
feat(mcp): memory-only toolset for OAuth-connected apps

### DIFF
--- a/apps/mcp-server/src/__tests__/oauth.test.ts
+++ b/apps/mcp-server/src/__tests__/oauth.test.ts
@@ -439,3 +439,54 @@ describe("Connected apps management (/api/oauth/connections)", () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe("Published (OAuth) toolset is memory-only", () => {
+  async function listTools(env: ReturnType<typeof createOAuthEnv>, token: string) {
+    const res = await app.fetch(
+      new Request("http://mcp.test/mcp", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      }),
+      env,
+      MOCK_CTX,
+    );
+    return res.text();
+  }
+
+  it("OAuth clients get the 6 memory tools and NOT vault/subscription", async () => {
+    const env = createOAuthEnv(createOAuthD1());
+    const clientId = await registerClient(env);
+    const { verifier, challenge } = await pkcePair();
+    const code = await getAuthCode(env, clientId, challenge);
+    const tok = (await (await app.fetch(
+      form({ grant_type: "authorization_code", client_id: clientId, code, redirect_uri: REDIRECT, code_verifier: verifier }),
+      env,
+    )).json()) as { access_token: string };
+
+    const text = await listTools(env, tok.access_token);
+    for (const name of ["create_conversation", "append_messages", "search", "get_conversation", "list_conversations", "delete_conversation"]) {
+      expect(text, name).toContain(name);
+    }
+    for (const name of ["vault_set", "vault_get", "vault_list", "vault_delete", "resolve_vault", "manage_subscription"]) {
+      expect(text, name).not.toContain(name);
+    }
+  });
+
+  it("API-key clients keep the full toolset incl. vault", async () => {
+    const db = createOAuthD1();
+    const env = createOAuthEnv(db);
+    const { raw: apiKey, prefix } = generateApiKeyRaw();
+    await db.prepare("INSERT INTO organizations (id, name, tier) VALUES (?, ?, ?)").bind("org_full", "Full", "free").run();
+    await db.prepare("INSERT INTO api_keys (id, organization_id, key_hash, key_prefix, name, expires_at) VALUES (?, ?, ?, ?, ?, ?)")
+      .bind("key_full", "org_full", await hashApiKey(apiKey), prefix, "Default", "2999-01-01 00:00:00").run();
+
+    const text = await listTools(env, apiKey);
+    expect(text).toContain("vault_set");
+    expect(text).toContain("manage_subscription");
+  });
+});

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -31,18 +31,33 @@ export function createMcpServer(env: Env, auth: AuthContext): McpServer {
     { instructions: SERVER_INSTRUCTIONS },
   );
 
+  // Core memory tools — available to every client (incl. OAuth-connected
+  // apps like ChatGPT).
   registerCreateConversation(server, env, auth);
   registerAppendMessages(server, env, auth);
   registerSearch(server, env, auth);
   registerGetConversation(server, env, auth);
   registerListConversations(server, env, auth);
   registerDeleteConversation(server, env, auth);
-  registerResolveVault(server, env, auth);
-  registerVaultSet(server, env, auth);
-  registerVaultGet(server, env, auth);
-  registerVaultList(server, env, auth);
-  registerVaultDelete(server, env, auth);
-  registerManageSubscription(server, env, auth);
+
+  // First-party-only tools. External OAuth clients (auth.apiKeyId is
+  // "oauth:<client_id>") get the memory-only surface: the secrets vault
+  // stores credentials (which app marketplaces like ChatGPT's prohibit
+  // collecting) and manage_subscription is billing, not memory. API-key /
+  // SDK callers — the user's own agents — keep the full toolset.
+  if (!isExternalOAuthClient(auth)) {
+    registerResolveVault(server, env, auth);
+    registerVaultSet(server, env, auth);
+    registerVaultGet(server, env, auth);
+    registerVaultList(server, env, auth);
+    registerVaultDelete(server, env, auth);
+    registerManageSubscription(server, env, auth);
+  }
 
   return server;
+}
+
+/** True when the session is an external app connected via OAuth (not an API key). */
+export function isExternalOAuthClient(auth: AuthContext): boolean {
+  return typeof auth.apiKeyId === "string" && auth.apiKeyId.startsWith("oauth:");
 }


### PR DESCRIPTION
Closes #188 (the vault decision). Implements the recommended **option 1**: OAuth-connected apps get a curated memory-only toolset; first-party API-key/SDK callers keep everything.

## Rule
`createMcpServer` checks `isExternalOAuthClient(auth)` (`auth.apiKeyId` starts with `oauth:`):
- **OAuth clients (ChatGPT, Claude):** `create_conversation`, `append_messages`, `search`, `get_conversation`, `list_conversations`, `delete_conversation` — the 6 memory tools.
- **API-key / SDK (first-party):** full toolset, incl. `vault_*`, `resolve_vault`, `manage_subscription` — unchanged.

## Why
OpenAI's App Directory prohibits apps that "collect credentials." Engram's vault is zero-knowledge (client-encrypted), but reviewers would flag `vault_set`'s "store a secret … api_key/token" regardless. Gating it removes the flag and keeps billing out of the published connector, without touching first-party functionality.

## Tests (123 passing)
The OAuth `tools/list` excludes vault/subscription and includes the 6 memory tools; the API-key `tools/list` still includes `vault_set`/`manage_subscription`.

Closes #188. Refs #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)