### PR TITLE
feat: strip internal account IDs from tool outputs (response minimization)

### DIFF
--- a/apps/mcp-server/src/__tests__/sdk-shared-sync.test.ts
+++ b/apps/mcp-server/src/__tests__/sdk-shared-sync.test.ts
@@ -48,9 +48,11 @@ type ReverseFieldMap<S, D> = {
 describe("SDK ↔ shared type-sync contract", () => {
   describe("Conversation", () => {
     it("has a complete snake→camel field mapping", () => {
-      const sharedToSdk: FieldMap<SharedConversation, SdkConversation> = {
+      // organization_id is intentionally NOT surfaced by the SDK (it's an
+      // internal account ID; see get-conversation/list-conversations), so it's
+      // excluded from the sync contract.
+      const sharedToSdk: FieldMap<Omit<SharedConversation, "organization_id">, SdkConversation> = {
         id: "id",
-        organization_id: "organizationId",
         title: "title",
         agent_id: "agentId",
         tags: "tags",
@@ -62,7 +64,6 @@ describe("SDK ↔ shared type-sync contract", () => {
 
       const sdkToShared: ReverseFieldMap<SharedConversation, SdkConversation> = {
         id: "id",
-        organizationId: "organization_id",
         title: "title",
         agentId: "agent_id",
         tags: "tags",
@@ -86,10 +87,10 @@ describe("SDK ↔ shared type-sync contract", () => {
 
   describe("Message", () => {
     it("has a complete snake→camel field mapping", () => {
-      const sharedToSdk: FieldMap<SharedMessage, SdkMessage> = {
+      // organization_id intentionally omitted from the SDK (internal account ID).
+      const sharedToSdk: FieldMap<Omit<SharedMessage, "organization_id">, SdkMessage> = {
         id: "id",
         conversation_id: "conversationId",
-        organization_id: "organizationId",
         role: "role",
         content: "content",
         tool_call_id: "toolCallId",
@@ -102,7 +103,6 @@ describe("SDK ↔ shared type-sync contract", () => {
       const sdkToShared: ReverseFieldMap<SharedMessage, SdkMessage> = {
         id: "id",
         conversationId: "conversation_id",
-        organizationId: "organization_id",
         role: "role",
         content: "content",
         toolCallId: "tool_call_id",

--- a/apps/mcp-server/src/mcp/tools/get-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/get-conversation.ts
@@ -60,11 +60,23 @@ export function registerGetConversation(
         };
       }
 
+      // Strip internal fields the model/user don't need and that app
+      // marketplaces flag (internal account IDs, storage encoding).
+      const { organization_id: _o, ...conversation } = result.conversation;
+      const messages = result.messages.map((m) => {
+        const {
+          organization_id: _mo,
+          content_encoding: _enc,
+          ...rest
+        } = m as typeof m & { organization_id?: string; content_encoding?: string };
+        return rest;
+      });
+
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result),
+            text: JSON.stringify({ conversation, messages }),
           },
         ],
       };

--- a/apps/mcp-server/src/mcp/tools/list-conversations.ts
+++ b/apps/mcp-server/src/mcp/tools/list-conversations.ts
@@ -42,11 +42,13 @@ export function registerListConversations(
         order: params.order,
       });
 
-      const conversations = (result.results as Array<Record<string, unknown>>).map((c) => ({
-        ...c,
-        tags: JSON.parse((c.tags as string) || "[]"),
-        metadata: JSON.parse((c.metadata as string) || "{}"),
-      }));
+      const conversations = (result.results as Array<Record<string, unknown>>).map(
+        ({ organization_id: _o, ...c }) => ({
+          ...c,
+          tags: JSON.parse((c.tags as string) || "[]"),
+          metadata: JSON.parse((c.metadata as string) || "{}"),
+        }),
+      );
 
       return {
         content: [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getengram/sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "TypeScript SDK for Engram — persistent memory for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -211,7 +211,8 @@ describe("Engram SDK", () => {
 
       const result = await engram.getConversation("conv_1");
       expect(result.conversation.id).toBe("conv_1");
-      expect(result.conversation.organizationId).toBe("org_1");
+      // organization_id is intentionally not surfaced (internal account ID).
+      expect("organizationId" in result.conversation).toBe(false);
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(body.params.arguments.conversation_id).toBe("conv_1");

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -292,7 +292,6 @@ export class Engram {
 function mapConversation(raw: Record<string, unknown>): Conversation {
   return {
     id: raw.id as string,
-    organizationId: raw.organization_id as string,
     title: (raw.title as string) ?? null,
     agentId: (raw.agent_id as string) ?? null,
     tags: (raw.tags as string[]) ?? [],
@@ -307,7 +306,6 @@ function mapMessage(raw: Record<string, unknown>): Message {
   return {
     id: raw.id as string,
     conversationId: raw.conversation_id as string,
-    organizationId: raw.organization_id as string,
     role: raw.role as Message["role"],
     content: raw.content as string,
     toolCallId: (raw.tool_call_id as string) ?? null,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -36,7 +36,6 @@ export interface MessageInput {
 export interface Message {
   id: string;
   conversationId: string;
-  organizationId: string;
   role: MessageRole;
   content: string;
   toolCallId: string | null;
@@ -50,7 +49,6 @@ export interface Message {
 
 export interface Conversation {
   id: string;
-  organizationId: string;
   title: string | null;
   agentId: string | null;
   tags: string[];


### PR DESCRIPTION
Closes #187 — now a confirmed App Directory rejection reason. OpenAI's submission doc lists *"internal account IDs"* among data you must not return undisclosed, and `get_conversation` / `list_conversations` returned **`organization_id`** (plus `get_conversation` leaked the internal `content_encoding`).

## Changes
- **MCP tools:** strip `organization_id` from `get_conversation` (conversation + messages) and `list_conversations`; strip `content_encoding` from messages.
- **SDK (coordinated):** remove `organizationId` from `Conversation` and `Message` types + `mapConversation`/`mapMessage`. Bumped `@getengram/sdk` to **0.2.0** (pre-1.0 breaking).
- **Contract test:** the `sdk-shared` sync invariant now excludes `organization_id` via `Omit` (the SDK intentionally drops it).

## Tests
SDK 34 ✓, mcp-server 134 ✓, full-repo typecheck clean. The worker tool output is what review sees; the SDK change keeps its typed contract honest. `created_at`/`updated_at` (legitimately useful content timestamps) are kept.

Closes #187. Refs #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)