### PR TITLE
perf: denormalize conversation_count (#41)

### DIFF
--- a/apps/mcp-server/src/__tests__/conversation-service.test.ts
+++ b/apps/mcp-server/src/__tests__/conversation-service.test.ts
@@ -75,7 +75,11 @@ describe("Conversation service", () => {
           return null;
         },
       });
-      return { prepare: (sql: string) => stmt(sql) } as unknown as D1Database;
+      return {
+        prepare: (sql: string) => stmt(sql),
+        batch: async (stmts: Array<{ run: () => Promise<unknown> }>) =>
+          Promise.all(stmts.map((s) => s.run())),
+      } as unknown as D1Database;
     }
 
     it("creates a default conversation, then reuses it on subsequent calls", async () => {

--- a/apps/mcp-server/src/mcp/tools/create-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/create-conversation.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createConversation } from "../../services/conversation.js";
-import { getConversationCount } from "@getengram/db";
+import { getOrgConversationCount } from "@getengram/db";
 import { checkConversationLimit } from "../../services/tier.js";
 import { fireWebhooks } from "../../services/webhooks.js";
 import { audit } from "../../services/audit.js";
@@ -37,7 +37,7 @@ export function registerCreateConversation(
     },
     async (params) => {
       // Check conversation limit
-      const countResult = await getConversationCount(env.DB, auth.organizationId);
+      const countResult = await getOrgConversationCount(env.DB, auth.organizationId);
       const currentCount = countResult?.count ?? 0;
       const tierCheck = checkConversationLimit(auth.tier, currentCount);
 

--- a/packages/db/migrations/0015_conversation_count.sql
+++ b/packages/db/migrations/0015_conversation_count.sql
@@ -1,0 +1,14 @@
+-- Denormalize conversation count onto organizations (engram#41).
+--
+-- create_conversation's tier check ran COUNT(*) over the whole conversations
+-- table on every call — O(n) per org. This column is maintained incrementally
+-- (insertConversation +1, deleteConversationById -1) so the check is O(1).
+ALTER TABLE organizations
+  ADD COLUMN conversation_count INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill existing orgs from the current row counts.
+UPDATE organizations
+SET conversation_count = (
+  SELECT COUNT(*) FROM conversations
+  WHERE conversations.organization_id = organizations.id
+);

--- a/packages/db/src/queries/conversations.ts
+++ b/packages/db/src/queries/conversations.ts
@@ -7,12 +7,19 @@ export function insertConversation(
   tags: string[],
   metadata: Record<string, unknown>
 ) {
-  return db
-    .prepare(
-      "INSERT INTO conversations (id, organization_id, title, agent_id, tags, metadata) VALUES (?, ?, ?, ?, ?, ?)"
-    )
-    .bind(id, organizationId, title, agentId, JSON.stringify(tags), JSON.stringify(metadata))
-    .run();
+  // Insert the row and bump the denormalized org counter atomically (engram#41).
+  return db.batch([
+    db
+      .prepare(
+        "INSERT INTO conversations (id, organization_id, title, agent_id, tags, metadata) VALUES (?, ?, ?, ?, ?, ?)"
+      )
+      .bind(id, organizationId, title, agentId, JSON.stringify(tags), JSON.stringify(metadata)),
+    db
+      .prepare(
+        "UPDATE organizations SET conversation_count = conversation_count + 1 WHERE id = ?"
+      )
+      .bind(organizationId),
+  ]);
 }
 
 export function getConversationById(db: D1Database, id: string, organizationId: string) {
@@ -94,9 +101,18 @@ export function updateConversationMessageCount(
     .run();
 }
 
+/** COUNT(*) fallback — kept for backfills/reconciliation and tests. */
 export function getConversationCount(db: D1Database, organizationId: string) {
   return db
     .prepare("SELECT COUNT(*) as count FROM conversations WHERE organization_id = ?")
+    .bind(organizationId)
+    .first<{ count: number }>();
+}
+
+/** O(1) read of the denormalized counter on the org row (engram#41). */
+export function getOrgConversationCount(db: D1Database, organizationId: string) {
+  return db
+    .prepare("SELECT conversation_count as count FROM organizations WHERE id = ?")
     .bind(organizationId)
     .first<{ count: number }>();
 }
@@ -108,5 +124,7 @@ export function deleteConversationById(db: D1Database, id: string, organizationI
     db.prepare("DELETE FROM conversation_chunks WHERE conversation_id = ? AND organization_id = ?").bind(id, organizationId),
     db.prepare("DELETE FROM messages WHERE conversation_id = ? AND organization_id = ?").bind(id, organizationId),
     db.prepare("DELETE FROM conversations WHERE id = ? AND organization_id = ?").bind(id, organizationId),
+    // Keep the denormalized org counter in sync; clamp at 0 defensively.
+    db.prepare("UPDATE organizations SET conversation_count = MAX(conversation_count - 1, 0) WHERE id = ?").bind(organizationId),
   ]);
 }


### PR DESCRIPTION
Closes #41.

`create_conversation`'s tier check ran `COUNT(*)` over the whole `conversations` table per call — O(n) per org. Now O(1).

## Changes
- `migration 0015` — `organizations.conversation_count INTEGER NOT NULL DEFAULT 0`, backfilled from current row counts.
- `insertConversation` — batches the insert with `conversation_count + 1` (atomic).
- `deleteConversationById` — batches a `MAX(conversation_count - 1, 0)` decrement (clamped).
- `getOrgConversationCount` — O(1) read of the column; `create_conversation` now uses it. `getConversationCount` (COUNT(*)) kept for backfills/reconciliation.

## Tests
139 mcp-server tests green (added `.batch` to the tagged conversation-service mock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)