### PR TITLE
feat(mcp): add output schemas to the 6 memory tools

### DIFF
--- a/apps/mcp-server/src/__tests__/mcp-tools-contract.test.ts
+++ b/apps/mcp-server/src/__tests__/mcp-tools-contract.test.ts
@@ -42,6 +42,7 @@ interface CapturedTool {
   description: string;
   schema: Record<string, unknown>;
   annotations?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
   handler: ToolHandler;
 }
 
@@ -59,6 +60,26 @@ function createCaptureServer(): {
       const annotations =
         rest.length >= 3 ? (rest[1] as Record<string, unknown>) : undefined;
       tools.set(name, { name, description, schema, annotations, handler });
+    },
+    // registerTool(name, { description, inputSchema, outputSchema, annotations }, handler)
+    registerTool: (
+      name: string,
+      config: {
+        description?: string;
+        inputSchema?: Record<string, unknown>;
+        outputSchema?: Record<string, unknown>;
+        annotations?: Record<string, unknown>;
+      },
+      handler: ToolHandler,
+    ) => {
+      tools.set(name, {
+        name,
+        description: config.description ?? "",
+        schema: config.inputSchema ?? {},
+        annotations: config.annotations,
+        outputSchema: config.outputSchema,
+        handler,
+      });
     },
   } as unknown as McpServer;
   return { server, tools };

--- a/apps/mcp-server/src/__tests__/oauth.test.ts
+++ b/apps/mcp-server/src/__tests__/oauth.test.ts
@@ -499,3 +499,44 @@ describe("Published (OAuth) toolset is memory-only", () => {
     expect(text).toContain("manage_subscription");
   });
 });
+
+describe("Tool output schemas (structuredContent validates at runtime)", () => {
+  it("create_conversation returns validated structuredContent via a real tools/call", async () => {
+    const env = createOAuthEnv(createOAuthD1());
+    const clientId = await registerClient(env);
+    const { verifier, challenge } = await pkcePair();
+    const code = await getAuthCode(env, clientId, challenge);
+    const tok = (await (await app.fetch(
+      form({ grant_type: "authorization_code", client_id: clientId, code, redirect_uri: REDIRECT, code_verifier: verifier }),
+      env,
+    )).json()) as { access_token: string };
+
+    // tools/call goes through the real McpServer, which validates the returned
+    // structuredContent against the tool's outputSchema. A schema mismatch
+    // would surface as a JSON-RPC error here.
+    const res = await app.fetch(
+      new Request("http://mcp.test/mcp", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${tok.access_token}`,
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "create_conversation", arguments: { title: "Schema test" } },
+        }),
+      }),
+      env,
+      MOCK_CTX,
+    );
+    const text = await res.text();
+    expect(res.status).not.toBe(401);
+    expect(text).toContain("structuredContent");
+    expect(text).toContain("conversation_id");
+    // No JSON-RPC error object (e.g. a validation failure).
+    expect(text).not.toMatch(/"error"\s*:\s*\{/);
+  });
+});

--- a/apps/mcp-server/src/mcp/tools/append-messages.ts
+++ b/apps/mcp-server/src/mcp/tools/append-messages.ts
@@ -20,10 +20,12 @@ export function registerAppendMessages(
   env: Env,
   auth: AuthContext
 ) {
-  server.tool(
+  server.registerTool(
     "append_messages",
-    "Store messages in Engram memory, verbatim and automatically chunked + embedded for search. conversation_id is OPTIONAL: omit it to append to the user's default memory (recommended for general 'remember this' requests) — never ask the user for an id. Pass a conversation_id (from create_conversation) only when you want to group a specific topic. The response returns the conversation_id used. Optionally accepts client-encrypted vault entries for secrets detected client-side.",
     {
+      description:
+        "Store messages in Engram memory, verbatim and automatically chunked + embedded for search. conversation_id is OPTIONAL: omit it to append to the user's default memory (recommended for general 'remember this' requests) — never ask the user for an id. Pass a conversation_id (from create_conversation) only when you want to group a specific topic. The response returns the conversation_id used. Optionally accepts client-encrypted vault entries for secrets detected client-side.",
+      inputSchema: {
       conversation_id: z
         .string()
         .optional()
@@ -59,13 +61,25 @@ export function registerAppendMessages(
         .describe(
           "Client-encrypted vault entries. Server stores these as opaque blobs — zero knowledge."
         ),
-    },
-    {
-      title: "Append messages",
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: false,
+      },
+      outputSchema: {
+        conversation_id: z.string().describe("The conversation the messages were stored in"),
+        appended: z.number().describe("Number of messages stored"),
+        message_ids: z.array(z.string()),
+        vault_entries_stored: z.number(),
+        usage: z
+          .object({ used: z.number(), limit: z.number(), remaining: z.number() })
+          .optional()
+          .describe("Monthly message usage for the org (limited tiers only)"),
+        notice: z.string().optional().describe("Heads-up shown when approaching the plan limit"),
+      },
+      annotations: {
+        title: "Append messages",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
     },
     async (params) => {
       // Atomically check tier limit AND increment usage in one operation.
@@ -148,20 +162,18 @@ export function registerAppendMessages(
       const meter = usageMeter(tierCheck.used, tierCheck.limit);
       const notice = approachingLimitNotice(meter, isOAuth);
 
+      const payload = {
+        conversation_id: conversationId,
+        appended: messages.length,
+        message_ids: messages.map((m) => m.id),
+        vault_entries_stored: params.vault_entries?.length ?? 0,
+        ...(meter ? { usage: meter } : {}),
+        ...(notice ? { notice } : {}),
+      };
+
       return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({
-              conversation_id: conversationId,
-              appended: messages.length,
-              message_ids: messages.map((m) => m.id),
-              vault_entries_stored: params.vault_entries?.length ?? 0,
-              ...(meter ? { usage: meter } : {}),
-              ...(notice ? { notice } : {}),
-            }),
-          },
-        ],
+        content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+        structuredContent: payload,
       };
     }
   );

--- a/apps/mcp-server/src/mcp/tools/create-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/create-conversation.ts
@@ -14,20 +14,26 @@ export function registerCreateConversation(
   env: Env,
   auth: AuthContext
 ) {
-  server.tool(
+  server.registerTool(
     "create_conversation",
-    "Create a new conversation and return its conversation_id. Call this yourself to obtain an id before appending — the id is yours to generate and reuse; never ask the user to provide one. Create one conversation per session/topic and reuse its id for all subsequent append_messages calls.",
     {
-      title: z.string().optional().describe("Title for the conversation"),
-      agent_id: z.string().optional().describe("Agent identifier (e.g. \"chatgpt\")"),
-      tags: z.array(z.string()).optional().describe("Tags for filtering"),
-      metadata: z.record(z.unknown()).optional().describe("Arbitrary metadata"),
-    },
-    {
-      title: "Create conversation",
-      readOnlyHint: false,
-      destructiveHint: false,
-      openWorldHint: false,
+      description:
+        "Create a new conversation and return its conversation_id. Call this yourself to obtain an id before appending — the id is yours to generate and reuse; never ask the user to provide one. Create one conversation per session/topic and reuse its id for all subsequent append_messages calls.",
+      inputSchema: {
+        title: z.string().optional().describe("Title for the conversation"),
+        agent_id: z.string().optional().describe("Agent identifier (e.g. \"chatgpt\")"),
+        tags: z.array(z.string()).optional().describe("Tags for filtering"),
+        metadata: z.record(z.unknown()).optional().describe("Arbitrary metadata"),
+      },
+      outputSchema: {
+        conversation_id: z.string().describe("The id of the created conversation"),
+      },
+      annotations: {
+        title: "Create conversation",
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
     },
     async (params) => {
       // Check conversation limit
@@ -87,6 +93,7 @@ export function registerCreateConversation(
             text: JSON.stringify({ conversation_id: id }),
           },
         ],
+        structuredContent: { conversation_id: id },
       };
     }
   );

--- a/apps/mcp-server/src/mcp/tools/delete-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/delete-conversation.ts
@@ -9,18 +9,23 @@ export function registerDeleteConversation(
   env: Env,
   auth: AuthContext
 ) {
-  server.tool(
+  server.registerTool(
     "delete_conversation",
-    "Delete a conversation and all its messages, chunks, and vector embeddings.",
     {
-      conversation_id: z.string().describe("The conversation to delete"),
-    },
-    {
-      title: "Delete conversation",
-      readOnlyHint: false,
-      destructiveHint: true,
-      idempotentHint: true,
-      openWorldHint: false,
+      description: "Delete a conversation and all its messages, chunks, and vector embeddings.",
+      inputSchema: {
+        conversation_id: z.string().describe("The conversation to delete"),
+      },
+      outputSchema: {
+        deleted: z.boolean().describe("True when the conversation was deleted"),
+      },
+      annotations: {
+        title: "Delete conversation",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async (params) => {
       const deleted = await deleteConversation(
@@ -50,6 +55,7 @@ export function registerDeleteConversation(
             text: JSON.stringify({ deleted: true }),
           },
         ],
+        structuredContent: { deleted: true },
       };
     }
   );

--- a/apps/mcp-server/src/mcp/tools/get-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/get-conversation.ts
@@ -9,10 +9,11 @@ export function registerGetConversation(
   env: Env,
   auth: AuthContext
 ) {
-  server.tool(
+  server.registerTool(
     "get_conversation",
-    "Get a conversation with its full verbatim messages. Supports pagination.",
     {
+      description: "Get a conversation with its full verbatim messages. Supports pagination.",
+      inputSchema: {
       conversation_id: z.string().describe("The conversation to retrieve"),
       message_limit: z
         .number()
@@ -29,13 +30,40 @@ export function registerGetConversation(
         .optional()
         .default(0)
         .describe("Message offset for pagination"),
-    },
-    {
-      title: "Get conversation",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: false,
+      },
+      outputSchema: {
+        conversation: z
+          .object({
+            id: z.string().optional(),
+            title: z.string().nullable().optional(),
+            agent_id: z.string().nullable().optional(),
+            tags: z.array(z.string()).optional(),
+            metadata: z.record(z.unknown()).optional(),
+            message_count: z.number().optional(),
+            created_at: z.string().optional(),
+            updated_at: z.string().optional(),
+          })
+          .passthrough(),
+        messages: z.array(
+          z
+            .object({
+              id: z.string().optional(),
+              conversation_id: z.string().optional(),
+              role: z.string().optional(),
+              content: z.string().optional(),
+              sequence: z.number().optional(),
+              created_at: z.string().optional(),
+            })
+            .passthrough(),
+        ),
+      },
+      annotations: {
+        title: "Get conversation",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async (params) => {
       audit(env.DB, auth.organizationId, auth.apiKeyId, "conversation.read", "conversation", params.conversation_id);
@@ -79,6 +107,7 @@ export function registerGetConversation(
             text: JSON.stringify({ conversation, messages }),
           },
         ],
+        structuredContent: { conversation, messages },
       };
     }
   );

--- a/apps/mcp-server/src/mcp/tools/list-conversations.ts
+++ b/apps/mcp-server/src/mcp/tools/list-conversations.ts
@@ -9,26 +9,45 @@ export function registerListConversations(
   env: Env,
   auth: AuthContext
 ) {
-  server.tool(
+  server.registerTool(
     "list_conversations",
-    "List conversations with filtering and sorting options.",
     {
-      limit: z.number().int().min(1).max(100).optional().default(20),
-      offset: z.number().int().min(0).optional().default(0),
-      agent_id: z.string().optional().describe("Filter by agent ID"),
-      tags: z.array(z.string()).optional().describe("Filter by tags"),
-      sort: z
-        .enum(["created_at", "updated_at", "message_count"])
-        .optional()
-        .default("updated_at"),
-      order: z.enum(["asc", "desc"]).optional().default("desc"),
-    },
-    {
-      title: "List conversations",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: false,
+      description: "List conversations with filtering and sorting options.",
+      inputSchema: {
+        limit: z.number().int().min(1).max(100).optional().default(20),
+        offset: z.number().int().min(0).optional().default(0),
+        agent_id: z.string().optional().describe("Filter by agent ID"),
+        tags: z.array(z.string()).optional().describe("Filter by tags"),
+        sort: z
+          .enum(["created_at", "updated_at", "message_count"])
+          .optional()
+          .default("updated_at"),
+        order: z.enum(["asc", "desc"]).optional().default("desc"),
+      },
+      outputSchema: {
+        conversations: z.array(
+          z
+            .object({
+              id: z.string().optional(),
+              title: z.string().nullable().optional(),
+              agent_id: z.string().nullable().optional(),
+              tags: z.array(z.string()).optional(),
+              metadata: z.record(z.unknown()).optional(),
+              message_count: z.number().optional(),
+              created_at: z.string().optional(),
+              updated_at: z.string().optional(),
+            })
+            .passthrough(),
+        ),
+        total: z.number(),
+      },
+      annotations: {
+        title: "List conversations",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async (params) => {
       audit(env.DB, auth.organizationId, auth.apiKeyId, "conversation.list");
@@ -60,6 +79,7 @@ export function registerListConversations(
             }),
           },
         ],
+        structuredContent: { conversations, total: conversations.length },
       };
     }
   );

--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -10,10 +10,12 @@ export function registerSearch(
   env: Env,
   auth: AuthContext
 ) {
-  server.tool(
+  server.registerTool(
     "search",
-    "Hybrid search (semantic + keyword) across stored conversations. Returns the most relevant chunk_text snippets with conversation_title, tags, and scores. One search is enough — do not retry with rephrased queries.",
     {
+      description:
+        "Hybrid search (semantic + keyword) across stored conversations. Returns the most relevant chunk_text snippets with conversation_title, tags, and scores. One search is enough — do not retry with rephrased queries.",
+      inputSchema: {
       query: z.string().describe("Search query text"),
       limit: z
         .number()
@@ -31,13 +33,33 @@ export function registerSearch(
         .array(z.string())
         .optional()
         .describe("Filter by conversation tags"),
-    },
-    {
-      title: "Search memory",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: false,
+      },
+      outputSchema: {
+        results: z
+          .array(
+            z
+              .object({
+                conversation_id: z.string().optional(),
+                conversation_title: z.string().optional(),
+                chunk_text: z.string().optional(),
+                score: z.number().optional(),
+                chunk_id: z.string().optional(),
+                start_sequence: z.number().optional(),
+                end_sequence: z.number().optional(),
+                tags: z.array(z.string()).optional(),
+              })
+              .passthrough(),
+          )
+          .describe("Relevant conversation snippets, best match first"),
+        total: z.number(),
+      },
+      annotations: {
+        title: "Search memory",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async (params) => {
       const results = await searchConversations(
@@ -63,6 +85,7 @@ export function registerSearch(
             text: JSON.stringify({ results, total: results.length }),
           },
         ],
+        structuredContent: { results, total: results.length },
       };
     }
   );


### PR DESCRIPTION
Migrates the 6 memory tools to `registerTool()` with an `outputSchema` + validated `structuredContent` (satisfies OpenAI's recommendation, improves model understanding of results). Variable/nested schemas use optional+passthrough so real responses always validate. A real `tools/call` test confirms the SDK validates with no runtime error. 136 tests, typecheck clean. Part of #184.