### PR TITLE
feat(search): project filter to eliminate cross-project noise

### DIFF
--- a/apps/mcp-server/src/__tests__/helpers.ts
+++ b/apps/mcp-server/src/__tests__/helpers.ts
@@ -110,6 +110,32 @@ export function createMockD1(): D1Database {
 
         let results = [...table];
 
+        // FTS query — will match against chunks_fts which doesn't exist in mock
+        if (sql.includes("chunks_fts")) {
+          return { results: [], success: true, meta: {} };
+        }
+
+        // Filter by id IN (...) — used by getChunksByIds and conversation metadata
+        // Must run before generic organization_id filter since org binding is last
+        if (sql.includes("id IN (") && !sql.includes("vectorize_id") && !sql.includes("chunk_id")) {
+          const hasOrgFilter = sql.includes("organization_id = ?");
+          const orgId = hasOrgFilter ? bindings[bindings.length - 1] : null;
+          const ids = hasOrgFilter ? bindings.slice(0, -1) : bindings;
+          results = results.filter((r) => ids.includes(r.id));
+          if (orgId) {
+            results = results.filter((r) => r.organization_id === orgId);
+          }
+          return { results, success: true, meta: {} };
+        }
+
+        // Filter by vectorize_id IN (...)
+        if (sql.includes("vectorize_id IN")) {
+          results = results.filter((r) =>
+            bindings.includes(r.vectorize_id)
+          );
+          return { results, success: true, meta: {} };
+        }
+
         // Filter by organization_id
         if (sql.includes("organization_id = ?") && bindings[0]) {
           results = results.filter(
@@ -123,30 +149,6 @@ export function createMockD1(): D1Database {
           results = results.filter(
             (r) => r.conversation_id === (bindings[convIdx] ?? bindings[0])
           );
-        }
-
-        // Filter by vectorize_id IN (...)
-        if (sql.includes("vectorize_id IN")) {
-          results = results.filter((r) =>
-            bindings.includes(r.vectorize_id)
-          );
-        }
-
-        // Filter by id IN (...) — used by getChunksByIds and conversation metadata
-        if (sql.includes("id IN (") && !sql.includes("vectorize_id") && !sql.includes("chunk_id")) {
-          // Bindings are the IDs followed possibly by organizationId
-          const hasOrgFilter = sql.includes("organization_id = ?");
-          const orgId = hasOrgFilter ? bindings[bindings.length - 1] : null;
-          const ids = hasOrgFilter ? bindings.slice(0, -1) : bindings;
-          results = results.filter((r) => ids.includes(r.id));
-          if (orgId) {
-            results = results.filter((r) => r.organization_id === orgId);
-          }
-        }
-
-        // FTS query — will match against chunks_fts which doesn't exist in mock
-        if (sql.includes("chunks_fts")) {
-          return { results: [], success: true, meta: {} };
         }
 
         return { results, success: true, meta: {} };

--- a/apps/mcp-server/src/__tests__/search-service.test.ts
+++ b/apps/mcp-server/src/__tests__/search-service.test.ts
@@ -230,3 +230,115 @@ describe("search service", () => {
     expect(results.length).toBe(2);
   });
 });
+
+describe("search project filtering", () => {
+  const organizationId = "org_proj";
+  let db: D1Database;
+  let env: ReturnType<typeof createMockEnv>;
+
+  beforeAll(() => {
+    db = createMockD1();
+
+    // Seed conversations with different project titles
+    db.prepare(
+      "INSERT INTO conversations (id, organization_id, title, tags, updated_at) VALUES (?,?,?,?,?)"
+    )
+      .bind("conv_engram", organizationId, "engram (2026-04-12 11:37)", "[]", "2026-04-12")
+      .run();
+    db.prepare(
+      "INSERT INTO conversations (id, organization_id, title, tags, updated_at) VALUES (?,?,?,?,?)"
+    )
+      .bind("conv_isleep", organizationId, "isleep (2026-04-12 11:38)", "[]", "2026-04-12")
+      .run();
+
+    // Seed chunks for each conversation
+    db.prepare(
+      "INSERT INTO conversation_chunks (id, conversation_id, organization_id, chunk_text, start_sequence, end_sequence, vectorize_id, created_at) VALUES (?,?,?,?,?,?,?,?)"
+    )
+      .bind("chk_eng", "conv_engram", organizationId, "[user]: deploy the worker", 1, 2, "vec_eng", "2026-04-12")
+      .run();
+    db.prepare(
+      "INSERT INTO conversation_chunks (id, conversation_id, organization_id, chunk_text, start_sequence, end_sequence, vectorize_id, created_at) VALUES (?,?,?,?,?,?,?,?)"
+    )
+      .bind("chk_isl", "conv_isleep", organizationId, "[user]: fix the lambda crash", 1, 2, "vec_isl", "2026-04-12")
+      .run();
+
+    env = createMockEnv(db);
+    (env.VECTORIZE as unknown as Record<string, unknown>).query = vi.fn(async () => ({
+      count: 2,
+      matches: [
+        { id: "vec_eng", score: 0.95 },
+        { id: "vec_isl", score: 0.90 },
+      ],
+    }));
+  });
+
+  it("returns results from all projects when no project filter", async () => {
+    const results = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "deploy",
+      10,
+      undefined,
+      undefined,
+      undefined,
+      0,
+      true
+    );
+
+    expect(results.length).toBe(2);
+  });
+
+  it("filters to only matching project by title prefix", async () => {
+    const results = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "deploy",
+      10,
+      undefined,
+      undefined,
+      undefined,
+      0,
+      true,
+      "engram"
+    );
+
+    expect(results.length).toBe(1);
+    expect(results[0].conversation_title).toContain("engram");
+  });
+
+  it("project filter is case-insensitive", async () => {
+    const results = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "deploy",
+      10,
+      undefined,
+      undefined,
+      undefined,
+      0,
+      true,
+      "Engram"
+    );
+
+    expect(results.length).toBe(1);
+    expect(results[0].conversation_title).toContain("engram");
+  });
+
+  it("returns empty when no conversations match project", async () => {
+    const results = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "deploy",
+      10,
+      undefined,
+      undefined,
+      undefined,
+      0,
+      true,
+      "nonexistent"
+    );
+
+    expect(results.length).toBe(0);
+  });
+});

--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -39,6 +39,10 @@ export function registerSearch(
         .array(z.string())
         .optional()
         .describe("Filter by conversation tags"),
+      project: z
+        .string()
+        .optional()
+        .describe("Filter by project name (matches conversation title prefix, case-insensitive). Use to avoid cross-project noise."),
       },
       outputSchema: {
         results: z
@@ -96,6 +100,10 @@ export function registerSearch(
         params.limit,
         params.conversation_id,
         params.tags,
+        undefined, // snippetChars
+        undefined, // minScore
+        undefined, // dedupe
+        params.project,
       );
 
       // When bodies are hidden, return the matching conversations'

--- a/apps/mcp-server/src/services/search.ts
+++ b/apps/mcp-server/src/services/search.ts
@@ -58,15 +58,17 @@ export async function searchConversations(
   tags?: string[],
   snippetChars: number = DEFAULT_SNIPPET_CHARS,
   minScore: number = DEFAULT_MIN_SCORE,
-  dedupe: boolean = true
+  dedupe: boolean = true,
+  project?: string
 ): Promise<SearchResult[]> {
   const cappedSnippet = Math.min(
     Math.max(snippetChars, 0),
     MAX_SNIPPET_CHARS
   );
 
-  // Over-fetch for post-processing headroom
-  const fetchK = Math.min(limit * 3, 50);
+  // Over-fetch for post-processing headroom. When a project filter is active,
+  // many results will be discarded so we fetch more aggressively.
+  const fetchK = Math.min(project ? limit * 6 : limit * 3, 50);
 
   const filter: VectorizeVectorMetadataFilter = { organization_id: organizationId };
   if (conversationId) {
@@ -235,6 +237,17 @@ export async function searchConversations(
     results = results.filter((r) => {
       if (!r.tags) return false;
       return tags.every((t) => r.tags!.includes(t));
+    });
+  }
+
+  // Filter by project — matches conversation titles that start with the
+  // project name (case-insensitive). This eliminates cross-project noise
+  // when the caller knows which project they care about.
+  if (project) {
+    const prefix = project.toLowerCase();
+    results = results.filter((r) => {
+      if (!r.conversation_title) return false;
+      return r.conversation_title.toLowerCase().startsWith(prefix);
     });
   }
 


### PR DESCRIPTION
## Summary
- Adds optional `project` parameter to the `search` MCP tool that filters results by conversation title prefix (case-insensitive)
- Increases over-fetch multiplier from 3x to 6x when project filter is active to compensate for post-filtering
- Fixes mock D1 `all()` handler ordering bug where `id IN (...)` queries were incorrectly filtered by the generic `organization_id` check

Closes #238

## Test plan
- [x] Project filter returns only matching conversations
- [x] Filter is case-insensitive
- [x] Returns empty when no conversations match
- [x] Existing behavior unchanged when `project` is omitted
- [x] All 151 tests pass, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)