### PR TITLE
fix: add error handling to prevent 76% worker crash rate

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -31,6 +31,16 @@ type HonoEnv = {
 
 const app = new Hono<HonoEnv>();
 
+// Global error handler — catches any uncaught exception and returns a
+// structured 500 instead of letting Cloudflare surface `scriptThrewException`.
+app.onError((err, c) => {
+  console.error(`[error] ${c.req.method} ${c.req.path}: ${err.message}`);
+  return c.json(
+    { error: "internal_error", message: err.message },
+    500,
+  );
+});
+
 // Health check
 app.get("/health", (c) => {
   return c.json({ status: "ok", service: "engram-mcp-server", version: "0.2.0" });
@@ -64,9 +74,14 @@ app.all("/mcp", authMiddleware, rateLimitMiddleware, async (c) => {
     sessionIdGenerator: undefined, // stateless
   });
 
-  await server.connect(transport);
-
-  return transport.handleRequest(c.req.raw);
+  try {
+    await server.connect(transport);
+    return await transport.handleRequest(c.req.raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[mcp] transport error: ${msg}`);
+    return c.json({ error: "mcp_error", message: msg }, 500);
+  }
 });
 
 // CORS for browser-originated calls from the marketing site + dashboard.

--- a/apps/mcp-server/src/services/conversation.ts
+++ b/apps/mcp-server/src/services/conversation.ts
@@ -155,58 +155,70 @@ export async function appendMessages(
   // Update conversation message count
   await updateConversationMessageCount(env.DB, conversationId, redacted.length);
 
-  // Chunk the redacted messages for embedding
+  // Chunk the redacted messages for embedding.
+  // Indexing (embeddings + vectorize) is best-effort — if it fails, messages
+  // are still stored. They just won't be searchable until the next successful
+  // index run. This prevents AI model or Vectorize rate limits from crashing
+  // the entire append_messages request.
   const chunks = chunkMessages(redacted);
 
   if (chunks.length > 0) {
-    // Generate embeddings for all chunks
-    const texts = chunks.map((c) => c.text);
-    const embeddings = await generateEmbeddings(env.AI, texts);
+    try {
+      // Generate embeddings for all chunks
+      const texts = chunks.map((c) => c.text);
+      const embeddings = await generateEmbeddings(env.AI, texts);
 
-    // Prepare chunk records with vectorize IDs
-    const chunkRecords = chunks.map((chunk, i) => {
-      const vectorizeId = generateId("chk");
-      return {
-        id: generateId("chk"),
-        conversationId,
-        organizationId,
-        chunkText: chunk.text,
-        chunkSummary: summarizeChunk(chunk.text),
-        startSequence: chunk.startSequence,
-        endSequence: chunk.endSequence,
-        vectorizeId,
-        embedding: embeddings[i],
-      };
-    });
+      // Prepare chunk records with vectorize IDs
+      const chunkRecords = chunks.map((chunk, i) => {
+        const vectorizeId = generateId("chk");
+        return {
+          id: generateId("chk"),
+          conversationId,
+          organizationId,
+          chunkText: chunk.text,
+          chunkSummary: summarizeChunk(chunk.text),
+          startSequence: chunk.startSequence,
+          endSequence: chunk.endSequence,
+          vectorizeId,
+          embedding: embeddings[i],
+        };
+      });
 
-    // Insert chunks into D1
-    await insertChunks(
-      env.DB,
-      chunkRecords.map((c) => ({
-        id: c.id,
-        conversationId: c.conversationId,
-        organizationId: c.organizationId,
-        chunkText: c.chunkText,
-        chunkSummary: c.chunkSummary,
-        startSequence: c.startSequence,
-        endSequence: c.endSequence,
-        vectorizeId: c.vectorizeId,
-      }))
-    );
+      // Insert chunks into D1
+      await insertChunks(
+        env.DB,
+        chunkRecords.map((c) => ({
+          id: c.id,
+          conversationId: c.conversationId,
+          organizationId: c.organizationId,
+          chunkText: c.chunkText,
+          chunkSummary: c.chunkSummary,
+          startSequence: c.startSequence,
+          endSequence: c.endSequence,
+          vectorizeId: c.vectorizeId,
+        }))
+      );
 
-    // Upsert vectors to Vectorize
-    const vectors = chunkRecords.map((c) => ({
-      id: c.vectorizeId,
-      values: c.embedding,
-      metadata: {
-        organization_id: organizationId,
-        conversation_id: conversationId,
-        start_sequence: c.startSequence,
-        end_sequence: c.endSequence,
-      },
-    }));
+      // Upsert vectors to Vectorize
+      const vectors = chunkRecords.map((c) => ({
+        id: c.vectorizeId,
+        values: c.embedding,
+        metadata: {
+          organization_id: organizationId,
+          conversation_id: conversationId,
+          start_sequence: c.startSequence,
+          end_sequence: c.endSequence,
+        },
+      }));
 
-    await env.VECTORIZE.upsert(vectors);
+      await env.VECTORIZE.upsert(vectors);
+    } catch (err) {
+      // Log but don't fail — messages are already stored above.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[index] Failed to index ${chunks.length} chunk(s) for ${conversationId}: ${msg}`,
+      );
+    }
   }
 
   return messages;

--- a/apps/mcp-server/src/services/search.ts
+++ b/apps/mcp-server/src/services/search.ts
@@ -74,20 +74,33 @@ export async function searchConversations(
   }
 
   // Run embedding generation and FTS5 keyword search in parallel.
-  // FTS errors (malformed queries) degrade gracefully to vector-only.
-  const [queryEmbedding, ftsResults] = await Promise.all([
-    generateEmbedding(env.AI, query),
+  // Both degrade gracefully — if the AI model or Vectorize is down,
+  // search falls back to whichever source is available.
+  const [embeddingResult, ftsResults] = await Promise.all([
+    generateEmbedding(env.AI, query)
+      .then((emb) => ({ ok: true as const, embedding: emb }))
+      .catch((err) => {
+        console.error(`[search] embedding failed, falling back to FTS-only: ${err instanceof Error ? err.message : err}`);
+        return { ok: false as const, embedding: null };
+      }),
     searchChunksFts(env.DB, query, organizationId, fetchK, conversationId)
       .catch(() => ({ results: [] as { chunk_id: string; rank: number }[] })),
   ]);
 
-  const vectorResults = await env.VECTORIZE.query(queryEmbedding, {
-    topK: fetchK,
-    filter,
-    returnMetadata: "all",
-  });
+  let vectorMatches: VectorizeMatch[] = [];
+  if (embeddingResult.ok) {
+    try {
+      const vectorResults = await env.VECTORIZE.query(embeddingResult.embedding, {
+        topK: fetchK,
+        filter,
+        returnMetadata: "all",
+      });
+      vectorMatches = (vectorResults.matches ?? []) as VectorizeMatch[];
+    } catch (err) {
+      console.error(`[search] vectorize query failed, using FTS-only: ${err instanceof Error ? err.message : err}`);
+    }
+  }
 
-  const vectorMatches = (vectorResults.matches ?? []) as VectorizeMatch[];
   const ftsMatches = ftsResults.results ?? [];
 
   if (vectorMatches.length === 0 && ftsMatches.length === 0) {


### PR DESCRIPTION
## Summary

The MCP server has a **76% error rate** — 105K out of 138K requests in the last 14 days are `scriptThrewException`. The worker has zero try-catch anywhere in the request chain. When the Cloudflare AI embedding model or Vectorize hit rate limits under heavy load from the auto-capture daemon (200-message batches, 5 concurrent, every 2 seconds), exceptions propagate uncaught.

### Three-layer fix:

1. **Global Hono `onError` handler** — catches any uncaught exception and returns a structured 500 with the error message logged, instead of Cloudflare surfacing `scriptThrewException`

2. **Try-catch around `/mcp` transport** — prevents MCP SDK or WebStandardStreamableHTTPServerTransport errors from crashing the worker

3. **Graceful degradation in `appendMessages`** — embedding generation and Vectorize upsert are now wrapped in try-catch. If indexing fails, messages are still stored (the critical path). They won't be searchable until the next successful chunk, but no data is lost.

4. **Graceful degradation in `searchConversations`** — if the AI model is down, search falls back to FTS-only results instead of crashing. If Vectorize query fails, same fallback.

### Before/After

| | Before | After |
|--|--------|-------|
| AI model rate limit | `scriptThrewException` (worker crash) | Messages stored, indexing skipped with log |
| Vectorize overload | `scriptThrewException` (worker crash) | Messages stored, vectors skipped with log |
| Transport error | `scriptThrewException` (worker crash) | 500 JSON response with error message |
| Search embedding fails | `scriptThrewException` (worker crash) | Falls back to FTS-only results |

## Test plan

- [x] All 147 tests pass
- [x] Typecheck passes
- [ ] Deploy to prod and monitor error rate via Cloudflare analytics
- [ ] Verify daemon retries work correctly with 500 responses (vs crashes)
- [ ] Check console logs for `[index]` and `[search]` error messages

## Priority

**Ship ASAP** — this is blocking promotion. Can't launch with 76% of requests crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)