### PR TITLE
perf: tags junction table for fast filtering (#42)

### DIFF
--- a/packages/db/migrations/0016_conversation_tags.sql
+++ b/packages/db/migrations/0016_conversation_tags.sql
@@ -1,0 +1,25 @@
+-- Normalize tags into a junction table for fast filtering (engram#42).
+--
+-- listConversations filtered tags with one EXISTS(json_each(tags)) subquery
+-- per tag — O(conversations) per tag, quadratic at scale. This junction table,
+-- indexed on (organization_id, tag), turns a tag filter into an index lookup.
+--
+-- conversations.tags (JSON) stays the source of truth (returned by the API and
+-- used for the default-conversation lookup); this table is a maintained index.
+-- Tags are immutable after creation, so a dual-write on insert/delete keeps it
+-- consistent — there is no update path to drift from.
+CREATE TABLE conversation_tags (
+  conversation_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  tag TEXT NOT NULL,
+  PRIMARY KEY (conversation_id, tag)
+);
+
+CREATE INDEX idx_conversation_tags_org_tag
+  ON conversation_tags (organization_id, tag);
+
+-- Backfill from existing conversations' JSON tag arrays.
+INSERT OR IGNORE INTO conversation_tags (conversation_id, organization_id, tag)
+SELECT c.id, c.organization_id, je.value
+FROM conversations c, json_each(c.tags) je
+WHERE je.value IS NOT NULL AND je.value != '';

--- a/packages/db/src/queries/conversations.ts
+++ b/packages/db/src/queries/conversations.ts
@@ -7,8 +7,9 @@ export function insertConversation(
   tags: string[],
   metadata: Record<string, unknown>
 ) {
-  // Insert the row and bump the denormalized org counter atomically (engram#41).
-  return db.batch([
+  // Insert the row, bump the denormalized org counter (engram#41), and populate
+  // the conversation_tags junction index (engram#42) — all atomically.
+  const statements = [
     db
       .prepare(
         "INSERT INTO conversations (id, organization_id, title, agent_id, tags, metadata) VALUES (?, ?, ?, ?, ?, ?)"
@@ -19,7 +20,18 @@ export function insertConversation(
         "UPDATE organizations SET conversation_count = conversation_count + 1 WHERE id = ?"
       )
       .bind(organizationId),
-  ]);
+  ];
+  for (const tag of tags) {
+    if (!tag) continue;
+    statements.push(
+      db
+        .prepare(
+          "INSERT OR IGNORE INTO conversation_tags (conversation_id, organization_id, tag) VALUES (?, ?, ?)"
+        )
+        .bind(id, organizationId, tag),
+    );
+  }
+  return db.batch(statements);
 }
 
 export function getConversationById(db: D1Database, id: string, organizationId: string) {
@@ -69,9 +81,11 @@ export function listConversations(
   }
 
   if (opts.tags && opts.tags.length > 0) {
+    // Filter via the conversation_tags junction index (engram#42) instead of
+    // a json_each scan. One EXISTS per tag = AND semantics (must have all).
     for (const tag of opts.tags) {
-      sql += ` AND EXISTS (SELECT 1 FROM json_each(tags) WHERE json_each.value = ?)`;
-      params.push(tag);
+      sql += ` AND EXISTS (SELECT 1 FROM conversation_tags ct WHERE ct.organization_id = ? AND ct.tag = ? AND ct.conversation_id = conversations.id)`;
+      params.push(organizationId, tag);
     }
   }
 
@@ -123,6 +137,7 @@ export function deleteConversationById(db: D1Database, id: string, organizationI
     db.prepare("DELETE FROM chunks_fts WHERE chunk_id IN (SELECT id FROM conversation_chunks WHERE conversation_id = ? AND organization_id = ?)").bind(id, organizationId),
     db.prepare("DELETE FROM conversation_chunks WHERE conversation_id = ? AND organization_id = ?").bind(id, organizationId),
     db.prepare("DELETE FROM messages WHERE conversation_id = ? AND organization_id = ?").bind(id, organizationId),
+    db.prepare("DELETE FROM conversation_tags WHERE conversation_id = ? AND organization_id = ?").bind(id, organizationId),
     db.prepare("DELETE FROM conversations WHERE id = ? AND organization_id = ?").bind(id, organizationId),
     // Keep the denormalized org counter in sync; clamp at 0 defensively.
     db.prepare("UPDATE organizations SET conversation_count = MAX(conversation_count - 1, 0) WHERE id = ?").bind(organizationId),

--- a/packages/db/src/queries/organizations.ts
+++ b/packages/db/src/queries/organizations.ts
@@ -133,6 +133,7 @@ export function deleteOrganizationById(db: D1Database, id: string) {
     // CASCADE handles the rest, but explicit deletes are safer for ordering
     db.prepare("DELETE FROM conversation_chunks WHERE organization_id = ?").bind(id),
     db.prepare("DELETE FROM messages WHERE organization_id = ?").bind(id),
+    db.prepare("DELETE FROM conversation_tags WHERE organization_id = ?").bind(id),
     db.prepare("DELETE FROM conversations WHERE organization_id = ?").bind(id),
     db.prepare("DELETE FROM organizations WHERE id = ?").bind(id),
   ]);


### PR DESCRIPTION
Closes #42.

Tag filtering in `listConversations` ran one `EXISTS(json_each(tags))` subquery per tag — O(conversations) per tag. Now an indexed junction lookup.

## Changes
- `migration 0016` — `conversation_tags (conversation_id, organization_id, tag)` with PK `(conversation_id, tag)` + index `(organization_id, tag)`; backfilled from existing JSON tag arrays.
- `insertConversation` — dual-writes junction rows (in the same atomic batch as the row + count bump).
- `deleteConversationById` / `deleteOrganizationById` — clean up junction rows.
- `listConversations` — tag filter now `EXISTS (… conversation_tags ct WHERE ct.organization_id = ? AND ct.tag = ? AND ct.conversation_id = conversations.id)`.

## Design
- `conversations.tags` JSON stays the source of truth (returned by the API, used by the default-conversation lookup). The junction is a pure filter index.
- **Tags are immutable after creation** (no update path exists), so a dual-write on insert/delete keeps the index consistent — verified by grep.

## Tests
139 mcp-server tests green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)