### PR TITLE
feat(privacy): org-level assistant sharing controls (worker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .env
 supabase/.temp/
 .claude/
+docs/launch/handoff/

--- a/apps/mcp-server/src/__tests__/privacy.test.ts
+++ b/apps/mcp-server/src/__tests__/privacy.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { privacy } from "../routes/privacy.js";
+import { createMockD1, createMockEnv } from "./helpers.js";
+import { insertOrganization } from "@getengram/db";
+import type { Env, AuthContext } from "../types.js";
+
+type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
+
+function createApp(orgId: string) {
+  const app = new Hono<HonoEnv>();
+  app.use("*", async (c, next) => {
+    c.set("auth", {
+      organizationId: orgId,
+      apiKeyId: "key_test",
+      tier: "free" as const,
+    });
+    await next();
+  });
+  app.route("/api/privacy", privacy);
+  return app;
+}
+
+describe("GET /api/privacy", () => {
+  it("defaults both toggles to open (true) for a fresh org", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    await insertOrganization(db, "org_p1", "Privacy Org");
+
+    const app = createApp("org_p1");
+    const res = await app.request("/api/privacy", {}, env);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.assistant_can_read_bodies).toBe(true);
+    expect(body.assistant_can_read_cross_conversation).toBe(true);
+  });
+});
+
+describe("PATCH /api/privacy", () => {
+  it("rejects non-boolean values with 400", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    await insertOrganization(db, "org_p2", "Privacy Org");
+
+    const app = createApp("org_p2");
+    const res = await app.request(
+      "/api/privacy",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ assistant_can_read_bodies: "nope" }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("invalid_settings");
+  });
+
+  it("updates one toggle and leaves the other at its default", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    await insertOrganization(db, "org_p3", "Privacy Org");
+
+    const app = createApp("org_p3");
+    const res = await app.request(
+      "/api/privacy",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ assistant_can_read_bodies: false }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.updated).toBe(true);
+    expect(body.assistant_can_read_bodies).toBe(false);
+    // Omitted field merges onto the current (default-open) value.
+    expect(body.assistant_can_read_cross_conversation).toBe(true);
+  });
+});

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -12,6 +12,7 @@ import { signup } from "./routes/signup.js";
 import { billing, billingSession, billingWebhook } from "./routes/billing.js";
 import { admin } from "./routes/admin.js";
 import { account } from "./routes/account.js";
+import { privacy } from "./routes/privacy.js";
 import { dataExport } from "./routes/export.js";
 import { oauthConnections } from "./routes/oauth-connections.js";
 import { purgeDeletedOrganizations } from "./cron/purge-deleted.js";
@@ -136,6 +137,7 @@ app.route("/api/seats", seats);
 app.route("/api/webhooks", webhooks);
 app.route("/api/usage", usage);
 app.route("/api/account", account);
+app.route("/api/privacy", privacy);
 app.route("/api/export", dataExport);
 app.route("/api/oauth/connections", oauthConnections);
 

--- a/apps/mcp-server/src/mcp/tools/get-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/get-conversation.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getConversation } from "../../services/conversation.js";
 import { audit } from "../../services/audit.js";
+import { loadPrivacy, PRIVACY_BODIES_NOTICE } from "../../services/privacy.js";
 import type { Env, AuthContext } from "../../types.js";
 
 export function registerGetConversation(
@@ -91,23 +92,37 @@ export function registerGetConversation(
       // Strip internal fields the model/user don't need and that app
       // marketplaces flag (internal account IDs, storage encoding).
       const { organization_id: _o, ...conversation } = result.conversation;
+      const privacy = await loadPrivacy(env.DB, auth.organizationId);
       const messages = result.messages.map((m) => {
         const {
           organization_id: _mo,
           content_encoding: _enc,
+          content,
           ...rest
-        } = m as typeof m & { organization_id?: string; content_encoding?: string };
-        return rest;
+        } = m as typeof m & {
+          organization_id?: string;
+          content_encoding?: string;
+          content?: string;
+        };
+        // Honor the org's privacy setting: when bodies are hidden, return
+        // message metadata (role, sequence, timestamps) but not content.
+        return privacy.canReadBodies
+          ? { ...rest, content }
+          : { ...rest, body_hidden: true };
       });
+
+      const payload = privacy.canReadBodies
+        ? { conversation, messages }
+        : { conversation, messages, privacy_notice: PRIVACY_BODIES_NOTICE };
 
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify({ conversation, messages }),
+            text: JSON.stringify(payload),
           },
         ],
-        structuredContent: { conversation, messages },
+        structuredContent: payload,
       };
     }
   );

--- a/apps/mcp-server/src/mcp/tools/list-conversations.ts
+++ b/apps/mcp-server/src/mcp/tools/list-conversations.ts
@@ -2,6 +2,10 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { listConversations as dbListConversations } from "@getengram/db";
 import { audit } from "../../services/audit.js";
+import {
+  loadPrivacy,
+  PRIVACY_CROSS_CONVERSATION_NOTICE,
+} from "../../services/privacy.js";
 import type { Env, AuthContext } from "../../types.js";
 
 export function registerListConversations(
@@ -51,6 +55,23 @@ export function registerListConversations(
     },
     async (params) => {
       audit(env.DB, auth.organizationId, auth.apiKeyId, "conversation.list");
+
+      // Listing all conversations is cross-conversation metadata sharing;
+      // honor the org's privacy setting.
+      const privacy = await loadPrivacy(env.DB, auth.organizationId);
+      if (!privacy.canReadCrossConversation) {
+        const payload = {
+          conversations: [],
+          total: 0,
+          privacy_notice: PRIVACY_CROSS_CONVERSATION_NOTICE,
+        };
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(payload) },
+          ],
+          structuredContent: payload,
+        };
+      }
 
       const result = await dbListConversations(env.DB, auth.organizationId, {
         limit: params.limit,

--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 import { searchConversations } from "../../services/search.js";
 import { trackSearchRun } from "../../services/tier.js";
 import { audit } from "../../services/audit.js";
+import {
+  loadPrivacy,
+  PRIVACY_BODIES_NOTICE,
+  PRIVACY_CROSS_CONVERSATION_NOTICE,
+} from "../../services/privacy.js";
 import type { Env, AuthContext } from "../../types.js";
 
 export function registerSearch(
@@ -62,7 +67,26 @@ export function registerSearch(
       },
     },
     async (params) => {
-      const results = await searchConversations(
+      const privacy = await loadPrivacy(env.DB, auth.organizationId);
+
+      // A search without a conversation_id spans all conversations. When
+      // cross-conversation access is off, only single-conversation search
+      // is allowed.
+      if (!privacy.canReadCrossConversation && !params.conversation_id) {
+        const payload = {
+          results: [],
+          total: 0,
+          privacy_notice: PRIVACY_CROSS_CONVERSATION_NOTICE,
+        };
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(payload) },
+          ],
+          structuredContent: payload,
+        };
+      }
+
+      const raw = await searchConversations(
         env,
         auth.organizationId,
         params.query,
@@ -71,6 +95,12 @@ export function registerSearch(
         params.tags,
       );
 
+      // When bodies are hidden, return the matching conversations'
+      // metadata (title, tags, score) but drop the verbatim snippet.
+      const results = privacy.canReadBodies
+        ? raw
+        : raw.map(({ chunk_text: _c, ...rest }) => rest);
+
       // Track usage (non-blocking)
       trackSearchRun(env.DB, auth.organizationId).catch(() => {});
       audit(env.DB, auth.organizationId, auth.apiKeyId, "search", undefined, undefined, {
@@ -78,14 +108,18 @@ export function registerSearch(
         results: results.length,
       });
 
+      const payload = privacy.canReadBodies
+        ? { results, total: results.length }
+        : { results, total: results.length, privacy_notice: PRIVACY_BODIES_NOTICE };
+
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify({ results, total: results.length }),
+            text: JSON.stringify(payload),
           },
         ],
-        structuredContent: { results, total: results.length },
+        structuredContent: payload,
       };
     }
   );

--- a/apps/mcp-server/src/routes/privacy.ts
+++ b/apps/mcp-server/src/routes/privacy.ts
@@ -1,0 +1,70 @@
+import { Hono } from "hono";
+import { getPrivacySettings, updatePrivacySettings } from "@getengram/db";
+import { audit } from "../services/audit.js";
+import type { Env, AuthContext } from "../types.js";
+
+type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
+
+const privacy = new Hono<HonoEnv>();
+
+// GET /api/privacy — current privacy & sharing settings for the org.
+privacy.get("/", async (c) => {
+  const auth = c.get("auth");
+  const row = await getPrivacySettings(c.env.DB, auth.organizationId);
+  return c.json({
+    // Default open when the columns are missing (pre-migration rows).
+    assistant_can_read_bodies: row?.assistant_can_read_bodies !== 0,
+    assistant_can_read_cross_conversation:
+      row?.assistant_can_read_cross_conversation !== 0,
+  });
+});
+
+// PATCH /api/privacy — update either/both toggles. Omitted fields are left as-is.
+privacy.patch("/", async (c) => {
+  const auth = c.get("auth");
+  const orgId = auth.organizationId;
+  const body = await c.req
+    .json<{
+      assistant_can_read_bodies?: unknown;
+      assistant_can_read_cross_conversation?: unknown;
+    }>()
+    .catch(() => ({}));
+
+  const bodies = (body as Record<string, unknown>).assistant_can_read_bodies;
+  const cross = (body as Record<string, unknown>)
+    .assistant_can_read_cross_conversation;
+
+  if (
+    (bodies !== undefined && typeof bodies !== "boolean") ||
+    (cross !== undefined && typeof cross !== "boolean")
+  ) {
+    return c.json(
+      {
+        error: "invalid_settings",
+        message:
+          "assistant_can_read_bodies and assistant_can_read_cross_conversation must be booleans",
+      },
+      400,
+    );
+  }
+
+  // Merge onto current values so a partial PATCH doesn't reset the other toggle.
+  const current = await getPrivacySettings(c.env.DB, orgId);
+  const next = {
+    assistant_can_read_bodies:
+      typeof bodies === "boolean"
+        ? bodies
+        : current?.assistant_can_read_bodies !== 0,
+    assistant_can_read_cross_conversation:
+      typeof cross === "boolean"
+        ? cross
+        : current?.assistant_can_read_cross_conversation !== 0,
+  };
+
+  await updatePrivacySettings(c.env.DB, orgId, next);
+  audit(c.env.DB, orgId, auth.apiKeyId, "privacy.update", undefined, undefined, next);
+
+  return c.json({ updated: true, ...next });
+});
+
+export { privacy };

--- a/apps/mcp-server/src/services/audit.ts
+++ b/apps/mcp-server/src/services/audit.ts
@@ -11,6 +11,7 @@ export type AuditAction =
   | "account.update_email"
   | "account.delete"
   | "account.restore"
+  | "privacy.update"
   | "data.export"
   | "auth.success"
   | "auth.failure"

--- a/apps/mcp-server/src/services/privacy.ts
+++ b/apps/mcp-server/src/services/privacy.ts
@@ -1,0 +1,31 @@
+import { getPrivacySettings } from "@getengram/db";
+
+/**
+ * Effective privacy posture for an organization, resolved to booleans.
+ * Both default to `true` (open) when the row/columns are missing, so the
+ * feature never regresses existing behavior. See engram-web#19.
+ */
+export interface EffectivePrivacy {
+  /** Assistants may see verbatim message/chunk content, not just metadata. */
+  canReadBodies: boolean;
+  /** Assistants may aggregate across conversations (list, global search). */
+  canReadCrossConversation: boolean;
+}
+
+export async function loadPrivacy(
+  db: D1Database,
+  organizationId: string,
+): Promise<EffectivePrivacy> {
+  const row = await getPrivacySettings(db, organizationId).catch(() => null);
+  return {
+    // Treat only an explicit 0 as "off"; missing/undefined => open.
+    canReadBodies: row?.assistant_can_read_bodies !== 0,
+    canReadCrossConversation: row?.assistant_can_read_cross_conversation !== 0,
+  };
+}
+
+export const PRIVACY_BODIES_NOTICE =
+  "Message bodies are hidden by this account's privacy settings. Only metadata (titles, tags, roles, timestamps) is shared. The account owner can change this at getengram.app/dashboard.";
+
+export const PRIVACY_CROSS_CONVERSATION_NOTICE =
+  "Cross-conversation access is disabled by this account's privacy settings. Provide a specific conversation_id to read within a single conversation. The account owner can change this at getengram.app/dashboard.";

--- a/packages/db/migrations/0014_privacy_settings.sql
+++ b/packages/db/migrations/0014_privacy_settings.sql
@@ -1,0 +1,16 @@
+-- Privacy & sharing settings per organization (engram-web#19).
+--
+-- Both default to 1 (ON) so existing behavior is unchanged — assistants
+-- consuming Engram over MCP keep full access until an org opts out.
+--   assistant_can_read_bodies:            0 => tools return message/chunk
+--                                         metadata only, never verbatim content.
+--   assistant_can_read_cross_conversation: 0 => tools that aggregate across
+--                                         conversations (list_conversations,
+--                                         global search) are disabled; the
+--                                         assistant only sees a conversation
+--                                         it was given the id for.
+ALTER TABLE organizations
+  ADD COLUMN assistant_can_read_bodies INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE organizations
+  ADD COLUMN assistant_can_read_cross_conversation INTEGER NOT NULL DEFAULT 1;

--- a/packages/db/src/queries/organizations.ts
+++ b/packages/db/src/queries/organizations.ts
@@ -78,6 +78,40 @@ export function setOrganizationTier(
     .run();
 }
 
+export interface PrivacySettingsRow {
+  assistant_can_read_bodies: number;
+  assistant_can_read_cross_conversation: number;
+}
+
+export function getPrivacySettings(db: D1Database, organizationId: string) {
+  return db
+    .prepare(
+      "SELECT assistant_can_read_bodies, assistant_can_read_cross_conversation FROM organizations WHERE id = ?",
+    )
+    .bind(organizationId)
+    .first<PrivacySettingsRow>();
+}
+
+export function updatePrivacySettings(
+  db: D1Database,
+  organizationId: string,
+  settings: {
+    assistant_can_read_bodies: boolean;
+    assistant_can_read_cross_conversation: boolean;
+  },
+) {
+  return db
+    .prepare(
+      "UPDATE organizations SET assistant_can_read_bodies = ?, assistant_can_read_cross_conversation = ? WHERE id = ?",
+    )
+    .bind(
+      settings.assistant_can_read_bodies ? 1 : 0,
+      settings.assistant_can_read_cross_conversation ? 1 : 0,
+      organizationId,
+    )
+    .run();
+}
+
 export function getVectorizeIdsByOrganization(
   db: D1Database,
   organizationId: string,


### PR DESCRIPTION
Worker/D1 side of engram-web#19 — org-level privacy & sharing controls, enforced in the MCP read tools. The dashboard UI lands in a companion engram-web PR.

## Two toggles (both default ON — no behavior change until opted out)
- **`assistant_can_read_bodies`** — off ⇒ `get_conversation` and `search` return metadata only (roles, titles, tags, scores), never verbatim content, with a `privacy_notice`.
- **`assistant_can_read_cross_conversation`** — off ⇒ `list_conversations` and *global* `search` (no `conversation_id`) are disabled; the assistant can still read within a conversation it was given the id for.

## Changes
- `migration 0014_privacy_settings.sql` — two `INTEGER NOT NULL DEFAULT 1` columns on `organizations`.
- `getPrivacySettings` / `updatePrivacySettings` query helpers.
- `services/privacy.ts` — `loadPrivacy()` (defaults open when columns absent) + notice strings.
- `GET`/`PATCH /api/privacy` (mirrors `/api/account`, merges partial PATCH).
- Enforcement in `get_conversation`, `list_conversations`, `search`.
- `privacy.update` audit action + `privacy.test.ts` (3 tests).

## Tests
All green — 139 mcp-server tests (incl. 3 new). Typecheck clean. Additive tool fields use passthrough schemas; enforcement defaults open when the column is missing, so nothing regresses.

Ref engram-web#19

🤖 Generated with [Claude Code](https://claude.com/claude-code)