### PR TITLE
feat(mcp): optional conversation_id on append_messages (auto-default memory)

### DIFF
--- a/apps/mcp-server/src/__tests__/conversation-service.test.ts
+++ b/apps/mcp-server/src/__tests__/conversation-service.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { createMockD1, createMockEnv } from "./helpers.js";
-import { createConversation, getConversation } from "../services/conversation.js";
+import {
+  createConversation,
+  getConversation,
+  getOrCreateDefaultConversation,
+} from "../services/conversation.js";
 import { insertOrganization, insertConversation as dbInsertConversation } from "@getengram/db";
 
 describe("Conversation service", () => {
@@ -35,6 +39,58 @@ describe("Conversation service", () => {
       const result = await getConversation(db, "org_svc", convId, 100, 0);
       expect(result).not.toBeNull();
       expect(result!.conversation.id).toBe(convId);
+    });
+  });
+
+  describe("getOrCreateDefaultConversation", () => {
+    // Tag-aware fake: createMockD1 doesn't parse the json_each tag lookup, so
+    // use a minimal store that does.
+    function createTaggedD1(): D1Database {
+      const convs: Array<Record<string, unknown>> = [];
+      const stmt = (sql: string, args: unknown[] = []) => ({
+        bind: (...a: unknown[]) => stmt(sql, a),
+        run: async () => {
+          if (/INSERT\s+INTO\s+conversations/i.test(sql)) {
+            convs.push({
+              id: args[0],
+              organization_id: args[1],
+              title: args[2],
+              agent_id: args[3],
+              tags: args[4],
+              metadata: args[5],
+            });
+          }
+          return { results: [], success: true, meta: {} };
+        },
+        first: async () => {
+          if (/FROM\s+conversations/i.test(sql) && /json_each/i.test(sql)) {
+            const [org, tag] = args as [string, string];
+            const found = convs.find(
+              (c) =>
+                c.organization_id === org &&
+                (JSON.parse((c.tags as string) || "[]") as string[]).includes(tag),
+            );
+            return found ? { id: found.id } : null;
+          }
+          return null;
+        },
+      });
+      return { prepare: (sql: string) => stmt(sql) } as unknown as D1Database;
+    }
+
+    it("creates a default conversation, then reuses it on subsequent calls", async () => {
+      const db = createTaggedD1();
+      const first = await getOrCreateDefaultConversation(db, "org_d");
+      expect(first).toMatch(/^conv_/);
+      const second = await getOrCreateDefaultConversation(db, "org_d");
+      expect(second).toBe(first);
+    });
+
+    it("keeps a separate default per organization", async () => {
+      const db = createTaggedD1();
+      const a = await getOrCreateDefaultConversation(db, "org_a");
+      const b = await getOrCreateDefaultConversation(db, "org_b");
+      expect(a).not.toBe(b);
     });
   });
 });

--- a/apps/mcp-server/src/__tests__/mcp-tools-contract.test.ts
+++ b/apps/mcp-server/src/__tests__/mcp-tools-contract.test.ts
@@ -158,6 +158,22 @@ describe("MCP tool contract — wire field names", () => {
       // Every id the SDK will map into messageIds must be a string.
       data.message_ids.forEach((id: unknown) => expect(typeof id).toBe("string"));
     });
+
+    it("works with no conversation_id and returns the conversation_id used", async () => {
+      const { server, tools } = createCaptureServer();
+      registerAppendMessages(server, env, { ...auth, tier: "enterprise" });
+      const tool = tools.get("append_messages");
+
+      const { data, isError } = parseToolResponse(
+        await tool!.handler({
+          messages: [{ role: "user", content: "remember this" }],
+        })
+      );
+      expect(isError).toBe(false);
+      expect(typeof data.conversation_id).toBe("string");
+      expect(data.conversation_id).toMatch(/^conv_/);
+      expect(data.appended).toBe(1);
+    });
   });
 
   describe("search", () => {

--- a/apps/mcp-server/src/mcp/tools/append-messages.ts
+++ b/apps/mcp-server/src/mcp/tools/append-messages.ts
@@ -1,6 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { appendMessages } from "../../services/conversation.js";
+import {
+  appendMessages,
+  getOrCreateDefaultConversation,
+} from "../../services/conversation.js";
 import { checkAndTrackMessages } from "../../services/tier.js";
 import { fireWebhooks } from "../../services/webhooks.js";
 import { audit } from "../../services/audit.js";
@@ -13,11 +16,12 @@ export function registerAppendMessages(
 ) {
   server.tool(
     "append_messages",
-    "Append messages to a conversation, stored verbatim and automatically chunked + embedded for search. If you don't have a conversation_id yet, call create_conversation first to get one — do NOT ask the user for it. Optionally accepts client-encrypted vault entries for secrets detected client-side.",
+    "Store messages in Engram memory, verbatim and automatically chunked + embedded for search. conversation_id is OPTIONAL: omit it to append to the user's default memory (recommended for general 'remember this' requests) — never ask the user for an id. Pass a conversation_id (from create_conversation) only when you want to group a specific topic. The response returns the conversation_id used. Optionally accepts client-encrypted vault entries for secrets detected client-side.",
     {
       conversation_id: z
         .string()
-        .describe("The conversation to append to. Obtain it from create_conversation; do not ask the user."),
+        .optional()
+        .describe("Optional. Omit to use the default memory; or pass one from create_conversation to group a topic. Never ask the user for it."),
       messages: z
         .array(
           z.object({
@@ -86,10 +90,15 @@ export function registerAppendMessages(
         };
       }
 
+      // No conversation_id → append to the org's default memory (find-or-create).
+      const conversationId =
+        params.conversation_id ??
+        (await getOrCreateDefaultConversation(env.DB, auth.organizationId));
+
       const messages = await appendMessages(
         env,
         auth.organizationId,
-        params.conversation_id,
+        conversationId,
         params.messages.map((m) => ({
           ...m,
           metadata: m.metadata as Record<string, unknown>,
@@ -103,7 +112,7 @@ export function registerAppendMessages(
         auth.apiKeyId,
         "messages.append",
         "conversation",
-        params.conversation_id,
+        conversationId,
         {
           count: messages.length,
           vault_entries: params.vault_entries?.length ?? 0,
@@ -112,7 +121,7 @@ export function registerAppendMessages(
 
       // Fire webhooks (non-blocking)
       fireWebhooks(env.DB, auth.organizationId, "messages.appended", {
-        conversation_id: params.conversation_id,
+        conversation_id: conversationId,
         message_count: messages.length,
         message_ids: messages.map((m) => m.id),
       }).catch(() => {});
@@ -122,6 +131,7 @@ export function registerAppendMessages(
           {
             type: "text" as const,
             text: JSON.stringify({
+              conversation_id: conversationId,
               appended: messages.length,
               message_ids: messages.map((m) => m.id),
               vault_entries_stored: params.vault_entries?.length ?? 0,

--- a/apps/mcp-server/src/services/conversation.ts
+++ b/apps/mcp-server/src/services/conversation.ts
@@ -9,6 +9,8 @@ import {
 import {
   insertConversation,
   getConversationById,
+  getDefaultConversationId,
+  DEFAULT_CONVERSATION_TAG,
   listConversations as dbListConversations,
   updateConversationMessageCount,
   deleteConversationById,
@@ -42,6 +44,22 @@ export async function createConversation(
     metadata ?? {}
   );
   return id;
+}
+
+/**
+ * Get the org's default memory conversation, creating it on first use. This
+ * is the target for append_messages calls that don't specify a conversation —
+ * it lets agents "just remember this" without managing conversation ids.
+ */
+export async function getOrCreateDefaultConversation(
+  db: D1Database,
+  organizationId: string,
+): Promise<string> {
+  const existing = await getDefaultConversationId(db, organizationId);
+  if (existing?.id) return existing.id;
+  return createConversation(db, organizationId, "Memory", undefined, [
+    DEFAULT_CONVERSATION_TAG,
+  ]);
 }
 
 export interface VaultEntryInput {

--- a/packages/db/src/queries/conversations.ts
+++ b/packages/db/src/queries/conversations.ts
@@ -22,6 +22,25 @@ export function getConversationById(db: D1Database, id: string, organizationId: 
     .first();
 }
 
+/** Tag marking the org's auto-created default memory conversation. */
+export const DEFAULT_CONVERSATION_TAG = "__engram_default__";
+
+/**
+ * Find the org's default memory conversation (the one append_messages writes
+ * to when no conversation_id is supplied). Returns its id or null.
+ */
+export function getDefaultConversationId(db: D1Database, organizationId: string) {
+  return db
+    .prepare(
+      `SELECT id FROM conversations
+       WHERE organization_id = ?
+         AND EXISTS (SELECT 1 FROM json_each(tags) WHERE json_each.value = ?)
+       ORDER BY created_at LIMIT 1`,
+    )
+    .bind(organizationId, DEFAULT_CONVERSATION_TAG)
+    .first<{ id: string }>();
+}
+
 export function listConversations(
   db: D1Database,
   organizationId: string,


### PR DESCRIPTION
Closes #201. Fixes the friction we hit twice with ChatGPT: it refuses to call `create_conversation` first and demands a `conversation_id` from the user.

## Change
`append_messages.conversation_id` is now **optional**:
- **Omitted** → append to the org's **default memory** conversation (find-or-create by a reserved tag). The response returns the `conversation_id` used.
- **Provided** (from `create_conversation`) → group a specific topic (unchanged).

So "use Engram to remember this" now works with zero ceremony — the agent doesn't have to manage ids at all. Description updated to say so.

## Compatibility
Backward compatible — existing callers pass an id; `@getengram/sdk` always passes one, so it's unaffected. The output adds `conversation_id` (new field, non-breaking).

## Tests (126 passing)
Default conversation create-then-reuse, per-org isolation, and the no-`conversation_id` tool path returning a `conv_` id.

Closes #201. Refs #184, #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)