### PR TITLE
feat: improve search recall with recency, proper nouns, and title context

### DIFF
--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -12,7 +12,7 @@ export function registerSearch(
 ) {
   server.tool(
     "search",
-    "Hybrid search (semantic + keyword) across stored conversations. Returns the most relevant chunk_text snippets with conversation_title, tags, and scores. One search is enough — do not retry with rephrased queries.",
+    "Hybrid search (semantic + keyword) across stored conversations. Returns the most relevant chunk_text snippets with conversation_title, tags, and scores. One search is enough — do not retry with rephrased queries. Tip: if the user references something recent (\"remember we were...\", \"pick up where we left off\"), use recency: \"strong\" to boost recent conversations. You can also use list_conversations(sort: \"updated_at\") for recent session context.",
     {
       query: z.string().describe("Search query text"),
       limit: z
@@ -31,8 +31,16 @@ export function registerSearch(
         .array(z.string())
         .optional()
         .describe("Filter by conversation tags"),
+      recency: z
+        .enum(["none", "auto", "strong"])
+        .optional()
+        .default("auto")
+        .describe("Recency bias: 'none' = pure relevance, 'auto' = modest boost to recent conversations (default), 'strong' = heavily prefer recent conversations"),
     },
     async (params) => {
+      const recencyWeights = { none: 0, auto: 0.15, strong: 0.5 };
+      const recencyWeight = recencyWeights[params.recency];
+
       const results = await searchConversations(
         env,
         auth.organizationId,
@@ -40,6 +48,10 @@ export function registerSearch(
         params.limit,
         params.conversation_id,
         params.tags,
+        undefined, // snippetChars
+        undefined, // minScore
+        undefined, // dedupe
+        recencyWeight,
       );
 
       // Track usage (non-blocking)

--- a/apps/mcp-server/src/services/conversation.ts
+++ b/apps/mcp-server/src/services/conversation.ts
@@ -140,8 +140,21 @@ export async function appendMessages(
   const chunks = chunkMessages(redacted);
 
   if (chunks.length > 0) {
-    // Generate embeddings for all chunks
-    const texts = chunks.map((c) => c.text);
+    // P1 + P4: Build context prefix from conversation title/tags.
+    // This enriches both FTS (keyword search on title) and embeddings
+    // (semantic search understands what the conversation is about).
+    const convTitle = (conv as Record<string, unknown>).title as string | null;
+    const convTags = JSON.parse(((conv as Record<string, unknown>).tags as string) || "[]") as string[];
+    const contextParts: string[] = [];
+    if (convTitle) contextParts.push(`Title: ${convTitle}`);
+    if (convTags.length > 0) contextParts.push(`Tags: ${convTags.join(", ")}`);
+    const contextPrefix = contextParts.join(" | ");
+
+    // P4: Prepend context to chunk text before embedding so vector search
+    // captures conversation-level meaning (e.g. "email to Antonia")
+    const texts = chunks.map((c) =>
+      contextPrefix ? `${contextPrefix}\n${c.text}` : c.text
+    );
     const embeddings = await generateEmbeddings(env.AI, texts);
 
     // Prepare chunk records with vectorize IDs
@@ -159,7 +172,7 @@ export async function appendMessages(
       };
     });
 
-    // Insert chunks into D1
+    // Insert chunks into D1 (P1: pass context prefix for FTS enrichment)
     await insertChunks(
       env.DB,
       chunkRecords.map((c) => ({
@@ -170,7 +183,8 @@ export async function appendMessages(
         startSequence: c.startSequence,
         endSequence: c.endSequence,
         vectorizeId: c.vectorizeId,
-      }))
+      })),
+      contextPrefix || undefined
     );
 
     // Upsert vectors to Vectorize

--- a/apps/mcp-server/src/services/search.ts
+++ b/apps/mcp-server/src/services/search.ts
@@ -19,9 +19,46 @@ const RRF_K = 60;
 // Max possible RRF score with 2 lists: 2 / (k + 0)
 const RRF_MAX = 2 / RRF_K;
 
+// P0: Recency decay — half-life ~7 days (lambda = ln(2)/7 ≈ 0.099)
+const RECENCY_LAMBDA = 0.099;
+const DEFAULT_RECENCY_WEIGHT = 0.15;
+
+// P2: Proper noun bonus — applied when exact name match found in chunk
+const PROPER_NOUN_BOOST = 0.3;
+
 function truncateSnippet(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;
   return text.slice(0, maxChars) + TRUNCATION_MARKER;
+}
+
+// P0: Exponential decay — returns [0, 1] where 1 = now, 0.5 ≈ 7 days ago
+function computeRecencyBoost(updatedAt: string): number {
+  const ageMs = Date.now() - new Date(updatedAt).getTime();
+  const ageDays = Math.max(ageMs / (1000 * 60 * 60 * 24), 0);
+  return Math.exp(-RECENCY_LAMBDA * ageDays);
+}
+
+// P2: Extract likely proper nouns — capitalized words ≥2 chars, not common English words
+const COMMON_WORDS = new Set([
+  "the", "and", "for", "are", "but", "not", "you", "all", "can", "had",
+  "her", "was", "one", "our", "out", "has", "his", "how", "its", "may",
+  "new", "now", "old", "see", "way", "who", "did", "get", "let", "say",
+  "she", "too", "use", "what", "when", "where", "which", "will", "with",
+  "this", "that", "from", "they", "been", "have", "many", "some", "them",
+  "than", "each", "make", "like", "just", "over", "such", "take", "into",
+  "most", "also", "about", "after", "before", "between", "could", "every",
+  "first", "found", "great", "house", "large", "never", "other",
+  "place", "point", "right", "small", "still", "think", "those", "under",
+  "being", "might", "should", "would", "could", "these", "their",
+  "email", "reply", "search", "remember", "write", "writing", "check",
+  "find", "look", "send", "sent", "draft", "last", "recent",
+]);
+
+function extractProperNouns(query: string): string[] {
+  return query
+    .split(/\s+/)
+    .filter((w) => /^[A-Z][a-z]{1,}/.test(w) && !COMMON_WORDS.has(w.toLowerCase()))
+    .map((w) => w.replace(/[^a-zA-Z]/g, ""));
 }
 
 export async function searchConversations(
@@ -33,7 +70,8 @@ export async function searchConversations(
   tags?: string[],
   snippetChars: number = DEFAULT_SNIPPET_CHARS,
   minScore: number = DEFAULT_MIN_SCORE,
-  dedupe: boolean = true
+  dedupe: boolean = true,
+  recencyWeight: number = DEFAULT_RECENCY_WEIGHT
 ): Promise<SearchResult[]> {
   const cappedSnippet = Math.min(
     Math.max(snippetChars, 0),
@@ -131,39 +169,65 @@ export async function searchConversations(
     rrfScores.set(chunkId, score + 1 / (RRF_K + rank));
   }
 
-  // Hydrate conversation title + tags
+  // Hydrate conversation title + tags + updated_at (P0: recency needs updated_at)
   const uniqueConvIds = [...new Set([...chunkMap.values()].map((c) => c.conversation_id))];
-  const convMeta = new Map<string, { title: string; tags: string[] }>();
+  const convMeta = new Map<string, { title: string; tags: string[]; updated_at: string }>();
 
   if (uniqueConvIds.length > 0) {
     const placeholders = uniqueConvIds.map(() => "?").join(",");
     const rows = await env.DB.prepare(
-      `SELECT id, title, tags FROM conversations WHERE id IN (${placeholders}) AND organization_id = ?`
+      `SELECT id, title, tags, updated_at FROM conversations WHERE id IN (${placeholders}) AND organization_id = ?`
     )
       .bind(...uniqueConvIds, organizationId)
-      .all<{ id: string; title: string; tags: string }>();
+      .all<{ id: string; title: string; tags: string; updated_at: string }>();
 
     for (const row of rows.results) {
       convMeta.set(row.id, {
         title: row.title,
         tags: row.tags ? JSON.parse(row.tags) : [],
+        updated_at: row.updated_at,
       });
     }
   }
 
-  // Build results with normalized RRF scores [0, 1]
+  // P2: Extract proper nouns for exact-match boosting
+  const properNouns = extractProperNouns(query);
+  const properNounsLower = properNouns.map((n) => n.toLowerCase());
+
+  // Build results with normalized RRF scores + P0 recency + P2 proper noun boosts
   let results: SearchResult[] = [];
   for (const [chunkId, rawScore] of rrfScores) {
     const chunk = chunkMap.get(chunkId);
     if (!chunk) continue;
     const meta = convMeta.get(chunk.conversation_id);
+
+    let score = rawScore / RRF_MAX; // normalize to [0, 1]
+
+    // P0: Recency boost — recent conversations score higher
+    if (recencyWeight > 0 && meta?.updated_at) {
+      const recency = computeRecencyBoost(meta.updated_at);
+      score *= 1 + recencyWeight * recency;
+    }
+
+    // P2: Proper noun boost — exact name matches get a bonus
+    if (properNounsLower.length > 0) {
+      const textLower = chunk.chunk_text.toLowerCase();
+      const titleLower = (meta?.title ?? "").toLowerCase();
+      for (const noun of properNounsLower) {
+        if (textLower.includes(noun) || titleLower.includes(noun)) {
+          score *= 1 + PROPER_NOUN_BOOST;
+          break; // one boost per chunk, not per noun
+        }
+      }
+    }
+
     results.push({
       chunk_id: chunk.id,
       conversation_id: chunk.conversation_id,
       conversation_title: meta?.title,
       tags: meta?.tags,
       chunk_text: truncateSnippet(chunk.chunk_text, cappedSnippet),
-      score: rawScore / RRF_MAX, // normalize to [0, 1]
+      score,
       start_sequence: chunk.start_sequence,
       end_sequence: chunk.end_sequence,
     });

--- a/packages/db/migrations/0013_fts_title_context.sql
+++ b/packages/db/migrations/0013_fts_title_context.sql
@@ -1,0 +1,17 @@
+-- P1: Backfill FTS index with conversation title context.
+-- This makes keyword searches match on conversation titles (e.g. "Antonia")
+-- even when the name only appears in the title, not the chunk text.
+
+DELETE FROM chunks_fts;
+
+INSERT INTO chunks_fts(chunk_text, chunk_id, organization_id)
+  SELECT
+    CASE
+      WHEN c.title IS NOT NULL AND c.title != ''
+        THEN 'Title: ' || c.title || CHAR(10) || cc.chunk_text
+      ELSE cc.chunk_text
+    END,
+    cc.id,
+    cc.organization_id
+  FROM conversation_chunks cc
+  JOIN conversations c ON c.id = cc.conversation_id;

--- a/packages/db/src/queries/chunks.ts
+++ b/packages/db/src/queries/chunks.ts
@@ -8,8 +8,13 @@ export function insertChunks(
     startSequence: number;
     endSequence: number;
     vectorizeId: string;
-  }>
+  }>,
+  ftsContext?: string
 ) {
+  // P1: Prepend conversation title/tags to FTS text so keyword search
+  // matches on conversation-level metadata, not just message content.
+  const ftsPrefix = ftsContext ? ftsContext + "\n" : "";
+
   const stmts = chunks.flatMap((c) => [
     db
       .prepare(
@@ -29,7 +34,7 @@ export function insertChunks(
       .prepare(
         "INSERT INTO chunks_fts(chunk_text, chunk_id, organization_id) VALUES (?, ?, ?)"
       )
-      .bind(c.chunkText, c.id, c.organizationId),
+      .bind(ftsPrefix + c.chunkText, c.id, c.organizationId),
   ]);
   return db.batch(stmts);
 }


### PR DESCRIPTION
## Summary

Closes #215. Search was failing to find conversations by entity names (e.g. "email to Antonia") because:

1. Semantic search dilutes proper nouns into generic concept space
2. No recency signal — yesterday's conversation scored the same as 3-month-old ones
3. Conversation titles weren't searchable via FTS
4. Embeddings had no conversation-level context

**Five improvements implemented:**

- **P0 — Recency-weighted scoring**: Exponential decay boost (half-life ~7 days) from `updated_at`. Default 15% weight, configurable via `recency` parameter.
- **P1 — FTS title context**: Conversation title prepended to chunk text in the FTS index so keyword searches match on titles. Migration 0013 backfills existing data.
- **P2 — Proper noun boost**: Extracts capitalized words from query, applies 30% score boost when exact match found in chunk text or conversation title.
- **P3 — `recency` parameter**: Search tool now exposes `recency: "none" | "auto" | "strong"` with hints in the tool description for session continuity queries.
- **P4 — Embedding context**: Title/tags prepended to chunk text before generating embeddings, giving vector search conversation-level meaning.

## Test plan

- [x] All 215 existing tests pass
- [x] Type check passes across all packages
- [ ] Deploy migration 0013 to staging and verify FTS backfill
- [ ] Test search for entity names that only appear in conversation titles
- [ ] Test `recency: "strong"` boosts recent conversations to top of results
- [ ] Verify new conversations get title context in both FTS and embeddings

🤖 Generated with [Claude Code](https://claude.com/claude-code)