### PR TITLE
fix(mcp): steer ChatGPT first-run away from the safety-blocked "remember everything" path (#231)

### DIFF
--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -18,11 +18,12 @@ import type { Env, AuthContext } from "../types.js";
 // Surfaced to clients (ChatGPT, Claude, …) in the MCP `initialize` response so
 // the model knows to use Engram for memory proactively, without being asked —
 // and that it owns the conversation_id rather than asking the user for one.
-const SERVER_INSTRUCTIONS = `Engram is persistent, searchable memory for AI agents. Use it proactively, without waiting to be asked.
+const SERVER_INSTRUCTIONS = `Engram is persistent, searchable memory. Use it proactively, without waiting to be asked.
 
-- At the start of a task or session, call \`search\` with a short summary of the user's request to recall relevant prior context, and use what you find.
-- When something worth remembering is established — decisions, preferences, facts, project or personal context — persist it: call \`create_conversation\` once to get a conversation_id (you own this id; never ask the user for it), then \`append_messages\` to store the user's message and your reply verbatim. Reuse that same conversation_id for the rest of the session.
-- Do not store trivial chatter (greetings, acknowledgements). Storage is verbatim and searchable by meaning.`;
+- Recall: at the start of a task, call \`search\` with a short summary of the user's request to surface relevant prior context, and use what you find.
+- Store: when something worth remembering is established — a decision, preference, fact, or useful context — call \`append_messages\` with the relevant messages from the current conversation, verbatim. conversation_id is OPTIONAL — omit it to use the user's default memory; never ask the user for one. Use \`create_conversation\` first only to group a distinct topic, then reuse that id.
+- "Remember this / save this chat": store the messages already in THIS conversation. You cannot retrieve the user's past or external conversations — so if they ask you to remember their whole history, save the current exchange, then tell them Engram records going forward and that they can bulk-import their full history by exporting their ChatGPT (or Claude) data and running \`engram import\` (see getengram.app/docs). Do not attempt to gather, reconstruct, or forward their entire chat history — you don't have access to it.
+- Skip trivial chatter (greetings, acknowledgements). Storage is verbatim and searchable by meaning.`;
 
 export function createMcpServer(env: Env, auth: AuthContext): McpServer {
   const server = new McpServer(

--- a/apps/mcp-server/src/mcp/tools/append-messages.ts
+++ b/apps/mcp-server/src/mcp/tools/append-messages.ts
@@ -25,7 +25,7 @@ export function registerAppendMessages(
     "append_messages",
     {
       description:
-        "Store messages in Engram memory, verbatim and automatically chunked + embedded for search. conversation_id is OPTIONAL: omit it to append to the user's default memory (recommended for general 'remember this' requests) — never ask the user for an id. Pass a conversation_id (from create_conversation) only when you want to group a specific topic. The response returns the conversation_id used. Optionally accepts client-encrypted vault entries for secrets detected client-side.",
+        "Store messages in Engram memory, verbatim and automatically chunked + embedded for search. Pass the relevant messages from the CURRENT conversation. conversation_id is OPTIONAL: omit it to append to the user's default memory (recommended for general 'remember this' requests) — never ask the user for an id. Pass a conversation_id (from create_conversation) only when you want to group a specific topic. The response returns the conversation_id used. Note: you can only store messages from the current conversation — you cannot fetch a user's past or external chat history; for bulk history, tell them to export their data and run `engram import`. Optionally accepts client-encrypted vault entries for secrets detected client-side.",
       inputSchema: {
       conversation_id: z
         .string()

--- a/docs/launch/chatgpt-app-listing.md
+++ b/docs/launch/chatgpt-app-listing.md
@@ -17,20 +17,35 @@ and epic get-engram/engram#184.
 ## Description
 
 **Short (one line):**
-> Persistent, searchable memory for ChatGPT — remember context across conversations.
+> Lasting, portable memory for ChatGPT — remember context across chats, and bring your history with you.
 
 **Long:**
-> Engram gives ChatGPT long-term memory. It stores conversations verbatim and
-> makes them searchable by meaning, so context, decisions, and preferences carry
-> across sessions instead of being forgotten. Ask ChatGPT to remember something
-> and recall it days or weeks later. Your memory is private to your account, and
-> the same memory works across any MCP client you connect.
+> Engram gives ChatGPT durable, private memory that you own. Tell ChatGPT to
+> remember something — a decision, a preference, a fact — and recall it days or
+> weeks later, in this chat or a brand-new one. Already have months of ChatGPT
+> history? Import it in one step and make all of it searchable by meaning.
+>
+> Your memory isn't locked to ChatGPT: the same Engram memory works across Claude,
+> Cursor, and any MCP-compatible tool, so context follows you everywhere instead of
+> being trapped in one app. Everything is stored verbatim, searchable by meaning,
+> and private to your account.
+
+**Getting started (put in the listing so first-run works):**
+> - Say **"remember this"** or **"save that to Engram"** to store something.
+> - Ask **"search Engram for …"** — or just ask about past context — to recall it.
+> - Bring your history: export your ChatGPT data and run `engram import` (see getengram.app/docs).
 
 **What it does (for the "functionality not native to ChatGPT" requirement):**
 ChatGPT has no durable, user-owned, semantically-searchable memory store that
 persists across conversations and is portable across clients. Engram provides
 exactly that — verbatim storage + hybrid (semantic + keyword) retrieval that the
 model calls as tools.
+
+> **Honesty guardrail (keep the listing compliant):** Describe Engram as
+> **save-on-request + import** — never "automatically records everything you say."
+> ChatGPT gives connectors no per-turn hook, and OpenAI's guidelines prohibit
+> pulling the full chat log; claiming silent full-capture would misrepresent the
+> app and risk the listing. The framing above is both accurate and compelling.
 
 ## Categories / availability
 


### PR DESCRIPTION
## Problem

#231: new ChatGPT App Directory users' first instinct is *"remember everything I've said."* That broad request is **blocked by ChatGPT's safety layer before it ever reaches Engram** (see the issue screenshots — "the tool call was blocked, so I can't confirm anything was saved"). The app looks broken on first use. And a connector can't access the user's full history anyway — OpenAI policy prohibits pulling the full chat log.

This is now urgent: **the app is live in the ChatGPT App Directory**, so real users land on this exact experience.

## Fix

We can't disable OpenAI's safety layer — but we can steer the model to do the **scoped thing that succeeds** instead of the broad thing that gets blocked. Reshaped `SERVER_INSTRUCTIONS` and the `append_messages` description so the model:

- Prefers `append_messages` **without** a `conversation_id` for "remember this" — drops the `create_conversation` ceremony ChatGPT resists (relates to #201).
- On *"remember my whole history"*: stores the **current exchange**, then tells the user Engram records **going forward** and points them to **`engram import`** for bulk history.
- Is told explicitly **not** to gather / reconstruct / forward the entire chat log (blocked by safety, not accessible, prohibited by policy).

Also refreshed `docs/launch/chatgpt-app-listing.md` (import + cross-app hooks, example prompts, honesty guardrail) now that the app is live.

## Verification
- `tsc --noEmit` clean.
- All **147** mcp-server tests pass.
- Note: takes effect after the Worker is redeployed (`mcp.getengram.app`).

Refs #231