### PR TITLE
feat(cli): import ChatGPT data export into Engram

### DIFF
--- a/apps/cli/src/__tests__/cli.test.ts
+++ b/apps/cli/src/__tests__/cli.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { linearize, type ChatConversation } from "../commands/import.js";
 
 describe("CLI", () => {
   it("exports all command modules", async () => {
@@ -33,5 +34,34 @@ describe("CLI", () => {
     expect(green("test")).toContain("test");
     expect(red("test")).toContain("test");
     expect(cyan("test")).toContain("test");
+  });
+});
+
+describe("ChatGPT import — linearize", () => {
+  const convo: ChatConversation = {
+    title: "Test",
+    current_node: "d",
+    mapping: {
+      root: { id: "root", parent: null, message: null },
+      sys: { id: "sys", parent: "root", message: { author: { role: "system" }, content: { content_type: "text", parts: [""] } } },
+      a: { id: "a", parent: "sys", message: { author: { role: "user" }, content: { content_type: "text", parts: ["hello"] } } },
+      b: { id: "b", parent: "a", message: { author: { role: "assistant" }, content: { content_type: "text", parts: ["hi there"] } } },
+      tool: { id: "tool", parent: "b", message: { author: { role: "tool" }, content: { content_type: "code", parts: ["{}"] } } },
+      d: { id: "d", parent: "tool", message: { author: { role: "user" }, content: { content_type: "text", parts: ["bye"] } } },
+    },
+  };
+
+  it("keeps only user/assistant text messages, in chronological order", () => {
+    const msgs = linearize(convo);
+    expect(msgs).toEqual([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "bye" },
+    ]);
+  });
+
+  it("returns [] for an empty/parentless mapping", () => {
+    expect(linearize({ current_node: "x", mapping: {} })).toEqual([]);
+    expect(linearize({})).toEqual([]);
   });
 });

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -1,0 +1,180 @@
+import { readFile } from "node:fs/promises";
+import { Engram, type MessageInput } from "@getengram/sdk";
+import { green, dim, bold } from "../output.js";
+
+/**
+ * Import a ChatGPT data export into Engram.
+ *
+ * Get the file: ChatGPT → Settings → Data controls → Export data. You'll be
+ * emailed a zip; inside is `conversations.json`. Point this command at it:
+ *
+ *   engram import ~/Downloads/chatgpt-export/conversations.json
+ *   engram import conversations.json --dry-run      # preview, no writes
+ *   engram import conversations.json --limit 50     # first 50 conversations
+ *
+ * Each ChatGPT conversation becomes an Engram conversation; messages are
+ * stored verbatim and embedded for semantic search.
+ */
+
+interface ChatNode {
+  id?: string;
+  parent?: string | null;
+  message?: {
+    author?: { role?: string };
+    content?: { content_type?: string; parts?: unknown[] };
+    create_time?: number | null;
+  } | null;
+}
+
+export interface ChatConversation {
+  title?: string | null;
+  create_time?: number | null;
+  current_node?: string | null;
+  mapping?: Record<string, ChatNode>;
+}
+
+const STORE_BATCH = 100;
+
+/** Walk the export's node tree (current_node → root) into a chronological list. */
+export function linearize(convo: ChatConversation): MessageInput[] {
+  const mapping = convo.mapping ?? {};
+  const chain: ChatNode[] = [];
+  let nodeId: string | null | undefined = convo.current_node;
+  const guard = new Set<string>();
+  while (nodeId && mapping[nodeId] && !guard.has(nodeId)) {
+    guard.add(nodeId);
+    chain.push(mapping[nodeId]);
+    nodeId = mapping[nodeId].parent;
+  }
+  chain.reverse();
+
+  const out: MessageInput[] = [];
+  for (const node of chain) {
+    const m = node.message;
+    if (!m) continue;
+    const role = m.author?.role;
+    if (role !== "user" && role !== "assistant") continue;
+    if (m.content?.content_type !== "text") continue;
+    const text = (m.content.parts ?? [])
+      .filter((p): p is string => typeof p === "string")
+      .join("\n")
+      .trim();
+    if (!text) continue;
+    out.push({ role, content: text });
+  }
+  return out;
+}
+
+export async function importChatgpt(
+  engram: Engram,
+  args: string[],
+  flags: Record<string, string>,
+): Promise<void> {
+  const file = args[0];
+  if (!file) {
+    console.error("Usage: engram import <conversations.json> [options]");
+    console.error("\nOptions:");
+    console.error("  --dry-run        Parse and report counts without writing");
+    console.error("  --limit <n>      Import only the first <n> conversations");
+    console.error("  --tag <name>     Add an extra tag to every imported conversation");
+    console.error("\nGet the file from ChatGPT → Settings → Data controls → Export data.");
+    process.exit(1);
+  }
+
+  const dryRun = "dry-run" in flags || "dryRun" in flags;
+  const limit = flags.limit ? parseInt(flags.limit, 10) : Infinity;
+  const extraTag = flags.tag;
+
+  let raw: string;
+  try {
+    raw = await readFile(file, "utf-8");
+  } catch {
+    console.error(`Could not read ${file}`);
+    process.exit(1);
+  }
+
+  let convos: ChatConversation[];
+  try {
+    const parsed = JSON.parse(raw);
+    // The export is an array; some tools wrap it as { conversations: [...] }.
+    convos = Array.isArray(parsed) ? parsed : (parsed.conversations ?? []);
+  } catch {
+    console.error("Not valid JSON. Point at conversations.json from your ChatGPT export.");
+    process.exit(1);
+  }
+
+  if (!Array.isArray(convos) || convos.length === 0) {
+    console.error("No conversations found in the file.");
+    process.exit(1);
+  }
+
+  const toImport = convos.slice(0, limit);
+  console.log(
+    `${bold("ChatGPT import")} ${dim(`(${toImport.length} of ${convos.length} conversations${dryRun ? ", dry run" : ""})`)}`,
+  );
+
+  let imported = 0;
+  let messageTotal = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const [i, convo] of toImport.entries()) {
+    const title = (convo.title || "Untitled").slice(0, 200);
+    const messages = linearize(convo);
+    if (messages.length === 0) {
+      skipped++;
+      continue;
+    }
+
+    const label = `[${i + 1}/${toImport.length}] ${title} ${dim(`(${messages.length} msgs)`)}`;
+    if (dryRun) {
+      console.log(`  ${dim("would import")} ${label}`);
+      imported++;
+      messageTotal += messages.length;
+      continue;
+    }
+
+    try {
+      const tags = ["chatgpt-import", ...(extraTag ? [extraTag] : [])];
+      const { conversationId } = await engram.createConversation({
+        title,
+        agentId: "chatgpt-import",
+        tags,
+        metadata: {
+          source: "chatgpt-export",
+          original_create_time: convo.create_time ?? null,
+        },
+      });
+      for (let b = 0; b < messages.length; b += STORE_BATCH) {
+        await engram.store({
+          conversationId,
+          messages: messages.slice(b, b + STORE_BATCH),
+        });
+      }
+      console.log(`  ${green("✓")} ${label}`);
+      imported++;
+      messageTotal += messages.length;
+    } catch (err) {
+      failed++;
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`  ✗ ${label} — ${msg}`);
+      // A message-limit error means the tier cap was hit; stop early rather
+      // than hammering the API with the rest.
+      if (/limit/i.test(msg)) {
+        console.error(
+          dim(
+            "\nHit a plan limit. Upgrade at https://getengram.app/pricing to import the rest, then re-run (already-imported conversations will duplicate — clear them first if needed).",
+          ),
+        );
+        break;
+      }
+    }
+  }
+
+  console.log(
+    `\n${bold("Done.")} ${imported} imported, ${messageTotal} messages` +
+      `${skipped ? `, ${skipped} empty skipped` : ""}` +
+      `${failed ? `, ${failed} failed` : ""}.`,
+  );
+  if (dryRun) console.log(dim("Dry run — nothing was written. Re-run without --dry-run to import."));
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -13,6 +13,7 @@ import {
 import { store } from "./commands/store.js";
 import { search } from "./commands/search.js";
 import { log as showLog } from "./commands/log.js";
+import { importChatgpt } from "./commands/import.js";
 import { daemonStart, daemonStop, daemonStatus, daemonInstall, daemonUninstall } from "./daemon/index.js";
 import { upgrade } from "./commands/upgrade.js";
 import { vaultKeygen, vaultStatus, loadVaultKey, vaultSet, vaultGet, vaultList, vaultDelete } from "./commands/vault.js";
@@ -24,7 +25,7 @@ const VERSION = "0.3.4";
 const TOP_COMMANDS = new Set([
   "help", "version", "store", "append", "search", "find", "convs",
   "start", "stop", "status", "install", "uninstall", "log",
-  "signup", "login", "link", "upgrade",
+  "signup", "login", "link", "upgrade", "import",
 ]);
 // Commands that take 2 words (group + subcommand)
 const GROUP_COMMANDS = new Set(["auth", "conversations", "conv", "daemon", "vault"]);
@@ -135,6 +136,7 @@ ${bold("COMMANDS")}
 
   ${bold("store")} -c <id> <message>  Store a message
   ${bold("search")} <query>           Semantic search across memory
+  ${bold("import")} <file.json>       Import a ChatGPT data export into memory
   ${bold("log")}                      Show recent AI conversation activity
   ${bold("upgrade")} [pro|team]       Upgrade your plan (opens Stripe checkout)
 
@@ -266,6 +268,10 @@ async function main(): Promise<void> {
 
       case "log":
         await showLog(await getClient(), args, flags);
+        break;
+
+      case "import":
+        await importChatgpt(await getClient(), args, flags);
         break;
 
       case "upgrade":

--- a/docs/guides/import-chatgpt.md
+++ b/docs/guides/import-chatgpt.md
@@ -1,0 +1,59 @@
+# Import your ChatGPT history into Engram
+
+ChatGPT (the model) can't bulk-upload your past conversations — it only sees the
+current chat. To give Engram your real history, export your data from ChatGPT and
+import the file with the Engram CLI. Every conversation is stored verbatim and
+embedded for semantic search, so you can recall it from any connected client.
+
+## 1. Export your data from ChatGPT
+
+1. ChatGPT → **Settings → Data controls → Export data**.
+2. Confirm. OpenAI emails you a download link (can take a few minutes to hours).
+3. Download and unzip it. Inside is **`conversations.json`** — that's the file you need.
+
+## 2. Import it
+
+You need an Engram API key (from [getengram.app/dashboard](https://getengram.app/dashboard)).
+
+```bash
+# Point the CLI at your key (or run `engram login` first)
+export ENGRAM_API_KEY=engram_sk_live_...
+
+# Preview first — counts only, writes nothing
+npx @getengram/cli import ~/Downloads/chatgpt-export/conversations.json --dry-run
+
+# Do the import
+npx @getengram/cli import ~/Downloads/chatgpt-export/conversations.json
+```
+
+Each ChatGPT conversation becomes an Engram conversation (tagged
+`chatgpt-import`), with user/assistant messages stored in order. System and
+tool/code messages are skipped.
+
+### Options
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Parse and report counts without writing anything |
+| `--limit <n>` | Import only the first `n` conversations |
+| `--tag <name>` | Add an extra tag to every imported conversation |
+
+## 3. Verify
+
+```bash
+npx @getengram/cli search "something you discussed in ChatGPT"
+```
+
+Or, in any connected client (ChatGPT, Claude, Cursor), ask it to search Engram —
+your imported history is now part of your memory.
+
+## Notes
+
+- **Plan limits.** A full export can be large. If you hit your monthly message
+  limit mid-import, the CLI stops and tells you — [upgrade](https://getengram.app/pricing)
+  and re-run. Already-imported conversations will duplicate on a re-run, so clear
+  them first if needed (filter by the `chatgpt-import` tag).
+- **Re-running** imports everything again; it does not de-duplicate. Use
+  `--limit` to test on a small slice first.
+- **Going forward**, you don't need this — connected clients append new
+  conversations to Engram live.


### PR DESCRIPTION
The real way to get your **full** ChatGPT history into Engram (vs. the model's recollection). Adds `engram import`.

## Usage
```bash
export ENGRAM_API_KEY=engram_sk_live_...
npx @getengram/cli import ~/Downloads/chatgpt-export/conversations.json --dry-run  # preview
npx @getengram/cli import ~/Downloads/chatgpt-export/conversations.json            # import
```

## What it does
- Parses ChatGPT's export (`conversations.json`): walks each conversation's node tree (`current_node` → root), keeps **user/assistant text** messages in chronological order, skips system/tool/code nodes.
- Creates one Engram conversation per chat (tagged `chatgpt-import`, with original create_time in metadata), stores messages in batches of 100.
- Flags: `--dry-run` (counts only), `--limit <n>`, `--tag <name>`. Stops cleanly and points to pricing if a plan limit is hit.

## Includes
- `docs/guides/import-chatgpt.md` — export-from-ChatGPT + import walkthrough.
- `linearize()` parser unit test (chronological order, filtering).

CLI typecheck + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)