### PR TITLE
fix: return 405 for GET/DELETE /mcp to stop 85% crash rate

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -65,8 +65,17 @@ app.get("/.well-known/openai-apps-challenge", (c) =>
 // OAuth authorization server endpoints (register, authorize, token).
 app.route("/oauth", oauth);
 
-// MCP endpoint — all methods
-app.all("/mcp", authMiddleware, rateLimitMiddleware, async (c) => {
+// MCP endpoint — POST only for stateless transport. GET (SSE listen) and
+// DELETE (session teardown) are not supported without server-side sessions.
+// Returning 405 immediately prevents Cloudflare from killing the request as
+// "hung" (scriptThrewException) when clients like Claude Code poll with GET.
+app.get("/mcp", (c) =>
+  c.json({ error: "method_not_allowed", message: "This server is stateless. Use POST for MCP requests." }, 405),
+);
+app.delete("/mcp", (c) =>
+  c.json({ error: "method_not_allowed", message: "This server is stateless. Session deletion is not supported." }, 405),
+);
+app.post("/mcp", authMiddleware, rateLimitMiddleware, async (c) => {
   const auth = c.get("auth");
   const server = createMcpServer(c.env, auth);
 


### PR DESCRIPTION
## Summary
- Return `405 Method Not Allowed` for `GET /mcp` and `DELETE /mcp` instead of letting stateless transport hang
- Eliminates ~43k daily `scriptThrewException` crashes (85% of all requests)
- No impact on MCP functionality — tool calls use POST

Closes #240

## Test plan
- [x] All 151 tests pass
- [ ] Deploy and verify crash rate drops to near zero
- [ ] Verify MCP tools still work from Claude Code and ChatGPT

🤖 Generated with [Claude Code](https://claude.com/claude-code)