### PR TITLE
feat(mcp): friendly upgrade message + usage meter for connected apps

### DIFF
--- a/apps/mcp-server/src/__tests__/usage-messaging.test.ts
+++ b/apps/mcp-server/src/__tests__/usage-messaging.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  usageMeter,
+  limitMessage,
+  approachingLimitNotice,
+} from "../mcp/usage-messaging.js";
+
+describe("usageMeter", () => {
+  it("computes remaining for limited tiers", () => {
+    expect(usageMeter(950, 1000)).toEqual({ used: 950, limit: 1000, remaining: 50 });
+  });
+  it("clamps remaining at 0", () => {
+    expect(usageMeter(1200, 1000)?.remaining).toBe(0);
+  });
+  it("returns undefined for unlimited / missing data", () => {
+    expect(usageMeter(5, -1)).toBeUndefined();
+    expect(usageMeter(undefined, 1000)).toBeUndefined();
+    expect(usageMeter(5, undefined)).toBeUndefined();
+  });
+});
+
+describe("limitMessage", () => {
+  it("routes OAuth users to their own dashboard, not a sale", () => {
+    const m = limitMessage({ unit: "messages", tier: "free", limit: 1000, used: 1000, isOAuth: true });
+    expect(m).toContain("getengram.app/dashboard");
+    expect(m).toMatch(/sign in/i);
+    expect(m).toMatch(/don't try to collect payment/i);
+  });
+  it("points API-key users to pricing", () => {
+    const m = limitMessage({ unit: "messages", tier: "free", limit: 1000, used: 1000, isOAuth: false });
+    expect(m).toContain("getengram.app/pricing");
+    expect(m).toContain("1000");
+  });
+});
+
+describe("approachingLimitNotice", () => {
+  it("warns at/above 80% usage", () => {
+    expect(approachingLimitNotice({ used: 800, limit: 1000, remaining: 200 }, true)).toMatch(/dashboard/);
+    expect(approachingLimitNotice({ used: 950, limit: 1000, remaining: 50 }, false)).toMatch(/pricing/);
+  });
+  it("stays quiet below 80%", () => {
+    expect(approachingLimitNotice({ used: 500, limit: 1000, remaining: 500 }, true)).toBeUndefined();
+  });
+  it("no notice for unlimited / undefined", () => {
+    expect(approachingLimitNotice(undefined, true)).toBeUndefined();
+    expect(approachingLimitNotice({ used: 1, limit: 0, remaining: 0 }, true)).toBeUndefined();
+  });
+});

--- a/apps/mcp-server/src/mcp/auth-kind.ts
+++ b/apps/mcp-server/src/mcp/auth-kind.ts
@@ -1,0 +1,6 @@
+import type { AuthContext } from "../types.js";
+
+/** True when the session is an external app connected via OAuth (not an API key). */
+export function isExternalOAuthClient(auth: AuthContext): boolean {
+  return typeof auth.apiKeyId === "string" && auth.apiKeyId.startsWith("oauth:");
+}

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -11,6 +11,7 @@ import { registerVaultGet } from "./tools/vault-get.js";
 import { registerVaultList } from "./tools/vault-list.js";
 import { registerVaultDelete } from "./tools/vault-delete.js";
 import { registerManageSubscription } from "./tools/manage-subscription.js";
+import { isExternalOAuthClient } from "./auth-kind.js";
 import type { Env, AuthContext } from "../types.js";
 
 // Surfaced to clients (ChatGPT, Claude, …) in the MCP `initialize` response so
@@ -55,9 +56,4 @@ export function createMcpServer(env: Env, auth: AuthContext): McpServer {
   }
 
   return server;
-}
-
-/** True when the session is an external app connected via OAuth (not an API key). */
-export function isExternalOAuthClient(auth: AuthContext): boolean {
-  return typeof auth.apiKeyId === "string" && auth.apiKeyId.startsWith("oauth:");
 }

--- a/apps/mcp-server/src/mcp/tools/append-messages.ts
+++ b/apps/mcp-server/src/mcp/tools/append-messages.ts
@@ -4,6 +4,12 @@ import {
   appendMessages,
   getOrCreateDefaultConversation,
 } from "../../services/conversation.js";
+import { isExternalOAuthClient } from "../auth-kind.js";
+import {
+  usageMeter,
+  limitMessage,
+  approachingLimitNotice,
+} from "../usage-messaging.js";
 import { checkAndTrackMessages } from "../../services/tier.js";
 import { fireWebhooks } from "../../services/webhooks.js";
 import { audit } from "../../services/audit.js";
@@ -72,6 +78,8 @@ export function registerAppendMessages(
         params.messages.length
       );
 
+      const isOAuth = isExternalOAuthClient(auth);
+
       if (!tierCheck.allowed) {
         return {
           content: [
@@ -79,10 +87,19 @@ export function registerAppendMessages(
               type: "text" as const,
               text: JSON.stringify({
                 error: tierCheck.error,
-                message: `Message limit exceeded. Your ${tierCheck.tier} plan allows ${tierCheck.limit?.toLocaleString()} messages/month. Used: ${tierCheck.used?.toLocaleString()}. Upgrade at https://getengram.app/pricing`,
+                message: limitMessage({
+                  unit: "messages",
+                  tier: tierCheck.tier,
+                  limit: tierCheck.limit,
+                  used: tierCheck.used,
+                  isOAuth,
+                }),
                 limit: tierCheck.limit,
                 used: tierCheck.used,
                 tier: tierCheck.tier,
+                upgrade_url: isOAuth
+                  ? "https://getengram.app/dashboard"
+                  : "https://getengram.app/pricing",
               }),
             },
           ],
@@ -126,6 +143,11 @@ export function registerAppendMessages(
         message_ids: messages.map((m) => m.id),
       }).catch(() => {});
 
+      // Usage meter — surfaced so the client can show progress and warn the
+      // user before they hit the monthly cap.
+      const meter = usageMeter(tierCheck.used, tierCheck.limit);
+      const notice = approachingLimitNotice(meter, isOAuth);
+
       return {
         content: [
           {
@@ -135,6 +157,8 @@ export function registerAppendMessages(
               appended: messages.length,
               message_ids: messages.map((m) => m.id),
               vault_entries_stored: params.vault_entries?.length ?? 0,
+              ...(meter ? { usage: meter } : {}),
+              ...(notice ? { notice } : {}),
             }),
           },
         ],

--- a/apps/mcp-server/src/mcp/tools/create-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/create-conversation.ts
@@ -5,6 +5,8 @@ import { getConversationCount } from "@getengram/db";
 import { checkConversationLimit } from "../../services/tier.js";
 import { fireWebhooks } from "../../services/webhooks.js";
 import { audit } from "../../services/audit.js";
+import { isExternalOAuthClient } from "../auth-kind.js";
+import { limitMessage } from "../usage-messaging.js";
 import type { Env, AuthContext } from "../../types.js";
 
 export function registerCreateConversation(
@@ -34,16 +36,26 @@ export function registerCreateConversation(
       const tierCheck = checkConversationLimit(auth.tier, currentCount);
 
       if (!tierCheck.allowed) {
+        const isOAuth = isExternalOAuthClient(auth);
         return {
           content: [
             {
               type: "text" as const,
               text: JSON.stringify({
                 error: tierCheck.error,
-                message: `Conversation limit exceeded. Your ${tierCheck.tier} plan allows ${tierCheck.limit} conversations. Upgrade at https://getengram.app/pricing`,
+                message: limitMessage({
+                  unit: "conversations",
+                  tier: tierCheck.tier,
+                  limit: tierCheck.limit,
+                  used: tierCheck.used,
+                  isOAuth,
+                }),
                 limit: tierCheck.limit,
                 used: tierCheck.used,
                 tier: tierCheck.tier,
+                upgrade_url: isOAuth
+                  ? "https://getengram.app/dashboard"
+                  : "https://getengram.app/pricing",
               }),
             },
           ],

--- a/apps/mcp-server/src/mcp/usage-messaging.ts
+++ b/apps/mcp-server/src/mcp/usage-messaging.ts
@@ -1,0 +1,63 @@
+// User-facing copy for plan limits + usage, tailored for OAuth-connected apps
+// (ChatGPT/Claude) vs first-party API-key/SDK callers. OAuth users are routed
+// to their own dashboard to upgrade (their org was provisioned with the email
+// they connected) — we never try to sell/charge inside the app.
+
+const DASHBOARD = "https://getengram.app/dashboard";
+const PRICING = "https://getengram.app/pricing";
+
+export interface UsageMeter {
+  used: number;
+  limit: number;
+  remaining: number;
+}
+
+/** Build a usage meter when the tier is limited; undefined for unlimited tiers. */
+export function usageMeter(used?: number, limit?: number): UsageMeter | undefined {
+  if (typeof used !== "number" || typeof limit !== "number" || limit < 0) {
+    return undefined;
+  }
+  return { used, limit, remaining: Math.max(0, limit - used) };
+}
+
+/** Friendly message when a plan limit is hit. */
+export function limitMessage(opts: {
+  unit: "messages" | "conversations";
+  tier?: string;
+  limit?: number;
+  used?: number;
+  isOAuth: boolean;
+}): string {
+  const { unit, tier, limit, used, isOAuth } = opts;
+  if (isOAuth) {
+    return (
+      `You've reached the free plan's monthly limit (${limit ?? "the included"} ${unit}). ` +
+      `Everything so far is safely saved in Engram. ` +
+      `Tell the user, warmly, that to keep saving memories they can upgrade their own Engram account: ` +
+      `open ${DASHBOARD}, sign in with the email they used to connect this app, and choose Upgrade — ` +
+      `the same account powers this connection, so the higher limit applies right away. ` +
+      `Don't try to collect payment here; just point them to their dashboard.`
+    );
+  }
+  return (
+    `${unit === "messages" ? "Message" : "Conversation"} limit reached ` +
+    `(${used ?? "?"}/${limit ?? "?"} this month on the ${tier ?? "free"} plan). ` +
+    `Upgrade at ${PRICING} to continue.`
+  );
+}
+
+/** A gentle heads-up once usage crosses 80%, so the user isn't surprised. */
+export function approachingLimitNotice(
+  meter: UsageMeter | undefined,
+  isOAuth: boolean,
+): string | undefined {
+  if (!meter || meter.limit <= 0) return undefined;
+  if (meter.used / meter.limit < 0.8) return undefined;
+  const where = isOAuth
+    ? `sign in at ${DASHBOARD} with the email you connected and upgrade`
+    : `upgrade at ${PRICING}`;
+  return (
+    `${meter.used}/${meter.limit} free messages used this month (${meter.remaining} left). ` +
+    `To avoid interruption, ${where}.`
+  );
+}

--- a/apps/mcp-server/src/services/tier.ts
+++ b/apps/mcp-server/src/services/tier.ts
@@ -64,7 +64,13 @@ export async function checkAndTrackMessages(
     };
   }
 
-  return { allowed: true };
+  // Success — surface the new count + limit so callers can show a usage meter.
+  return {
+    allowed: true,
+    used: result.messages_stored,
+    limit: limits.messages_per_month,
+    tier,
+  };
 }
 
 export async function checkMessageLimit(


### PR DESCRIPTION
Closes #207. Addresses the billing UX for ChatGPT users.

## Friendly, account-aware upgrade message
When an **OAuth-connected app (ChatGPT/Claude)** hits the free limit, the tool returns a warm, signup-oriented message that routes the user to **their own** Engram dashboard:
> "…to keep saving memories they can upgrade their own Engram account: open getengram.app/dashboard, sign in with the email they used to connect this app, and choose Upgrade…"

Their org was already provisioned (via the OAuth consent, by email), so the same account powers the connection — upgrading there lifts the limit immediately. We **never sell inside the app** (OpenAI prohibits in-app digital-subscription sales); first-party API-key/SDK callers still get the `getengram.app/pricing` link.

## Usage meter
`append_messages` success responses now include `{ usage: { used, limit, remaining } }` plus an `approachingLimitNotice` at ≥80%, so the client can show progress and warn before the cap. `checkAndTrackMessages` returns the new count on success (via the existing `RETURNING`), so the meter adds **no extra query**. (The dashboard already has its own usage cards.)

## Tests
134 passing (+8 for the messaging helpers). Typecheck clean.

Closes #207. Refs #184, #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)