### PR TITLE
feat(security): API-key scopes + enforcement — RBAC v1 (#69)

### DIFF
--- a/apps/mcp-server/src/__tests__/account.test.ts
+++ b/apps/mcp-server/src/__tests__/account.test.ts
@@ -15,6 +15,7 @@ function createApp(orgId: string) {
     c.set("auth", {
       organizationId: orgId,
       apiKeyId: "key_test",
+      scopes: ["read", "write", "search", "delete"],
       tier: "free" as const,
     });
     await next();

--- a/apps/mcp-server/src/__tests__/billing.test.ts
+++ b/apps/mcp-server/src/__tests__/billing.test.ts
@@ -134,7 +134,7 @@ describe("POST /api/billing/checkout", () => {
   beforeEach(async () => {
     db = createMockD1();
     env = createBillingEnv(db);
-    auth = { organizationId: "org_test", apiKeyId: "key_test", tier: "free" };
+    auth = { organizationId: "org_test", apiKeyId: "key_test", tier: "free", scopes: ["read", "write", "search", "delete"] };
     await insertOrganizationWithEmail(db, "org_test", "Test Org", "test@example.com");
   });
 
@@ -241,7 +241,7 @@ describe("POST /api/billing/portal", () => {
   beforeEach(async () => {
     db = createMockD1();
     env = createBillingEnv(db);
-    auth = { organizationId: "org_test", apiKeyId: "key_test", tier: "pro" };
+    auth = { organizationId: "org_test", apiKeyId: "key_test", tier: "pro", scopes: ["read", "write", "search", "delete"] };
   });
 
   it("creates a portal session for org with Stripe customer", async () => {

--- a/apps/mcp-server/src/__tests__/export.test.ts
+++ b/apps/mcp-server/src/__tests__/export.test.ts
@@ -13,6 +13,7 @@ function createApp(orgId: string) {
     c.set("auth", {
       organizationId: orgId,
       apiKeyId: "key_test",
+      scopes: ["read", "write", "search", "delete"],
       tier: "free" as const,
     });
     await next();

--- a/apps/mcp-server/src/__tests__/mcp-tools-contract.test.ts
+++ b/apps/mcp-server/src/__tests__/mcp-tools-contract.test.ts
@@ -108,7 +108,7 @@ describe("MCP tool contract — wire field names", () => {
   beforeAll(async () => {
     db = createMockD1();
     env = createMockEnv(db) as unknown as Env;
-    auth = { organizationId: ORG, apiKeyId: "key_test", tier: TIER };
+    auth = { organizationId: ORG, apiKeyId: "key_test", tier: TIER, scopes: ["read", "write", "search", "delete"] };
     await insertOrganization(db, ORG, "Contract Org");
     // Pro tier uses usage tracking, so seed a usage row so checkMessageLimit
     // doesn't try to run a getOrCreateUsage write the mock can't satisfy.

--- a/apps/mcp-server/src/__tests__/privacy.test.ts
+++ b/apps/mcp-server/src/__tests__/privacy.test.ts
@@ -13,6 +13,7 @@ function createApp(orgId: string) {
     c.set("auth", {
       organizationId: orgId,
       apiKeyId: "key_test",
+      scopes: ["read", "write", "search", "delete"],
       tier: "free" as const,
     });
     await next();

--- a/apps/mcp-server/src/__tests__/rate-limit.test.ts
+++ b/apps/mcp-server/src/__tests__/rate-limit.test.ts
@@ -13,6 +13,7 @@ function createApp(tier: AuthContext["tier"] = "free") {
     c.set("auth", {
       organizationId: `org_${tier}`,
       apiKeyId: "key_test",
+      scopes: ["read", "write", "search", "delete"],
       tier,
     });
     await next();
@@ -40,6 +41,7 @@ describe("rate limit middleware", () => {
       c.set("auth", {
         organizationId: "org_burst_test",
         apiKeyId: "key_test",
+        scopes: ["read", "write", "search", "delete"],
         tier: "free",
       });
       await next();
@@ -63,6 +65,7 @@ describe("rate limit middleware", () => {
       c.set("auth", {
         organizationId: "org_error_body_test",
         apiKeyId: "key_test",
+        scopes: ["read", "write", "search", "delete"],
         tier: "free",
       });
       await next();
@@ -89,6 +92,7 @@ describe("rate limit middleware", () => {
       c.set("auth", {
         organizationId: "org_enterprise_test",
         apiKeyId: "key_test",
+        scopes: ["read", "write", "search", "delete"],
         tier: "enterprise",
       });
       await next();

--- a/apps/mcp-server/src/__tests__/scopes.test.ts
+++ b/apps/mcp-server/src/__tests__/scopes.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  ALL_SCOPES,
+  isScope,
+  parseScopes,
+  hasScope,
+  scopeError,
+} from "../mcp/scopes.js";
+import type { AuthContext } from "../types.js";
+
+function auth(scopes: AuthContext["scopes"]): AuthContext {
+  return { organizationId: "org", apiKeyId: "key", tier: "free", scopes };
+}
+
+describe("api-key scopes (#69)", () => {
+  it("isScope validates known scopes", () => {
+    expect(isScope("read")).toBe(true);
+    expect(isScope("admin")).toBe(false);
+  });
+
+  it("parseScopes splits and validates, ignoring junk", () => {
+    expect(parseScopes("read,search")).toEqual(["read", "search"]);
+    expect(parseScopes("read, delete , bogus")).toEqual(["read", "delete"]);
+  });
+
+  it("parseScopes defaults to full access for empty/garbled input", () => {
+    expect(parseScopes(null)).toEqual(ALL_SCOPES);
+    expect(parseScopes("")).toEqual(ALL_SCOPES);
+    expect(parseScopes("nonsense")).toEqual(ALL_SCOPES);
+  });
+
+  it("hasScope checks the caller's granted scopes", () => {
+    expect(hasScope(auth(["search"]), "search")).toBe(true);
+    expect(hasScope(auth(["search"]), "write")).toBe(false);
+  });
+
+  it("scopeError is an MCP error result naming the missing scope", () => {
+    const err = scopeError("delete");
+    expect(err.isError).toBe(true);
+    const payload = JSON.parse(err.content[0].text) as Record<string, unknown>;
+    expect(payload.error).toBe("insufficient_scope");
+    expect(payload.required).toBe("delete");
+  });
+});

--- a/apps/mcp-server/src/__tests__/seats.test.ts
+++ b/apps/mcp-server/src/__tests__/seats.test.ts
@@ -55,7 +55,7 @@ describe("GET /api/seats", () => {
   it("returns empty list for new org", async () => {
     const db = createMockD1();
     const env = createSeatsEnv(db);
-    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team" };
+    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team", scopes: ["read", "write", "search", "delete"] };
     await insertOrgWithSeatLimit(db, "org_1", "Test Org", "test@example.com", "team", 5);
 
     const app = createSeatsApp(env, auth);
@@ -69,7 +69,7 @@ describe("GET /api/seats", () => {
   it("returns invited seats", async () => {
     const db = createMockD1();
     const env = createSeatsEnv(db);
-    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team" };
+    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team", scopes: ["read", "write", "search", "delete"] };
     await insertOrgWithSeatLimit(db, "org_1", "Test Org", "test@example.com", "team", 5);
 
     const app = createSeatsApp(env, auth);
@@ -96,7 +96,7 @@ describe("POST /api/seats", () => {
   it("invites a seat successfully", async () => {
     const db = createMockD1();
     const env = createSeatsEnv(db);
-    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team" };
+    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team", scopes: ["read", "write", "search", "delete"] };
     await insertOrgWithSeatLimit(db, "org_1", "Test Org", "test@example.com", "team", 5);
 
     const app = createSeatsApp(env, auth);
@@ -116,7 +116,7 @@ describe("POST /api/seats", () => {
   it("returns 400 without email", async () => {
     const db = createMockD1();
     const env = createSeatsEnv(db);
-    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team" };
+    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team", scopes: ["read", "write", "search", "delete"] };
     await insertOrgWithSeatLimit(db, "org_1", "Test Org", "test@example.com", "team", 5);
 
     const app = createSeatsApp(env, auth);
@@ -132,7 +132,7 @@ describe("POST /api/seats", () => {
   it("enforces seat limit from org.seat_limit", async () => {
     const db = createMockD1();
     const env = createSeatsEnv(db);
-    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team" };
+    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team", scopes: ["read", "write", "search", "delete"] };
     // Only 2 seats allowed
     await insertOrgWithSeatLimit(db, "org_1", "Test Org", "test@example.com", "team", 2);
 
@@ -168,7 +168,7 @@ describe("POST /api/seats", () => {
   it("free tier defaults to 1 seat", async () => {
     const db = createMockD1();
     const env = createSeatsEnv(db);
-    const auth: AuthContext = { organizationId: "org_free", apiKeyId: "key_1", tier: "free" };
+    const auth: AuthContext = { organizationId: "org_free", apiKeyId: "key_1", tier: "free", scopes: ["read", "write", "search", "delete"] };
     await insertOrgWithSeatLimit(db, "org_free", "Free Org", "free@example.com", "free", 1);
 
     const app = createSeatsApp(env, auth);
@@ -193,7 +193,7 @@ describe("POST /api/seats", () => {
   it("allows custom role", async () => {
     const db = createMockD1();
     const env = createSeatsEnv(db);
-    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team" };
+    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team", scopes: ["read", "write", "search", "delete"] };
     await insertOrgWithSeatLimit(db, "org_1", "Test Org", "test@example.com", "team", 5);
 
     const app = createSeatsApp(env, auth);
@@ -217,7 +217,7 @@ describe("POST /api/seats/:id/accept", () => {
   it("accepts an invited seat", async () => {
     const db = createMockD1();
     const env = createSeatsEnv(db);
-    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team" };
+    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team", scopes: ["read", "write", "search", "delete"] };
     await insertOrgWithSeatLimit(db, "org_1", "Test Org", "test@example.com", "team", 5);
 
     const app = createSeatsApp(env, auth);
@@ -242,7 +242,7 @@ describe("POST /api/seats/:id/accept", () => {
   it("returns 404 for nonexistent seat", async () => {
     const db = createMockD1();
     const env = createSeatsEnv(db);
-    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team" };
+    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team", scopes: ["read", "write", "search", "delete"] };
     await insertOrgWithSeatLimit(db, "org_1", "Test Org", "test@example.com", "team", 5);
 
     const app = createSeatsApp(env, auth);
@@ -261,7 +261,7 @@ describe("DELETE /api/seats/:id", () => {
   it("removes a seat", async () => {
     const db = createMockD1();
     const env = createSeatsEnv(db);
-    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team" };
+    const auth: AuthContext = { organizationId: "org_1", apiKeyId: "key_1", tier: "team", scopes: ["read", "write", "search", "delete"] };
     await insertOrgWithSeatLimit(db, "org_1", "Test Org", "test@example.com", "team", 5);
 
     const app = createSeatsApp(env, auth);

--- a/apps/mcp-server/src/mcp/scopes.ts
+++ b/apps/mcp-server/src/mcp/scopes.ts
@@ -1,0 +1,43 @@
+import type { AuthContext, Scope } from "../types.js";
+
+// A key carries a subset of scopes; each memory tool requires one.
+// Legacy/OAuth callers get all four. (engram#69)
+export type { Scope };
+export const ALL_SCOPES: Scope[] = ["read", "write", "search", "delete"];
+
+export function isScope(value: string): value is Scope {
+  return (ALL_SCOPES as string[]).includes(value);
+}
+
+/** Parse a stored comma-separated scope string into a validated array. */
+export function parseScopes(raw: string | null | undefined): Scope[] {
+  if (!raw) return [...ALL_SCOPES];
+  const parsed = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s): s is Scope => isScope(s));
+  // An empty/garbled value shouldn't lock a caller out of everything silently;
+  // treat it as full access (matches the column default).
+  return parsed.length > 0 ? parsed : [...ALL_SCOPES];
+}
+
+export function hasScope(auth: AuthContext, scope: Scope): boolean {
+  return auth.scopes.includes(scope);
+}
+
+/** Standard MCP error result when a key lacks a required scope. */
+export function scopeError(scope: Scope) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          error: "insufficient_scope",
+          required: scope,
+          message: `This API key does not have the '${scope}' permission. Create a key with this scope at getengram.app/dashboard.`,
+        }),
+      },
+    ],
+    isError: true as const,
+  };
+}

--- a/apps/mcp-server/src/mcp/tools/append-messages.ts
+++ b/apps/mcp-server/src/mcp/tools/append-messages.ts
@@ -13,6 +13,7 @@ import {
 import { checkAndTrackMessages } from "../../services/tier.js";
 import { fireWebhooks } from "../../services/webhooks.js";
 import { audit } from "../../services/audit.js";
+import { hasScope, scopeError } from "../scopes.js";
 import type { Env, AuthContext } from "../../types.js";
 
 export function registerAppendMessages(
@@ -82,6 +83,7 @@ export function registerAppendMessages(
       },
     },
     async (params) => {
+      if (!hasScope(auth, "write")) return scopeError("write");
       // Atomically check tier limit AND increment usage in one operation.
       // Prevents race conditions where concurrent requests both pass the
       // check but together exceed the limit.

--- a/apps/mcp-server/src/mcp/tools/create-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/create-conversation.ts
@@ -7,6 +7,7 @@ import { fireWebhooks } from "../../services/webhooks.js";
 import { audit } from "../../services/audit.js";
 import { isExternalOAuthClient } from "../auth-kind.js";
 import { limitMessage } from "../usage-messaging.js";
+import { hasScope, scopeError } from "../scopes.js";
 import type { Env, AuthContext } from "../../types.js";
 
 export function registerCreateConversation(
@@ -36,6 +37,7 @@ export function registerCreateConversation(
       },
     },
     async (params) => {
+      if (!hasScope(auth, "write")) return scopeError("write");
       // Check conversation limit
       const countResult = await getOrgConversationCount(env.DB, auth.organizationId);
       const currentCount = countResult?.count ?? 0;

--- a/apps/mcp-server/src/mcp/tools/delete-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/delete-conversation.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { deleteConversation } from "../../services/conversation.js";
 import { audit } from "../../services/audit.js";
+import { hasScope, scopeError } from "../scopes.js";
 import type { Env, AuthContext } from "../../types.js";
 
 export function registerDeleteConversation(
@@ -28,6 +29,7 @@ export function registerDeleteConversation(
       },
     },
     async (params) => {
+      if (!hasScope(auth, "delete")) return scopeError("delete");
       const deleted = await deleteConversation(
         env,
         auth.organizationId,

--- a/apps/mcp-server/src/mcp/tools/get-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/get-conversation.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getConversation } from "../../services/conversation.js";
 import { audit } from "../../services/audit.js";
 import { loadPrivacy, PRIVACY_BODIES_NOTICE } from "../../services/privacy.js";
+import { hasScope, scopeError } from "../scopes.js";
 import type { Env, AuthContext } from "../../types.js";
 
 export function registerGetConversation(
@@ -67,6 +68,7 @@ export function registerGetConversation(
       },
     },
     async (params) => {
+      if (!hasScope(auth, "read")) return scopeError("read");
       audit(env.DB, auth.organizationId, auth.apiKeyId, "conversation.read", "conversation", params.conversation_id);
 
       const result = await getConversation(

--- a/apps/mcp-server/src/mcp/tools/list-conversations.ts
+++ b/apps/mcp-server/src/mcp/tools/list-conversations.ts
@@ -6,6 +6,7 @@ import {
   loadPrivacy,
   PRIVACY_CROSS_CONVERSATION_NOTICE,
 } from "../../services/privacy.js";
+import { hasScope, scopeError } from "../scopes.js";
 import type { Env, AuthContext } from "../../types.js";
 
 export function registerListConversations(
@@ -54,6 +55,7 @@ export function registerListConversations(
       },
     },
     async (params) => {
+      if (!hasScope(auth, "read")) return scopeError("read");
       audit(env.DB, auth.organizationId, auth.apiKeyId, "conversation.list");
 
       // Listing all conversations is cross-conversation metadata sharing;

--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -8,6 +8,7 @@ import {
   PRIVACY_BODIES_NOTICE,
   PRIVACY_CROSS_CONVERSATION_NOTICE,
 } from "../../services/privacy.js";
+import { hasScope, scopeError } from "../scopes.js";
 import type { Env, AuthContext } from "../../types.js";
 
 export function registerSearch(
@@ -68,6 +69,7 @@ export function registerSearch(
       },
     },
     async (params) => {
+      if (!hasScope(auth, "search")) return scopeError("search");
       const privacy = await loadPrivacy(env.DB, auth.organizationId);
 
       // A search without a conversation_id spans all conversations. When

--- a/apps/mcp-server/src/middleware/auth.ts
+++ b/apps/mcp-server/src/middleware/auth.ts
@@ -7,6 +7,7 @@ import {
 } from "@getengram/db";
 import { audit } from "../services/audit.js";
 import { originOf, wwwAuthenticate } from "../oauth/metadata.js";
+import { ALL_SCOPES, parseScopes } from "../mcp/scopes.js";
 import type { Env, AuthContext } from "../types.js";
 
 export async function authMiddleware(
@@ -39,6 +40,9 @@ export async function authMiddleware(
       organizationId: row.organization_id,
       apiKeyId: `oauth:${row.client_id}`,
       tier: (row.tier ?? "free") as AuthContext["tier"],
+      // OAuth connections get the full memory scope set; their tool surface
+      // is already narrowed elsewhere (isExternalOAuthClient).
+      scopes: [...ALL_SCOPES],
     });
     await next();
     return;
@@ -65,6 +69,7 @@ export async function authMiddleware(
     organizationId: row.organization_id,
     apiKeyId: row.key_id,
     tier: (row.tier ?? "free") as AuthContext["tier"],
+    scopes: parseScopes(row.scopes),
   });
 
   // Update last_used_at non-blocking

--- a/apps/mcp-server/src/routes/keys.ts
+++ b/apps/mcp-server/src/routes/keys.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { generateId, generateApiKeyRaw, hashApiKey, TIER_LIMITS } from "@getengram/shared";
 import { insertApiKey, getApiKeysByOrg, getApiKeyCount, revokeApiKey } from "@getengram/db";
+import { ALL_SCOPES, isScope } from "../mcp/scopes.js";
 import type { Env, AuthContext } from "../types.js";
 
 type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
@@ -17,7 +18,31 @@ keys.get("/", async (c) => {
 // Create a new API key
 keys.post("/", async (c) => {
   const auth = c.get("auth");
-  const body = await c.req.json<{ name?: string }>();
+  const body = await c.req.json<{ name?: string; scopes?: unknown }>();
+
+  // Optional least-privilege scopes; default to full access when omitted.
+  let scopes = [...ALL_SCOPES];
+  if (body.scopes !== undefined) {
+    if (
+      !Array.isArray(body.scopes) ||
+      !body.scopes.every((s) => typeof s === "string" && isScope(s))
+    ) {
+      return c.json(
+        {
+          error: "invalid_scopes",
+          message: `scopes must be a subset of: ${ALL_SCOPES.join(", ")}`,
+        },
+        400,
+      );
+    }
+    scopes = [...new Set(body.scopes as (typeof ALL_SCOPES)[number][])];
+    if (scopes.length === 0) {
+      return c.json(
+        { error: "invalid_scopes", message: "at least one scope is required" },
+        400,
+      );
+    }
+  }
 
   // Check key limit
   const limits = TIER_LIMITS[auth.tier];
@@ -37,10 +62,10 @@ keys.post("/", async (c) => {
   const keyHash = await hashApiKey(raw);
   const name = body.name || "default";
 
-  await insertApiKey(c.env.DB, id, auth.organizationId, keyHash, prefix, name);
+  await insertApiKey(c.env.DB, id, auth.organizationId, keyHash, prefix, name, scopes.join(","));
 
   // Return the raw key ONCE — it can never be retrieved again
-  return c.json({ id, key: raw, prefix, name }, 201);
+  return c.json({ id, key: raw, prefix, name, scopes }, 201);
 });
 
 // Revoke an API key

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -18,8 +18,13 @@ export interface Env {
   SUPABASE_ANON_KEY: string;
 }
 
+/** Least-privilege scopes for API keys (engram#69). */
+export type Scope = "read" | "write" | "search" | "delete";
+
 export interface AuthContext {
   organizationId: string;
   apiKeyId: string;
   tier: "free" | "pro" | "team" | "enterprise";
+  /** Scopes granted to the calling key: subset of read/write/search/delete. */
+  scopes: Scope[];
 }

--- a/packages/db/migrations/0018_api_key_scopes.sql
+++ b/packages/db/migrations/0018_api_key_scopes.sql
@@ -1,0 +1,7 @@
+-- Per-API-key scopes for least-privilege access (engram#69).
+--
+-- Comma-separated subset of: read, write, search, delete. Existing keys
+-- default to full access so nothing breaks; new keys can be minted narrower
+-- (e.g. a search-only key). Enforced in the MCP tool handlers.
+ALTER TABLE api_keys
+  ADD COLUMN scopes TEXT NOT NULL DEFAULT 'read,write,search,delete';

--- a/packages/db/src/queries/api-keys.ts
+++ b/packages/db/src/queries/api-keys.ts
@@ -4,13 +4,14 @@ export function insertApiKey(
   organizationId: string,
   keyHash: string,
   keyPrefix: string,
-  name: string
+  name: string,
+  scopes: string = "read,write,search,delete"
 ) {
   return db
     .prepare(
-      "INSERT INTO api_keys (id, organization_id, key_hash, key_prefix, name) VALUES (?, ?, ?, ?, ?)"
+      "INSERT INTO api_keys (id, organization_id, key_hash, key_prefix, name, scopes) VALUES (?, ?, ?, ?, ?, ?)"
     )
-    .bind(id, organizationId, keyHash, keyPrefix, name)
+    .bind(id, organizationId, keyHash, keyPrefix, name, scopes)
     .run();
 }
 
@@ -30,7 +31,7 @@ export function getApiKeyByHash(db: D1Database, keyHash: string) {
 export function getApiKeyWithOrg(db: D1Database, keyHash: string) {
   return db
     .prepare(
-      `SELECT k.id AS key_id, k.organization_id, o.tier
+      `SELECT k.id AS key_id, k.organization_id, k.scopes, o.tier
        FROM api_keys k
        JOIN organizations o ON o.id = k.organization_id
        WHERE k.key_hash = ?
@@ -38,7 +39,7 @@ export function getApiKeyWithOrg(db: D1Database, keyHash: string) {
          AND (k.expires_at IS NULL OR k.expires_at > datetime('now'))`
     )
     .bind(keyHash)
-    .first<{ key_id: string; organization_id: string; tier: string }>();
+    .first<{ key_id: string; organization_id: string; scopes: string; tier: string }>();
 }
 
 export function updateApiKeyLastUsed(db: D1Database, id: string) {
@@ -51,7 +52,7 @@ export function updateApiKeyLastUsed(db: D1Database, id: string) {
 export function getApiKeysByOrg(db: D1Database, organizationId: string) {
   return db
     .prepare(
-      "SELECT id, key_prefix AS prefix, name, expires_at, last_used_at, created_at FROM api_keys WHERE organization_id = ? AND revoked_at IS NULL ORDER BY created_at"
+      "SELECT id, key_prefix AS prefix, name, scopes, expires_at, last_used_at, created_at FROM api_keys WHERE organization_id = ? AND revoked_at IS NULL ORDER BY created_at"
     )
     .bind(organizationId)
     .all();


### PR DESCRIPTION
Closes #69 — the highest-value, self-contained slice of the RBAC proposal (items 1, 3, 5). Seat roles and IP allowlist are scoped out (noted below).

## What
Least-privilege **scopes** on API keys — a subset of `read`, `write`, `search`, `delete` — enforced in the MCP tool handlers.

- `migration 0018` — `api_keys.scopes TEXT NOT NULL DEFAULT 'read,write,search,delete'`. **Existing keys keep full access** (backward compatible).
- `getApiKeyWithOrg` returns `scopes`; `authMiddleware` parses them onto `AuthContext`. OAuth connections get the full memory scope set (their tool surface is already narrowed by `isExternalOAuthClient`).
- **Enforcement** (each returns `insufficient_scope` when missing):
  | tool | scope |
  |---|---|
  | `search` | search |
  | `get_conversation`, `list_conversations` | read |
  | `create_conversation`, `append_messages` | write |
  | `delete_conversation` | delete |
- `POST /api/keys` accepts an optional `scopes: string[]` to mint a narrower key (e.g. a **search-only** key); validated against the allowed set and echoed back. Omitted ⇒ full access.
- `parseScopes` treats empty/garbled values as full access, so a bad row never silently locks a caller out.

## Deferred (follow-ups, noted on the issue)
- **Seat roles** (owner/admin/member/readonly) — API-key auth has no seat/role concept attached today.
- **IP allowlist** (optional in the issue).
- **Dashboard UI** for creating scoped keys (the API supports it now).

## Tests
New `scopes.test.ts` (parse/validate/enforce). 147 mcp-server tests green; typecheck clean. Additive + default-open, so nothing regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)