### PR TITLE
feat: referral_source tracking for user acquisition

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "engram": {
+      "url": "https://mcp.getengram.app/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_ENGRAM_API_KEY"
+      }
+    }
+  }
+}

--- a/apps/mcp-server/src/oauth/router.ts
+++ b/apps/mcp-server/src/oauth/router.ts
@@ -269,7 +269,7 @@ oauth.post("/authorize/approve", async (c) => {
     orgId = existing.id;
   } else {
     orgId = generateId("org");
-    await insertOrganizationWithEmail(c.env.DB, orgId, email.split("@")[0], email);
+    await insertOrganizationWithEmail(c.env.DB, orgId, email.split("@")[0], email, "chatgpt");
   }
 
   const scope = body.scope || DEFAULT_SCOPE;

--- a/apps/mcp-server/src/routes/signup.ts
+++ b/apps/mcp-server/src/routes/signup.ts
@@ -92,9 +92,10 @@ signup.post("/", async (c) => {
     );
   }
 
-  // Accept optional plan from body (defaults to free)
+  // Accept optional plan and referral source from body
   const body = await c.req.json().catch(() => ({}));
   const plan = body.plan === "pro" ? "pro" : "free";
+  const ref = body.ref || body.referral_source || null;
 
   // Find-or-create the org
   let orgId: string;
@@ -108,7 +109,7 @@ signup.post("/", async (c) => {
   } else {
     orgId = generateId("org");
     const orgName = email.split("@")[0];
-    await insertOrganizationWithEmail(c.env.DB, orgId, orgName, email);
+    await insertOrganizationWithEmail(c.env.DB, orgId, orgName, email, ref);
     await seedWelcomeConversation(c.env.DB, orgId);
     created = true;
   }
@@ -137,9 +138,11 @@ signup.post("/", async (c) => {
 // This powers `engram signup` from the CLI, letting AI agents self-provision
 // accounts without any human interaction.
 signup.post("/anonymous", async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const ref = body.ref || body.referral_source || "cli";
   const orgId = generateId("org");
   const orgName = `anon-${orgId.slice(4, 12)}`;
-  await insertOrganization(c.env.DB, orgId, orgName);
+  await insertOrganization(c.env.DB, orgId, orgName, ref);
   await seedWelcomeConversation(c.env.DB, orgId);
 
   const keyId = generateId("key");

--- a/packages/db/migrations/0019_referral_source.sql
+++ b/packages/db/migrations/0019_referral_source.sql
@@ -1,0 +1,2 @@
+-- Track where users came from (chatgpt, claude, cursor, cli, web, etc.)
+ALTER TABLE organizations ADD COLUMN referral_source TEXT;

--- a/packages/db/src/queries/organizations.ts
+++ b/packages/db/src/queries/organizations.ts
@@ -1,7 +1,7 @@
-export function insertOrganization(db: D1Database, id: string, name: string) {
+export function insertOrganization(db: D1Database, id: string, name: string, referralSource?: string) {
   return db
-    .prepare("INSERT INTO organizations (id, name) VALUES (?, ?)")
-    .bind(id, name)
+    .prepare("INSERT INTO organizations (id, name, referral_source) VALUES (?, ?, ?)")
+    .bind(id, name, referralSource ?? null)
     .run();
 }
 
@@ -17,10 +17,11 @@ export function insertOrganizationWithEmail(
   id: string,
   name: string,
   email: string,
+  referralSource?: string,
 ) {
   return db
-    .prepare("INSERT INTO organizations (id, name, email) VALUES (?, ?, ?)")
-    .bind(id, name, email)
+    .prepare("INSERT INTO organizations (id, name, email, referral_source) VALUES (?, ?, ?, ?)")
+    .bind(id, name, email, referralSource ?? null)
     .run();
 }
 


### PR DESCRIPTION
## Summary
- Adds `referral_source` column to organizations table
- Tracks where users come from: `chatgpt`, `cli`, `web`, or custom values
- OAuth flow auto-tags as `chatgpt`
- Anonymous signup defaults to `cli`
- Web dashboard signup tags as `web`

## Already done
- Migration applied to production
- 86 existing ChatGPT OAuth users backfilled

🤖 Generated with [Claude Code](https://claude.com/claude-code)