### PR TITLE
docs(launch): ChatGPT app launch bundle + demo GIF script (+ orphaned guide mirrors)

### DIFF
--- a/docs/guides/chatgpt.md
+++ b/docs/guides/chatgpt.md
@@ -1,13 +1,23 @@
 # ChatGPT Integration Guide
 
-Connect Engram to ChatGPT as a custom MCP connector. ChatGPT authenticates via
+Connect Engram to ChatGPT as an **app / MCP connector**. ChatGPT authenticates via
 **OAuth**, and Engram is a full OAuth 2.1 authorization server, so you sign in
 with your Engram account once and ChatGPT stays connected — no API key to paste.
 
-## Add the connector
+Once connected, memories saved in ChatGPT are searchable from Claude, Cursor, and
+every other connected tool — one shared memory across all of them.
 
-> Requires a paid ChatGPT tier (Plus/Pro/Business/Enterprise). Developer-mode
-> custom connectors vary by tier and region.
+## Add Engram
+
+### Option A — Add the Engram app (recommended)
+
+1. **Settings → Apps & Connectors.**
+2. Search for **Engram** and add it.
+3. Sign in with your Engram account (OAuth) and authorize. Engram's tools appear.
+
+### Option B — Developer-mode custom connector
+
+> Developer-mode custom connectors vary by tier and region.
 
 1. **Settings → Apps & Connectors → Advanced settings → enable Developer mode.**
 2. Back on the Connectors page, choose **Create / Add custom connector**.
@@ -17,12 +27,8 @@ with your Engram account once and ChatGPT stays connected — no API key to past
 5. Click **Connect**. A getengram.app window opens — **sign in** and **Authorize**.
 6. ChatGPT returns to the connector and Engram's tools appear. Done.
 
-That's it. ChatGPT now has `search`, `create_conversation`, `append_messages`,
-and the rest of Engram's tools.
-
-> **Not the Apps directory.** The **Apps** entry in the ChatGPT sidebar is a
-> curated, publish-only store — Engram is not a published ChatGPT app and won't
-> appear there. Custom connectors (above) are the path for connecting Engram.
+Either way, ChatGPT now has `search`, `create_conversation`, `append_messages`,
+and the rest of the memory tools.
 
 ## How the OAuth flow works
 
@@ -42,10 +48,23 @@ You don't need to know this to use it, but for the curious:
 Access is scoped to your account. You can revoke a connected app anytime from
 your [dashboard](https://getengram.app/dashboard).
 
-## Auto-memory in ChatGPT
+## How memory capture works in ChatGPT
 
-To make ChatGPT use Engram automatically, add memory instructions to a
-**Project** (Settings → Projects) or a Custom GPT's instructions:
+Unlike Claude Code or Cursor — which run on your machine and let Engram capture
+every message automatically — **ChatGPT is a hosted app with no background capture
+hook.** By OpenAI's design and app-store policy, no connector can silently record
+your entire conversation. So in ChatGPT, Engram works two complementary ways.
+
+### 1. Save on request — "remember this"
+
+Tell ChatGPT to remember something and it's stored in Engram verbatim, then
+searchable from every connected tool:
+
+- *"Save this decision to Engram."*
+- *"Remember that we're using Postgres for the billing service."*
+
+To make this proactive, add memory instructions to a **Project**
+(Settings → Projects) or a Custom GPT's instructions:
 
 ```
 At the start of a conversation, call Engram's `search` tool with a summary of
@@ -58,27 +77,61 @@ Store: preferences, decisions and their reasoning, important facts.
 Don't store: greetings or trivial, temporary details.
 ```
 
+ChatGPT honors this on a best-effort basis — it decides when to call tools —
+which is reliable for the things you explicitly want kept.
+
+### 2. Import your full history — one time
+
+To bring **everything you've already said in ChatGPT** into Engram, use the
+native export plus `engram import`:
+
+1. **ChatGPT → Settings → Data Controls → Export data.** Unzip the emailed
+   download to find `conversations.json`.
+2. Import it:
+
+   ```bash
+   export ENGRAM_API_KEY=engram_sk_live_...
+   npx @getengram/cli import ~/Downloads/chatgpt-export/conversations.json --dry-run  # preview
+   npx @getengram/cli import ~/Downloads/chatgpt-export/conversations.json            # import
+   ```
+
+Every conversation is stored verbatim, tagged `chatgpt-import`, and embedded for
+search. See the [import guide](./import-chatgpt.md) for options.
+
+> **Note:** the native export is available on ChatGPT Free / Plus / Pro / eligible
+> Edu plans, can take up to 7 days to arrive (link expires 24h after delivery),
+> and is not currently available for ChatGPT Business / Enterprise workspaces.
+
+### What ChatGPT can't do (and no app can)
+
+Engram can't silently auto-record every ChatGPT message in the background the way
+it does for Claude Code and Cursor — there's no per-message hook for connectors,
+and OpenAI's policy prohibits pulling your full chat log. The honest, complete
+story is: **save what matters on request + import your history in bulk**, and get
+automatic verbatim capture in the local tools that support it.
+
 ## Other clients
 
-Engram works the same across every MCP-native client — memories stored in one
-are searchable from the others:
+Engram works across every MCP-native client — memories stored in one are
+searchable from the others:
 
-| Client | Best for |
-|--------|----------|
-| [Claude Desktop](./claude-desktop.md) | General conversations, research, personal use |
-| [Claude Code](./claude-code.md) | CLI-based coding and engineering |
-| [Cursor](./cursor.md) | IDE-based coding |
-| [Windsurf](./windsurf.md) | IDE-based coding with Cascade flows |
-| [Codex CLI](./codex.md) | CLI-based coding with OpenAI models |
-
-These use a Bearer API key directly; ChatGPT uses the OAuth flow above. Either
-way it's the same memory.
+| Client | Capture |
+|--------|---------|
+| [Claude Code](./claude-code.md) | Automatic, verbatim (local) |
+| [Cursor](./cursor.md) | Automatic, verbatim (local) |
+| [Claude Desktop](./claude-desktop.md) | On request (MCP) |
+| ChatGPT | On request + bulk import |
+| [Windsurf](./windsurf.md) | On request (MCP) |
+| [Codex CLI](./codex.md) | On request (MCP) |
 
 ## Troubleshooting
 
 - **No "OAuth" option / can't add a connector.** Developer-mode custom connectors
-  require a paid tier and aren't available in every region yet.
+  require a paid tier and aren't available in every region yet — try Option A.
 - **Login window doesn't return to ChatGPT.** Make sure pop-ups for chatgpt.com
   are allowed, then retry **Connect**.
 - **Tools don't appear after authorizing.** Remove and re-add the connector; on
   re-add, ChatGPT re-runs discovery.
+- **A tool call was "blocked."** ChatGPT's safety layer can refuse broad requests
+  like "save my entire history" before they reach Engram. Ask it to save the
+  current exchange ("remember this"), or use the import path above for bulk history.

--- a/docs/guides/vscode.md
+++ b/docs/guides/vscode.md
@@ -1,0 +1,124 @@
+# VS Code Integration Guide
+
+Give GitHub Copilot in VS Code persistent memory across sessions using Engram. VS Code connects to Engram as an **MCP server**, and because that memory is shared, anything Copilot stores is also available in Cursor, Claude, ChatGPT, and every other connected tool.
+
+> **Requires:** GitHub Copilot in VS Code with MCP support and **Agent mode** in Copilot Chat.
+
+## Setup
+
+### 1. Get an API Key
+
+Sign up at [getengram.app](https://getengram.app).
+
+### 2. Add the MCP Server
+
+**Option A: Command Palette**
+
+1. Open the Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`).
+2. Run **MCP: Add Server**.
+3. Choose **HTTP** (a remote server), and enter the URL `https://mcp.getengram.app/mcp`.
+4. Pick **Workspace** (saves to `.vscode/mcp.json`) or **Global** (user config).
+
+**Option B: Config file**
+
+Create `.vscode/mcp.json` in your project. VS Code uses a top-level `servers` key (not `mcpServers`), and `inputs` to prompt for secrets so your key isn't hardcoded:
+
+```json
+{
+  "inputs": [
+    {
+      "id": "engram-key",
+      "type": "promptString",
+      "description": "Engram API key",
+      "password": true
+    }
+  ],
+  "servers": {
+    "engram": {
+      "type": "http",
+      "url": "https://mcp.getengram.app/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:engram-key}"
+      }
+    }
+  }
+}
+```
+
+VS Code prompts for the key the first time the server starts and stores it securely. To open the user-level config instead, run **MCP: Open User Configuration**.
+
+> Avoid hardcoding the key directly in `headers`. Use the `inputs` prompt above (or an environment file) so the value stays out of source control.
+
+### 3. Verify
+
+Open Copilot Chat, switch to **Agent** mode, and confirm Engram appears in the Tools picker (enable it if needed). Then ask it to search Engram — if it can call the `search` tool, you're connected.
+
+---
+
+## Automatic Memory
+
+VS Code Copilot loads workspace instructions from `.github/copilot-instructions.md` into every Agent session — the equivalent of Cursor's `.cursorrules` or Claude Code's `CLAUDE.md`.
+
+Create `.github/copilot-instructions.md` in your project root:
+
+```markdown
+## Engram Memory
+
+You have access to Engram memory tools via MCP. Use them automatically.
+
+### On session start
+
+Search Engram for context relevant to the current task:
+
+    search
+      query: "<summary of what the user is asking about>"
+      limit: 5
+
+Include any relevant results in your working context.
+
+### During the session
+
+When something worth remembering is established, store it:
+
+    create_conversation
+      title: "<concise description>"
+      agent_id: "vscode"
+      tags: ["<project-name>", "<topic>"]
+
+    append_messages
+      conversation_id: "<id>"
+      messages:
+        - role: "user"
+          content: "<what the user asked>"
+        - role: "assistant"
+          content: "<what you did and why>"
+
+### What to store
+
+- Decisions and their reasoning
+- Bug investigations and resolutions
+- User preferences and coding style
+- Architecture discussions
+
+### What NOT to store
+
+- Routine code generation
+- File reads and searches
+- Information already in git
+```
+
+---
+
+## Agent Mode is Required
+
+MCP tools are only available in Copilot Chat's **Agent mode**, where Copilot can autonomously call tools. Ask, Edit, and inline modes won't trigger Engram. Select **Agent** at the top of the Chat view, and make sure Engram's tools are enabled in the Tools picker.
+
+## How capture works
+
+Like Cursor and Claude Desktop, VS Code capture is **on request via MCP** — Copilot stores memories when the task or your instructions call for it. It's reliable for the context you want kept. (Automatic, verbatim capture of every message is only available where a local agent can read the transcript, such as Claude Code.)
+
+## Tips
+
+- **Commit `.github/copilot-instructions.md`** so everyone on the team gets auto-memory behavior.
+- **Use `.vscode/mcp.json`** for per-project setup and share it with your team (the `inputs` prompt keeps the key out of the repo).
+- **Combine with other tools.** Same API key = shared memory. Debug in VS Code, recall the context in Claude Code or Cursor.

--- a/docs/launch/chatgpt-app/README.md
+++ b/docs/launch/chatgpt-app/README.md
@@ -1,0 +1,31 @@
+# ChatGPT App — Launch Bundle
+
+Copy-paste-ready launch posts for **Engram now being live in the ChatGPT App Directory**. Each file is one channel. Retargeted from the generic (Claude-Code-first) drafts in the parent folder to lead with the ChatGPT app.
+
+## The two hooks (use everywhere)
+
+1. **Import your ChatGPT history** — export your data, run `engram import`, and every past conversation is searchable forever. Unique, true, and it's the "wow."
+2. **One memory across ChatGPT, Claude & Cursor** — save in one, recall in the others. Your memory isn't locked to one app.
+
+## Honesty guardrail (protects the listing)
+
+- ✅ Say: "save what matters + import your history," "portable memory across your AI tools."
+- ❌ Never say: "Engram auto-records everything you say in ChatGPT." It's false (no per-turn hook), disappoints users, and violates the App Directory terms you were approved under. In ChatGPT, capture is **save-on-request + bulk import**. Automatic verbatim capture is a Claude Code / Cursor thing — market it there.
+
+## Accuracy checklist
+
+- Product/repo license is **BSL-1.1**; the SDK + CLI are **MIT**.
+- Free tier = **1,000 messages/month**. Pro = **$39/mo**.
+- You **can** now say "available in the ChatGPT App Directory" (it's live).
+- Don't claim a Homebrew tap until `engram` is actually on homebrew-core (#36).
+
+## Launch-day sequence (Tue–Thu, US morning)
+
+1. **Pre-req:** a 20–30s demo GIF (connect → "remember this" → new chat → recall → then the import kicker). This carries every post.
+2. **Product Hunt** — schedule for 12:01am PT; be present all day to reply.
+3. **Show HN** — post as a text "Show HN"; stay and answer comments the first hour.
+4. **r/ChatGPT + r/OpenAI** — value-first post, not an ad (need karma first, #230).
+5. **X thread** from **@getengram** (create the account first, engram-web #46).
+6. Cross-link: PH ↔ X ↔ site. Pin the X thread.
+
+Files: `show-hn.md` · `product-hunt.md` · `reddit-chatgpt.md` · `x-thread.md`

--- a/docs/launch/chatgpt-app/demo-gif-script.md
+++ b/docs/launch/chatgpt-app/demo-gif-script.md
@@ -1,0 +1,63 @@
+# Demo GIF / Video — Shot List & Script
+
+The single highest-leverage launch asset. It carries Product Hunt, Show HN, the X thread, and the landing page. Goal: in ~25 seconds, show the one thing words can't — **memory saved in ChatGPT, recalled in a different app**, then the **import** kicker.
+
+## Specs
+
+- **Length:** 20–30s. Silent, looping GIF/MP4 (people scroll with sound off). Add captions/text overlays for each beat.
+- **Format:** MP4 for X/PH (better quality), GIF fallback. ~1280×720 or the app's native aspect. Keep under ~10 MB so it autoplays.
+- **Pace:** fast. Cut dead air — trim thinking/loading time, jump straight to results. No slow typing; pre-type or speed-ramp.
+- **Look:** clean desktop, light mode, hide personal data / other tabs / notifications. One browser window, no clutter.
+- **Capture:** screen recorder at 60fps, then export to GIF at ~15–20fps. Add a subtle cursor highlight.
+
+## The narrative (3 beats)
+
+**Beat 1 — Save in ChatGPT (0:00–0:08)**
+The setup. Show memory going *in*, on request.
+
+- On screen: a ChatGPT chat with Engram connected (tools visible).
+- Type: `Remember that we're using Hono, not Express, for the API — decided for edge/Workers support.`
+- ChatGPT calls Engram and confirms it saved. Text overlay: **"Save anything to memory."**
+
+**Beat 2 — Recall in a DIFFERENT app (0:08–0:18) ← the money shot**
+Prove it's not locked to ChatGPT. This is the whole pitch.
+
+- Hard cut to **Cursor** (or Claude). New session, different tool. Text overlay: **"Open a different app…"**
+- Type: `What web framework did we pick for the API, and why?`
+- It calls Engram `search` and answers: *"Hono — chosen over Express for edge/Cloudflare Workers support."*
+- Text overlay: **"…it remembers. One memory, every AI."**
+
+**Beat 3 — Import your history (0:18–0:25) — the kicker**
+The "wow, I want that."
+
+- Quick cut to a terminal. Text overlay: **"Bring your whole ChatGPT history."**
+- Show: `engram import ~/Downloads/chatgpt-export/conversations.json`
+- Output scrolls: `Imported 1,284 conversations ✓`
+- End card: **Engram — one memory, everywhere.** + `getengram.app`
+
+## Captions/overlay copy (exact)
+
+1. "Save anything to memory." (ChatGPT)
+2. "Open a different app…" (cut to Cursor)
+3. "…it remembers. One memory, every AI."
+4. "Bring your whole ChatGPT history." (terminal)
+5. End card: "Engram — one memory, everywhere. · getengram.app"
+
+## Honesty guardrail (don't fake it)
+
+- Beat 1 must be an **explicit** "remember this," never implied always-on capture. The demo shows save-on-request + cross-app recall + import — all true. Do **not** stage ChatGPT "auto-saving" a message you didn't ask it to save.
+- Use a real recall result, not a scripted fake — semantic search actually returns it, so show the real thing.
+
+## Variants to cut from the same recording
+
+- **6s teaser** (X reply / preview): Beat 2 only — the cross-app recall. The single most surprising moment.
+- **Vertical 9:16** (Reddit/Shorts/TikTok): same beats, stacked.
+- **Still frames** for the App Directory screenshots (#191): (a) Engram connected in ChatGPT, (b) a save confirmation, (c) a recall result.
+
+## Pre-flight checklist
+
+- [ ] Engram connected in both ChatGPT and Cursor, signed into the **same** account (shared memory won't work otherwise).
+- [ ] A clean demo memory that recalls cleanly (rehearse the exact query).
+- [ ] A real (or realistic sample) `conversations.json` for the import shot.
+- [ ] Hide: API keys, emails, other conversations, browser bookmarks, OS notifications (enable Do Not Disturb).
+- [ ] Record 2–3 takes; keep the tightest. Verify it loops without a jarring jump.

--- a/docs/launch/chatgpt-app/product-hunt.md
+++ b/docs/launch/chatgpt-app/product-hunt.md
@@ -1,0 +1,35 @@
+# Product Hunt — ChatGPT app launch
+
+> Schedule for 12:01am PT. Be present all day to reply. Lead with the demo GIF.
+
+## Name
+Engram
+
+## Tagline (60 chars max)
+Persistent memory for ChatGPT, Claude & Cursor — one brain
+
+## Description (260 chars)
+Engram gives ChatGPT long-term memory you actually own — and it's shared across Claude and Cursor too. Save what matters, import your full ChatGPT history, and recall it from any tool. Stored verbatim, searchable by meaning, private to you.
+
+## First comment (maker)
+Hey Product Hunt 👋
+
+I kept hitting the same wall: every AI tool remembers separately, or not at all. I'd work through something with ChatGPT, then open Cursor the next day and it knew nothing. I was the integration layer between my own tools — re-explaining the same context over and over.
+
+Engram is one memory that lives under all of them. Connect it once (it's now a ChatGPT app, and works with Claude, Cursor, Windsurf, and any MCP tool), and:
+
+🧠 **Save what matters** — tell ChatGPT "remember this" and recall it days later, in this chat or a new one.
+📥 **Import your history** — export your ChatGPT data, run `engram import`, and every past conversation becomes searchable.
+🔗 **One memory, everywhere** — save in ChatGPT, recall in Claude or Cursor.
+
+It stores conversations **verbatim** (no lossy summaries) and searches them by meaning. Everything's private to your account and runs on Cloudflare.
+
+Being upfront about how it works: in ChatGPT you invoke it ("remember this" / "search Engram"), because ChatGPT gives apps no way to silently record everything — and we wouldn't want it to. On local tools like Claude Code it can capture automatically.
+
+Free tier (1,000 messages/mo) to try it. Would love to hear what context *you* keep re-explaining to your AI tools.
+
+## Topics
+Artificial Intelligence · Productivity · Developer Tools · ChatGPT · Open Source
+
+## Links
+Site: https://getengram.app · GitHub: https://github.com/get-engram/engram

--- a/docs/launch/chatgpt-app/reddit-chatgpt.md
+++ b/docs/launch/chatgpt-app/reddit-chatgpt.md
@@ -1,0 +1,29 @@
+# Reddit — r/ChatGPT and r/OpenAI
+
+> Value-first, not an ad. Reddit punishes promo. Lead with the problem + a genuinely useful tip (the data export), mention the tool once, and be around to answer. You need account karma first (#230). Read each sub's self-promo rules before posting.
+
+## Title options
+- "TIL you can export your entire ChatGPT history and make it searchable — here's how I did it"
+- "I gave ChatGPT memory that carries over to Claude and Cursor. Here's the setup."
+
+## Body (r/ChatGPT — leads with the useful tip)
+
+Two things a lot of people don't realize:
+
+1. **You can export everything you've ever said to ChatGPT.** Settings → Data Controls → Export data. You get a `conversations.json` with your full history.
+2. On its own that file just sits there. So I've been piping it into a memory layer (Engram) that stores it verbatim and lets me search it by meaning — and then recall it from ChatGPT, Claude, and Cursor.
+
+The part that changed my workflow: it's **one shared memory** across tools. I save a decision in ChatGPT, and Cursor knows it the next day. No more re-explaining my project every session.
+
+Setup was quick: in ChatGPT it's Settings → Apps & Connectors → add Engram (OAuth, no API key). Then you either say "remember this" as you go, or bulk-import the export above with the CLI (`engram import`).
+
+Honest caveat so nobody's surprised: ChatGPT doesn't let any app silently record your whole chat in the background (there's no per-turn hook, and OpenAI's policy forbids grabbing your full log). So it's "save what matters + import your history," not magic auto-capture. That was fine for me — the import covers the back-catalog and "remember this" covers going forward.
+
+Free tier is 1,000 messages/month if you want to try it: getengram.app. It's also open source.
+
+Curious what others do here — does anyone else feel the pain of every tool having separate memory, or is ChatGPT's built-in memory enough for you?
+
+## Notes
+- For **r/OpenAI**, trim the hand-holding and keep it more technical (MCP connector, verbatim storage, semantic search).
+- Reply to every comment for the first few hours. Don't drop-and-run.
+- One link max in the body. Don't crosspost the identical text same-day.

--- a/docs/launch/chatgpt-app/show-hn.md
+++ b/docs/launch/chatgpt-app/show-hn.md
@@ -1,0 +1,38 @@
+# Show HN — ChatGPT app launch
+
+**Title:** `Show HN: Engram – give ChatGPT long-term memory you can take to Claude and Cursor`
+
+> Post as a **text** Show HN (better discussion than a URL post). Post Tue–Thu, US morning, and stay to answer comments the first hour.
+
+---
+
+Engram is now a ChatGPT app (also works with Claude and Cursor). It gives ChatGPT durable, private memory that you own — and, importantly, memory that isn't trapped inside ChatGPT.
+
+The problem: every AI tool keeps its own little memory, or none. You explain your project to ChatGPT on Monday, then Cursor knows nothing about it on Tuesday. You become the copy-paste layer between your own tools.
+
+Engram is a single memory store that sits under all of them via MCP. Two things it does that I haven't seen combined elsewhere:
+
+1. **Import your existing history.** Export your ChatGPT (or Claude) data, run `engram import`, and every past conversation is stored verbatim and searchable by meaning. Your back-catalog becomes queryable from any connected tool.
+
+2. **Shared memory across tools.** Save something in ChatGPT, recall it in Claude or Cursor. Same memory, everywhere.
+
+How capture works, honestly, because it differs per host:
+
+- **ChatGPT** — you invoke it ("remember this," "search Engram for…"). ChatGPT gives connectors no per-turn hook, so an app can't silently record everything — and OpenAI's policy prohibits pulling your full chat log. So it's save-on-request + the bulk import above.
+- **Claude Code / Cursor** — these run locally, so capture can be automatic and verbatim. For Claude Code the CLI runs a background daemon that captures every session.
+
+Under the hood it's stored verbatim (no lossy summarization), chunked, and embedded for semantic search. The whole backend runs on Cloudflare — Workers for the MCP server, D1 for storage, Vectorize for search, Workers AI for embeddings.
+
+Connect in ChatGPT: Settings → Apps & Connectors → add Engram (OAuth, no key to paste). Free tier is 1,000 messages/month; Pro is $39/mo.
+
+Source is BSL-1.1; the SDK + CLI are MIT: https://github.com/get-engram/engram
+Site: https://getengram.app
+
+I'd love feedback — especially: what context do you find yourself re-explaining to your AI tools the most? And would "one memory across all of them" actually change how you work, or is per-tool memory enough?
+
+---
+
+## Accuracy notes
+- BSL-1.1 (product) / MIT (SDK+CLI). Free tier 1,000 msgs/mo. $39 Pro.
+- Do NOT claim ChatGPT auto-records everything — it's save-on-request + import.
+- OK to say "ChatGPT app" now that it's live in the directory.

--- a/docs/launch/chatgpt-app/x-thread.md
+++ b/docs/launch/chatgpt-app/x-thread.md
@@ -1,0 +1,51 @@
+# X/Twitter thread — ChatGPT app launch
+
+> Post from @getengram (create it first — engram-web #46). Attach the demo GIF to tweet 1. Pin the thread.
+
+## Tweet 1 (hook + news)
+Engram is now a ChatGPT app 🧠
+
+It gives ChatGPT long-term memory — and unlike ChatGPT's built-in memory, this one comes with you to Claude and Cursor.
+
+One memory. Every AI you use.
+
+[demo GIF: remember in ChatGPT → recall in Cursor]
+
+## Tweet 2 (the unlock)
+The best part: bring your history.
+
+Export your ChatGPT data → run `engram import` → every conversation you've ever had is stored verbatim and searchable by meaning.
+
+Your back-catalog becomes a queryable memory. From any tool.
+
+## Tweet 3 (the moat)
+Most "AI memory" is trapped in one app.
+
+Engram sits underneath your tools via MCP, so:
+
+• save a decision in ChatGPT
+• recall it in Cursor tomorrow
+• reference it in Claude next week
+
+Same memory, everywhere. You own it.
+
+## Tweet 4 (honest, which builds trust)
+We're straight about how it works:
+
+In ChatGPT you invoke it ("remember this"). No app can silently record your whole chat — ChatGPT gives no per-turn hook and OpenAI's policy forbids grabbing the full log.
+
+On Claude Code / Cursor, capture is automatic + verbatim.
+
+## Tweet 5 (substance)
+No lossy summaries. Engram stores conversations word-for-word and searches them semantically, so recall returns the actual reasoning — not "user prefers Postgres" with the why deleted.
+
+Runs entirely on Cloudflare. Fast, private, per-account isolated.
+
+## Tweet 6 (CTA)
+Add Engram in ChatGPT: Settings → Apps & Connectors → Engram.
+
+Free tier (1,000 msgs/mo). Open source.
+
+→ https://getengram.app
+
+Your AI should remember. Now it does — everywhere.

--- a/docs/launch/one-memory-everywhere.md
+++ b/docs/launch/one-memory-everywhere.md
@@ -1,0 +1,59 @@
+# One Memory, Everywhere
+
+**Engram is the memory that follows you across every AI. Save something in ChatGPT, recall it in Claude or Cursor.**
+
+*Published July 8, 2026 · Get Engram Inc*
+
+---
+
+## Your memory is trapped in whichever app you were using
+
+You explained your architecture to ChatGPT on Monday. On Tuesday you're in Cursor, and it has no idea that conversation ever happened. Wednesday you're back in Claude Code, re-explaining the same three constraints you already talked through twice.
+
+Every AI tool you use keeps its own little memory — or no memory at all. ChatGPT remembers a few things inside ChatGPT. Cursor knows this repo, for this session. Claude Code starts every conversation from zero. None of them talk to each other. So *you* become the integration layer: copying context between tools, re-explaining decisions, and losing the reasoning the moment a session ends.
+
+That's backwards. The conversation is the most valuable thing you produce with an AI — the place where the problem gets understood and the decision gets made. It shouldn't belong to one app. It should belong to *you*, and follow you wherever you go.
+
+## Memory as a layer, not a feature
+
+Engram is a single, persistent memory that sits underneath all your AI tools instead of inside one of them.
+
+Connect it once, and every tool that speaks [MCP](https://modelcontextprotocol.io) — Claude Code, Claude Desktop, Cursor, Windsurf, ChatGPT, Codex — reads and writes the same memory. Something you save in one shows up in all of them. Ask any of them "what did we decide about the auth flow?" and the answer is there, even if the decision was made three weeks ago in a different app.
+
+Two things make this actually work, not just sound nice:
+
+**It's stored verbatim.** Engram doesn't summarize your conversations into lossy "memories." It keeps the full text and makes it searchable by meaning, so recall returns what was actually said — the real reasoning, not a paraphrase of it.
+
+**It's yours and portable.** Your memory isn't locked to a vendor's account. It's one store you own, queryable from any client, exportable, and — because it lives behind MCP — future-proof against whatever tool you adopt next.
+
+## How it works in each app — honestly
+
+Every AI host is built differently, and we're straight with you about what each one can do. This is a feature, not fine print: knowing the difference is how you get the most out of it.
+
+**Claude Code & Cursor — automatic.** These tools run on your machine and expose your session to a local Engram agent. Memory capture is automatic and complete: every message is saved verbatim as you work, with zero ceremony. This is the full "it just remembers" experience.
+
+**ChatGPT — you invoke it, plus one-time import.** ChatGPT is a hosted app with strong guardrails, so Engram works two ways there. Say *"remember this"* or *"save that to Engram,"* and it's stored forever and searchable everywhere else. And you can bring your entire back-catalog in one move: export your ChatGPT history and run `engram import` — all of it becomes part of your searchable memory. (ChatGPT can't silently record everything in the background — no app can, by OpenAI's design — so Engram is honest about that instead of pretending otherwise.)
+
+The payoff is the same regardless of where a memory came from: **once it's in Engram, it's available from every connected tool.** Save in ChatGPT, recall in Cursor. Decide in Claude Code, reference in ChatGPT. The memory follows you; the app is just a window into it.
+
+## Why "everywhere" is the whole point
+
+A memory that only works in one tool isn't memory — it's a session. The value compounds precisely *because* it crosses apps:
+
+- The research you did in ChatGPT is in context when you start building in Cursor.
+- The bug you root-caused in Claude Code is recallable when a teammate asks about it in a different tool next month.
+- Your preferences, your project's decisions, the "why" behind past choices — established once, present everywhere, never re-explained.
+
+You stop being the copy-paste bridge between your tools. Your AIs start sharing a brain.
+
+## Get started
+
+1. **Get a key** at [getengram.app](https://getengram.app).
+2. **Connect your tools** — add the Engram MCP server to Claude Code, Cursor, ChatGPT, or any MCP client (guides at [getengram.app/docs](https://getengram.app/docs)).
+3. **Bring your history** — `engram import` your existing ChatGPT or Claude export so day one starts with everything you've already said.
+
+Then just work. Save something in one place, recall it in another. One memory, everywhere.
+
+---
+
+*Engram is open source (MIT) and available hosted at [getengram.app](https://getengram.app) or self-hosted. Persistent, verbatim, searchable memory for every AI you use.*


### PR DESCRIPTION
## What

Now that Engram is **live in the ChatGPT App Directory**, this adds the promotional launch bundle plus a few docs written earlier this session that never got committed.

### Launch bundle (`docs/launch/chatgpt-app/`)
Copy-paste-ready posts, each leading with the two true/unique hooks — **import your ChatGPT history** + **one memory across ChatGPT/Claude/Cursor** — and none claiming silent auto-capture (keeps the App Directory listing compliant).
- `README.md` — playbook: hooks, honesty guardrail, accuracy checklist, launch-day sequence
- `show-hn.md`, `product-hunt.md`, `reddit-chatgpt.md`, `x-thread.md` — per-channel
- `demo-gif-script.md` — shot list for the save→recall-in-another-app→import demo

### Orphaned docs now landed
- `guides/chatgpt.md` — repo mirror synced to the modernized web guide
- `guides/vscode.md` — VS Code (Copilot) MCP connect guide (refs #234)
- `launch/one-memory-everywhere.md` — cross-app positioning post

Docs-only; no code changes.