### PR TITLE
feat(cli): support Claude exports in engram import (auto-detect)

### DIFF
--- a/apps/cli/src/__tests__/cli.test.ts
+++ b/apps/cli/src/__tests__/cli.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { linearize, type ChatConversation } from "../commands/import.js";
+import {
+  linearize,
+  linearizeClaude,
+  normalizeExport,
+  type ChatConversation,
+} from "../commands/import.js";
 
 describe("CLI", () => {
   it("exports all command modules", async () => {
@@ -63,5 +68,39 @@ describe("ChatGPT import — linearize", () => {
   it("returns [] for an empty/parentless mapping", () => {
     expect(linearize({ current_node: "x", mapping: {} })).toEqual([]);
     expect(linearize({})).toEqual([]);
+  });
+});
+
+describe("import — Claude + format detection", () => {
+  it("linearizes a Claude conversation (text and content blocks)", () => {
+    const msgs = linearizeClaude({
+      name: "Test",
+      chat_messages: [
+        { sender: "human", text: "hi" },
+        { sender: "assistant", content: [{ type: "text", text: "hello" }] },
+        { sender: "tool", text: "ignored" },
+        { sender: "human", text: "  " },
+      ],
+    });
+    expect(msgs).toEqual([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ]);
+  });
+
+  it("detects ChatGPT vs Claude vs unknown", () => {
+    expect(normalizeExport([{ mapping: {}, current_node: null }]).format).toBe("chatgpt");
+    expect(normalizeExport([{ chat_messages: [] }]).format).toBe("claude");
+    expect(normalizeExport([{ foo: "bar" }]).format).toBe("unknown");
+    expect(normalizeExport([]).format).toBe("unknown");
+  });
+
+  it("normalizes Claude conversations with title + messages", () => {
+    const { format, conversations } = normalizeExport([
+      { name: "My chat", created_at: "2026-01-01", chat_messages: [{ sender: "human", text: "yo" }] },
+    ]);
+    expect(format).toBe("claude");
+    expect(conversations[0].title).toBe("My chat");
+    expect(conversations[0].messages).toEqual([{ role: "user", content: "yo" }]);
   });
 });

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -3,19 +3,21 @@ import { Engram, type MessageInput } from "@getengram/sdk";
 import { green, dim, bold } from "../output.js";
 
 /**
- * Import a ChatGPT data export into Engram.
+ * Import a ChatGPT or Claude data export into Engram. The format is
+ * auto-detected from the file.
  *
- * Get the file: ChatGPT → Settings → Data controls → Export data. You'll be
- * emailed a zip; inside is `conversations.json`. Point this command at it:
+ *   - ChatGPT: Settings → Data controls → Export data → `conversations.json`
+ *   - Claude:  Settings → Account → Export data → `conversations.json`
  *
- *   engram import ~/Downloads/chatgpt-export/conversations.json
+ *   engram import ~/Downloads/conversations.json
  *   engram import conversations.json --dry-run      # preview, no writes
  *   engram import conversations.json --limit 50     # first 50 conversations
  *
- * Each ChatGPT conversation becomes an Engram conversation; messages are
+ * Each source conversation becomes an Engram conversation; messages are
  * stored verbatim and embedded for semantic search.
  */
 
+// --- ChatGPT export shapes ---
 interface ChatNode {
   id?: string;
   parent?: string | null;
@@ -33,9 +35,31 @@ export interface ChatConversation {
   mapping?: Record<string, ChatNode>;
 }
 
+// --- Claude export shapes ---
+interface ClaudeMessage {
+  sender?: string; // "human" | "assistant"
+  text?: string;
+  content?: Array<{ type?: string; text?: string }>;
+  created_at?: string | null;
+}
+
+export interface ClaudeConversation {
+  name?: string | null;
+  created_at?: string | null;
+  chat_messages?: ClaudeMessage[];
+}
+
+export type SourceFormat = "chatgpt" | "claude" | "unknown";
+
+export interface NormalizedConversation {
+  title: string;
+  created: string | number | null;
+  messages: MessageInput[];
+}
+
 const STORE_BATCH = 100;
 
-/** Walk the export's node tree (current_node → root) into a chronological list. */
+/** Walk a ChatGPT export's node tree (current_node → root) into a chronological list. */
 export function linearize(convo: ChatConversation): MessageInput[] {
   const mapping = convo.mapping ?? {};
   const chain: ChatNode[] = [];
@@ -65,7 +89,66 @@ export function linearize(convo: ChatConversation): MessageInput[] {
   return out;
 }
 
-export async function importChatgpt(
+/** Flatten a Claude export conversation into a chronological message list. */
+export function linearizeClaude(convo: ClaudeConversation): MessageInput[] {
+  const out: MessageInput[] = [];
+  for (const m of convo.chat_messages ?? []) {
+    const role =
+      m.sender === "assistant" ? "assistant" : m.sender === "human" ? "user" : null;
+    if (!role) continue;
+    let text = typeof m.text === "string" ? m.text.trim() : "";
+    if (!text && Array.isArray(m.content)) {
+      text = m.content
+        .filter((b) => b?.type === "text" && typeof b.text === "string")
+        .map((b) => b.text as string)
+        .join("\n")
+        .trim();
+    }
+    if (!text) continue;
+    out.push({ role, content: text });
+  }
+  return out;
+}
+
+/** Detect the export format and normalize every conversation. */
+export function normalizeExport(parsed: unknown): {
+  format: SourceFormat;
+  conversations: NormalizedConversation[];
+} {
+  const arr = Array.isArray(parsed)
+    ? parsed
+    : ((parsed as { conversations?: unknown[] })?.conversations ?? []);
+  if (!Array.isArray(arr) || arr.length === 0) {
+    return { format: "unknown", conversations: [] };
+  }
+  const first = arr[0] as Record<string, unknown>;
+
+  if (first && ("mapping" in first || "current_node" in first)) {
+    return {
+      format: "chatgpt",
+      conversations: (arr as ChatConversation[]).map((c) => ({
+        title: (c.title || "Untitled").slice(0, 200),
+        created: c.create_time ?? null,
+        messages: linearize(c),
+      })),
+    };
+  }
+
+  if (first && ("chat_messages" in first || "sender" in first)) {
+    return {
+      format: "claude",
+      conversations: (arr as ClaudeConversation[]).map((c) => ({
+        title: (c.name || "Untitled").slice(0, 200),
+        created: c.created_at ?? null,
+        messages: linearizeClaude(c),
+      })),
+    };
+  }
+
+  return { format: "unknown", conversations: [] };
+}
+
+export async function importHistory(
   engram: Engram,
   args: string[],
   flags: Record<string, string>,
@@ -77,7 +160,10 @@ export async function importChatgpt(
     console.error("  --dry-run        Parse and report counts without writing");
     console.error("  --limit <n>      Import only the first <n> conversations");
     console.error("  --tag <name>     Add an extra tag to every imported conversation");
-    console.error("\nGet the file from ChatGPT → Settings → Data controls → Export data.");
+    console.error(
+      "\nGet the file from ChatGPT (Settings → Data controls → Export data) or",
+    );
+    console.error("Claude (Settings → Account → Export data). Format is auto-detected.");
     process.exit(1);
   }
 
@@ -93,24 +179,26 @@ export async function importChatgpt(
     process.exit(1);
   }
 
-  let convos: ChatConversation[];
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw);
-    // The export is an array; some tools wrap it as { conversations: [...] }.
-    convos = Array.isArray(parsed) ? parsed : (parsed.conversations ?? []);
+    parsed = JSON.parse(raw);
   } catch {
-    console.error("Not valid JSON. Point at conversations.json from your ChatGPT export.");
+    console.error("Not valid JSON. Point at conversations.json from your export.");
     process.exit(1);
   }
 
-  if (!Array.isArray(convos) || convos.length === 0) {
-    console.error("No conversations found in the file.");
+  const { format, conversations } = normalizeExport(parsed);
+  if (format === "unknown" || conversations.length === 0) {
+    console.error(
+      "Unrecognized export. Expected a ChatGPT or Claude conversations.json.",
+    );
     process.exit(1);
   }
 
-  const toImport = convos.slice(0, limit);
+  const source = format === "claude" ? "claude-import" : "chatgpt-import";
+  const toImport = conversations.slice(0, limit);
   console.log(
-    `${bold("ChatGPT import")} ${dim(`(${toImport.length} of ${convos.length} conversations${dryRun ? ", dry run" : ""})`)}`,
+    `${bold(`${format} import`)} ${dim(`(${toImport.length} of ${conversations.length} conversations${dryRun ? ", dry run" : ""})`)}`,
   );
 
   let imported = 0;
@@ -119,47 +207,40 @@ export async function importChatgpt(
   let failed = 0;
 
   for (const [i, convo] of toImport.entries()) {
-    const title = (convo.title || "Untitled").slice(0, 200);
-    const messages = linearize(convo);
-    if (messages.length === 0) {
+    if (convo.messages.length === 0) {
       skipped++;
       continue;
     }
 
-    const label = `[${i + 1}/${toImport.length}] ${title} ${dim(`(${messages.length} msgs)`)}`;
+    const label = `[${i + 1}/${toImport.length}] ${convo.title} ${dim(`(${convo.messages.length} msgs)`)}`;
     if (dryRun) {
       console.log(`  ${dim("would import")} ${label}`);
       imported++;
-      messageTotal += messages.length;
+      messageTotal += convo.messages.length;
       continue;
     }
 
     try {
-      const tags = ["chatgpt-import", ...(extraTag ? [extraTag] : [])];
+      const tags = [source, ...(extraTag ? [extraTag] : [])];
       const { conversationId } = await engram.createConversation({
-        title,
-        agentId: "chatgpt-import",
+        title: convo.title,
+        agentId: source,
         tags,
-        metadata: {
-          source: "chatgpt-export",
-          original_create_time: convo.create_time ?? null,
-        },
+        metadata: { source: `${format}-export`, original_create_time: convo.created },
       });
-      for (let b = 0; b < messages.length; b += STORE_BATCH) {
+      for (let b = 0; b < convo.messages.length; b += STORE_BATCH) {
         await engram.store({
           conversationId,
-          messages: messages.slice(b, b + STORE_BATCH),
+          messages: convo.messages.slice(b, b + STORE_BATCH),
         });
       }
       console.log(`  ${green("✓")} ${label}`);
       imported++;
-      messageTotal += messages.length;
+      messageTotal += convo.messages.length;
     } catch (err) {
       failed++;
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`  ✗ ${label} — ${msg}`);
-      // A message-limit error means the tier cap was hit; stop early rather
-      // than hammering the API with the rest.
       if (/limit/i.test(msg)) {
         console.error(
           dim(

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -13,7 +13,7 @@ import {
 import { store } from "./commands/store.js";
 import { search } from "./commands/search.js";
 import { log as showLog } from "./commands/log.js";
-import { importChatgpt } from "./commands/import.js";
+import { importHistory } from "./commands/import.js";
 import { daemonStart, daemonStop, daemonStatus, daemonInstall, daemonUninstall } from "./daemon/index.js";
 import { upgrade } from "./commands/upgrade.js";
 import { vaultKeygen, vaultStatus, loadVaultKey, vaultSet, vaultGet, vaultList, vaultDelete } from "./commands/vault.js";
@@ -136,7 +136,7 @@ ${bold("COMMANDS")}
 
   ${bold("store")} -c <id> <message>  Store a message
   ${bold("search")} <query>           Semantic search across memory
-  ${bold("import")} <file.json>       Import a ChatGPT data export into memory
+  ${bold("import")} <file.json>       Import a ChatGPT or Claude data export
   ${bold("log")}                      Show recent AI conversation activity
   ${bold("upgrade")} [pro|team]       Upgrade your plan (opens Stripe checkout)
 
@@ -271,7 +271,7 @@ async function main(): Promise<void> {
         break;
 
       case "import":
-        await importChatgpt(await getClient(), args, flags);
+        await importHistory(await getClient(), args, flags);
         break;
 
       case "upgrade":

--- a/docs/guides/import-chatgpt.md
+++ b/docs/guides/import-chatgpt.md
@@ -1,15 +1,18 @@
-# Import your ChatGPT history into Engram
+# Import your ChatGPT / Claude history into Engram
 
-ChatGPT (the model) can't bulk-upload your past conversations — it only sees the
-current chat. To give Engram your real history, export your data from ChatGPT and
-import the file with the Engram CLI. Every conversation is stored verbatim and
-embedded for semantic search, so you can recall it from any connected client.
+A chat model can't bulk-upload your past conversations — it only sees the current
+chat. To give Engram your real history, export your data and import the file with
+the Engram CLI. **ChatGPT and Claude exports are both supported** (the format is
+auto-detected). Every conversation is stored verbatim and embedded for semantic
+search, so you can recall it from any connected client.
 
-## 1. Export your data from ChatGPT
+## 1. Export your data
 
-1. ChatGPT → **Settings → Data controls → Export data**.
-2. Confirm. OpenAI emails you a download link (can take a few minutes to hours).
-3. Download and unzip it. Inside is **`conversations.json`** — that's the file you need.
+**ChatGPT:** Settings → **Data controls → Export data**. You'll be emailed a
+download link; unzip it and find **`conversations.json`**.
+
+**Claude:** Settings → **Account → Export data**. Same idea — unzip and find
+**`conversations.json`**.
 
 ## 2. Import it
 


### PR DESCRIPTION
Extends `engram import` to accept **Claude** data exports as well as ChatGPT — the format is auto-detected from the file.

## Changes
- `normalizeExport()` detects ChatGPT (`mapping`/`current_node`) vs Claude (`chat_messages`/`sender`) and normalizes both to `{title, created, messages}`.
- `linearizeClaude()` flattens Claude conversations (handles both `text` and `content[]` block shapes; maps `human`→`user`).
- Imported Claude chats are tagged `claude-import`.
- Docs updated to cover both ChatGPT and Claude exports.

## Tests
CLI tests cover Claude linearization, format detection (chatgpt/claude/unknown), and normalization. Typecheck + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)