### PR TITLE
perf: token-aware chunking (#45)

### DIFF
--- a/packages/shared/src/__tests__/chunk.test.ts
+++ b/packages/shared/src/__tests__/chunk.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { chunkMessages } from "../utils/chunk.js";
+import { describe, it, expect, vi } from "vitest";
+import { chunkMessages, estimateTokens } from "../utils/chunk.js";
 import type { Message } from "../types/index.js";
+
+const MAX_CHARS = 480 * 4; // mirrors MAX_TOKENS * CHARS_PER_TOKEN in chunk.ts
 
 function makeMessage(sequence: number, role: string, content: string): Message {
   return {
@@ -129,5 +131,47 @@ describe("chunkMessages", () => {
     expect(chunks[0].startSequence).toBe(1);
     expect(chunks[0].endSequence).toBe(1);
     expect(chunks[0].text).toBe("[user]: Hello");
+  });
+
+  describe("token-aware splitting (#45)", () => {
+    it("estimateTokens approximates chars/4", () => {
+      expect(estimateTokens("")).toBe(0);
+      expect(estimateTokens("abcd")).toBe(1);
+      expect(estimateTokens("a".repeat(2000))).toBe(500);
+    });
+
+    it("keeps every chunk within the embedding budget when a window overflows", () => {
+      const onWarn = vi.fn();
+      // 5 messages of ~500 chars each => window well over MAX_CHARS.
+      const messages = Array.from({ length: 5 }, (_, i) =>
+        makeMessage(i + 1, "user", "x".repeat(500)),
+      );
+
+      const chunks = chunkMessages(messages, { onWarn });
+
+      // The window got split, so we produce more than the naive 2 chunks.
+      expect(chunks.length).toBeGreaterThan(2);
+      for (const c of chunks) {
+        expect(c.text.length).toBeLessThanOrEqual(MAX_CHARS);
+      }
+      // Multi-message split doesn't warn (no single message is oversized).
+      expect(onWarn).not.toHaveBeenCalled();
+    });
+
+    it("hard-splits a single oversized message and warns", () => {
+      const onWarn = vi.fn();
+      const messages = [makeMessage(1, "user", "y".repeat(2500))];
+
+      const chunks = chunkMessages(messages, { onWarn });
+
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const c of chunks) {
+        expect(c.text.length).toBeLessThanOrEqual(MAX_CHARS);
+        // All pieces belong to the one message's sequence.
+        expect(c.startSequence).toBe(1);
+        expect(c.endSequence).toBe(1);
+      }
+      expect(onWarn).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/packages/shared/src/utils/chunk.ts
+++ b/packages/shared/src/utils/chunk.ts
@@ -3,14 +3,88 @@ import type { Message } from "../types/index.js";
 const WINDOW_SIZE = 5;
 const STRIDE = 3;
 
+// bge-base-en-v1.5 has a 512-token context window; anything past it is silently
+// truncated by the embedding model, so the tail of an oversized chunk would be
+// dropped without error. Cap chunks below that with headroom, estimating tokens
+// at ~4 chars/token (a conservative average for English + code). (engram#45)
+const CHARS_PER_TOKEN = 4;
+const MAX_TOKENS = 480;
+const MAX_CHARS = MAX_TOKENS * CHARS_PER_TOKEN; // ~1920
+
 export interface ChunkResult {
   text: string;
   startSequence: number;
   endSequence: number;
 }
 
-export function chunkMessages(messages: Message[]): ChunkResult[] {
+export interface ChunkOptions {
+  /** Called when an oversized message/window has to be split. Defaults to console.warn. */
+  onWarn?: (message: string) => void;
+}
+
+/** Rough token estimate for a string (chars / 4). */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+interface Part {
+  seq: number;
+  text: string;
+}
+
+/**
+ * Split an oversized window (its formatted per-message parts) into sub-chunks
+ * that each fit the embedding budget. A single message larger than the budget
+ * is hard-split by characters, keeping its sequence on each piece.
+ */
+function splitOversized(parts: Part[], warn: (m: string) => void): ChunkResult[] {
+  const out: ChunkResult[] = [];
+  let buf: Part[] = [];
+  let bufChars = 0;
+
+  const flush = () => {
+    if (buf.length === 0) return;
+    out.push({
+      text: buf.map((p) => p.text).join("\n"),
+      startSequence: buf[0].seq,
+      endSequence: buf[buf.length - 1].seq,
+    });
+    buf = [];
+    bufChars = 0;
+  };
+
+  for (const part of parts) {
+    if (part.text.length > MAX_CHARS) {
+      // One message is too big on its own — flush what we have, then hard-split.
+      flush();
+      const pieces = Math.ceil(part.text.length / MAX_CHARS);
+      warn(
+        `chunk: message at sequence ${part.seq} is ~${estimateTokens(part.text)} tokens, over the ${MAX_TOKENS}-token embedding limit; splitting into ${pieces} pieces.`,
+      );
+      for (let j = 0; j < part.text.length; j += MAX_CHARS) {
+        out.push({
+          text: part.text.slice(j, j + MAX_CHARS),
+          startSequence: part.seq,
+          endSequence: part.seq,
+        });
+      }
+      continue;
+    }
+    const partChars = part.text.length + 1; // + joining newline
+    if (bufChars + partChars > MAX_CHARS && buf.length > 0) flush();
+    buf.push(part);
+    bufChars += partChars;
+  }
+  flush();
+  return out;
+}
+
+export function chunkMessages(
+  messages: Message[],
+  opts: ChunkOptions = {},
+): ChunkResult[] {
   if (messages.length === 0) return [];
+  const warn = opts.onWarn ?? ((m: string) => console.warn(m));
 
   const sorted = [...messages].sort((a, b) => a.sequence - b.sequence);
   const chunks: ChunkResult[] = [];
@@ -19,15 +93,23 @@ export function chunkMessages(messages: Message[]): ChunkResult[] {
     const window = sorted.slice(i, i + WINDOW_SIZE);
     if (window.length === 0) break;
 
-    const text = window
-      .map((m) => `[${m.role}]: ${m.content}`)
-      .join("\n");
+    const parts: Part[] = window.map((m) => ({
+      seq: m.sequence,
+      text: `[${m.role}]: ${m.content}`,
+    }));
+    const text = parts.map((p) => p.text).join("\n");
 
-    chunks.push({
-      text,
-      startSequence: window[0].sequence,
-      endSequence: window[window.length - 1].sequence,
-    });
+    if (estimateTokens(text) <= MAX_TOKENS) {
+      chunks.push({
+        text,
+        startSequence: window[0].sequence,
+        endSequence: window[window.length - 1].sequence,
+      });
+    } else {
+      // Window overflows the embedding context — split it so nothing is
+      // silently truncated at embed time.
+      chunks.push(...splitOversized(parts, warn));
+    }
 
     // If window didn't fill, we've reached the end
     if (window.length < WINDOW_SIZE) break;


### PR DESCRIPTION
Closes #45.

Fixed window=5/stride=3 chunking never checked size, so a window (or a single long message) could blow past bge-base-en-v1.5's 512-token context — the embedding model then silently truncates, dropping the tail of the chunk with no error.

## Changes (`packages/shared/src/utils/chunk.ts`)
- `estimateTokens(text)` = `ceil(len/4)`.
- Budget of **480 tokens (~1920 chars)** with headroom under the 512 limit.
- A window over budget is split into sub-chunks that each fit (grouping whole messages).
- A **single** message over budget is hard-split by characters, keeping its sequence on each piece, and **warns** (default `console.warn`, overridable via `onWarn`).
- Under-budget windows produce identical output to before — no behavior change for normal traffic.

## Tests
+3 cases (estimate, window overflow stays within budget + no warn, single-message hard-split + warns). Shared: 112 green; mcp-server: 139 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)