### PR TITLE
feat(mcp): serve OpenAI App Directory domain-verification token

### DIFF
--- a/apps/mcp-server/src/__tests__/oauth.test.ts
+++ b/apps/mcp-server/src/__tests__/oauth.test.ts
@@ -102,6 +102,15 @@ describe("OAuth discovery", () => {
     expect(body.grant_types_supported).toContain("refresh_token");
   });
 
+  it("serves the OpenAI App Directory domain-verification token", async () => {
+    const res = await app.fetch(
+      new Request("http://mcp.test/.well-known/openai-apps-challenge"),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect((await res.text()).trim()).toBe("wcJv6LrYXHjM7WuahvvnVsS-MHiXsf198fF43dpFkB8");
+  });
+
   it("challenges unauthenticated /mcp with resource_metadata", async () => {
     const res = await app.fetch(
       new Request("http://mcp.test/mcp", { method: "POST" }),

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -44,6 +44,13 @@ app.get("/.well-known/oauth-authorization-server", (c) =>
   c.json(authorizationServerMetadata(originOf(c.req.url))),
 );
 
+// OpenAI App Directory domain-ownership verification. Serves the challenge
+// token (a public proof, not a secret) at the well-known path OpenAI checks.
+const OPENAI_APPS_CHALLENGE_TOKEN = "wcJv6LrYXHjM7WuahvvnVsS-MHiXsf198fF43dpFkB8";
+app.get("/.well-known/openai-apps-challenge", (c) =>
+  c.text(OPENAI_APPS_CHALLENGE_TOKEN),
+);
+
 // OAuth authorization server endpoints (register, authorize, token).
 app.route("/oauth", oauth);
 


### PR DESCRIPTION
Serves the domain-ownership challenge token at `/.well-known/openai-apps-challenge` so OpenAI can verify `mcp.getengram.app` during App Directory submission (#184). Public proof, not a secret. +1 test.