### PR TITLE
feat: free-tier rolling memory window — archive, never delete (#252)

### DIFF
--- a/apps/mcp-server/src/__tests__/retention.test.ts
+++ b/apps/mcp-server/src/__tests__/retention.test.ts
@@ -1,0 +1,123 @@
+// Free-tier memory window (engram#252): archived — never deleted — outside a
+// rolling retention window; upgrading unlocks instantly.
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { createMockD1, createMockEnv } from "./helpers.js";
+import { searchConversations } from "../services/search.js";
+import { retentionCutoff } from "../services/tier.js";
+import { retentionNotice } from "../mcp/usage-messaging.js";
+import { RETENTION_ENFORCEMENT_DATE } from "@getengram/shared";
+
+const DAY = 86_400_000;
+const AFTER_ENFORCEMENT = Date.parse(RETENTION_ENFORCEMENT_DATE) + DAY;
+const BEFORE_ENFORCEMENT = Date.parse(RETENTION_ENFORCEMENT_DATE) - DAY;
+
+describe("retentionCutoff (#252)", () => {
+  it("is null for permanent-retention tiers at any time", () => {
+    expect(retentionCutoff("pro", AFTER_ENFORCEMENT)).toBeNull();
+    expect(retentionCutoff("team", AFTER_ENFORCEMENT)).toBeNull();
+    expect(retentionCutoff("enterprise", AFTER_ENFORCEMENT)).toBeNull();
+  });
+
+  it("is null for free before the announced enforcement date (grace period)", () => {
+    expect(retentionCutoff("free", BEFORE_ENFORCEMENT)).toBeNull();
+  });
+
+  it("is the window start for free after enforcement", () => {
+    const cutoff = retentionCutoff("free", AFTER_ENFORCEMENT);
+    expect(cutoff).not.toBeNull();
+    const ageDays = (AFTER_ENFORCEMENT - Date.parse(cutoff!)) / DAY;
+    expect(ageDays).toBeCloseTo(30, 5);
+  });
+});
+
+describe("search respects the memory window (#252)", () => {
+  const organizationId = "org_retention";
+  let env: ReturnType<typeof createMockEnv>;
+
+  const now = Date.now();
+  const fresh = new Date(now - 1 * DAY).toISOString();
+  const stale = new Date(now - 60 * DAY).toISOString();
+  const cutoff = new Date(now - 30 * DAY).toISOString();
+
+  beforeAll(() => {
+    const db = createMockD1();
+    const insertChunk =
+      "INSERT INTO conversation_chunks (id, conversation_id, organization_id, chunk_text, start_sequence, end_sequence, vectorize_id, created_at) VALUES (?,?,?,?,?,?,?,?)";
+    db.prepare(insertChunk)
+      .bind("chk_new", "conv_new", organizationId, "[user]: recent plans", 1, 2, "vec_new", fresh)
+      .run();
+    db.prepare(insertChunk)
+      .bind("chk_old", "conv_old", organizationId, "[user]: ancient plans", 1, 2, "vec_old", stale)
+      .run();
+
+    const insertConv =
+      "INSERT INTO conversations (id, organization_id, title, tags, updated_at) VALUES (?,?,?,?,?)";
+    db.prepare(insertConv)
+      .bind("conv_new", organizationId, "Recent", "[]", fresh)
+      .run();
+    db.prepare(insertConv)
+      .bind("conv_old", organizationId, "Ancient", "[]", stale)
+      .run();
+
+    env = createMockEnv(db);
+    (env.VECTORIZE as unknown as Record<string, unknown>).query = vi.fn(async () => ({
+      count: 2,
+      matches: [
+        { id: "vec_new", score: 0.9 },
+        { id: "vec_old", score: 0.9 },
+      ],
+    }));
+  });
+
+  it("hides archived conversations and reports the withheld count", async () => {
+    const outcome = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "plans",
+      10,
+      undefined,
+      undefined,
+      undefined,
+      0, // minScore off — isolate the retention filter
+      true,
+      undefined,
+      cutoff,
+    );
+    expect(outcome.results.map((r) => r.conversation_id)).toEqual(["conv_new"]);
+    expect(outcome.archived_conversations).toBe(1);
+  });
+
+  it("returns everything when there is no cutoff (paid tiers / grace period)", async () => {
+    const outcome = await searchConversations(
+      env as unknown as Parameters<typeof searchConversations>[0],
+      organizationId,
+      "plans",
+      10,
+      undefined,
+      undefined,
+      undefined,
+      0,
+      true,
+      undefined,
+      null,
+    );
+    expect(outcome.results.length).toBe(2);
+    expect(outcome.archived_conversations).toBe(0);
+  });
+});
+
+describe("retentionNotice copy (#252)", () => {
+  it("says archived + nothing deleted, and routes OAuth users to the dashboard", () => {
+    const msg = retentionNotice({ archivedCount: 3, retentionDays: 30, isOAuth: true });
+    expect(msg).toContain("3 older conversations");
+    expect(msg).toContain("archived");
+    expect(msg).toContain("Nothing is deleted");
+    expect(msg).toContain("dashboard");
+  });
+
+  it("routes API-key users to pricing and handles the singular case", () => {
+    const msg = retentionNotice({ archivedCount: 1, retentionDays: 30, isOAuth: false });
+    expect(msg).toContain("1 older conversation matched");
+    expect(msg).toContain("pricing");
+  });
+});

--- a/apps/mcp-server/src/__tests__/search-service.test.ts
+++ b/apps/mcp-server/src/__tests__/search-service.test.ts
@@ -80,7 +80,7 @@ describe("search service", () => {
   });
 
   it("does not return a `messages` field on search results", async () => {
-    const results = await searchConversations(
+    const { results } = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "greeting",
@@ -101,7 +101,7 @@ describe("search service", () => {
   });
 
   it("truncates chunk_text to the snippet cap with a marker", async () => {
-    const results = await searchConversations(
+    const { results } = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "greeting",
@@ -125,7 +125,7 @@ describe("search service", () => {
   });
 
   it("honours a custom snippet_chars parameter", async () => {
-    const results = await searchConversations(
+    const { results } = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "greeting",
@@ -143,7 +143,7 @@ describe("search service", () => {
   });
 
   it("caps snippet_chars at 5000", async () => {
-    const results = await searchConversations(
+    const { results } = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "greeting",
@@ -162,7 +162,7 @@ describe("search service", () => {
   });
 
   it("filters out results below min_score", async () => {
-    const allResults = await searchConversations(
+    const { results: allResults } = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "greeting",
@@ -180,7 +180,7 @@ describe("search service", () => {
 
     // Filter with a threshold between the two scores
     const midpoint = (topScore + lowScore) / 2;
-    const filtered = await searchConversations(
+    const { results: filtered } = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "greeting",
@@ -197,7 +197,7 @@ describe("search service", () => {
   });
 
   it("deduplicates chunks from the same conversation by default", async () => {
-    const results = await searchConversations(
+    const { results } = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "greeting",
@@ -215,7 +215,7 @@ describe("search service", () => {
   });
 
   it("returns all chunks when dedupe is false", async () => {
-    const results = await searchConversations(
+    const { results } = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "greeting",
@@ -274,7 +274,7 @@ describe("search project filtering", () => {
   });
 
   it("returns results from all projects when no project filter", async () => {
-    const results = await searchConversations(
+    const { results } = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "deploy",
@@ -290,7 +290,7 @@ describe("search project filtering", () => {
   });
 
   it("filters to only matching project by title prefix", async () => {
-    const results = await searchConversations(
+    const { results } = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "deploy",
@@ -308,7 +308,7 @@ describe("search project filtering", () => {
   });
 
   it("project filter is case-insensitive", async () => {
-    const results = await searchConversations(
+    const { results } = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "deploy",
@@ -326,7 +326,7 @@ describe("search project filtering", () => {
   });
 
   it("returns empty when no conversations match project", async () => {
-    const results = await searchConversations(
+    const { results } = await searchConversations(
       env as unknown as Parameters<typeof searchConversations>[0],
       organizationId,
       "deploy",

--- a/apps/mcp-server/src/mcp/tools/get-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/get-conversation.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 import { getConversation } from "../../services/conversation.js";
 import { audit } from "../../services/audit.js";
 import { loadPrivacy, PRIVACY_BODIES_NOTICE } from "../../services/privacy.js";
+import { retentionCutoff } from "../../services/tier.js";
+import { retentionNotice } from "../usage-messaging.js";
+import { isExternalOAuthClient } from "../auth-kind.js";
+import { TIER_LIMITS } from "@getengram/shared";
 import { hasScope, scopeError } from "../scopes.js";
 import type { Env, AuthContext } from "../../types.js";
 
@@ -58,6 +62,16 @@ export function registerGetConversation(
             })
             .passthrough(),
         ),
+        archived: z
+          .boolean()
+          .optional()
+          .describe(
+            "True when this conversation is outside the free plan's memory window — messages withheld, never deleted; upgrading unlocks it",
+          ),
+        retention_notice: z
+          .string()
+          .optional()
+          .describe("Present when archived — relay this to the user"),
       },
       annotations: {
         title: "Get conversation",
@@ -94,6 +108,34 @@ export function registerGetConversation(
       // Strip internal fields the model/user don't need and that app
       // marketplaces flag (internal account IDs, storage encoding).
       const { organization_id: _o, ...conversation } = result.conversation;
+
+      // Memory window (engram#252): archived conversations return their
+      // metadata but not their messages — mirrors the search-side wall so
+      // get_conversation can't bypass it. Never deleted; upgrade unlocks.
+      const cutoff = retentionCutoff(auth.tier);
+      const updatedAt = (conversation as { updated_at?: string }).updated_at;
+      if (
+        cutoff &&
+        updatedAt &&
+        !Number.isNaN(Date.parse(updatedAt)) &&
+        Date.parse(updatedAt) < Date.parse(cutoff)
+      ) {
+        const payload = {
+          conversation,
+          messages: [],
+          archived: true,
+          retention_notice: retentionNotice({
+            archivedCount: 1,
+            retentionDays: TIER_LIMITS[auth.tier].retention_days,
+            isOAuth: isExternalOAuthClient(auth),
+          }),
+        };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+          structuredContent: payload,
+        };
+      }
+
       const privacy = await loadPrivacy(env.DB, auth.organizationId);
       const messages = result.messages.map((m) => {
         const {

--- a/apps/mcp-server/src/mcp/tools/list-conversations.ts
+++ b/apps/mcp-server/src/mcp/tools/list-conversations.ts
@@ -7,6 +7,7 @@ import {
   PRIVACY_CROSS_CONVERSATION_NOTICE,
 } from "../../services/privacy.js";
 import { hasScope, scopeError } from "../scopes.js";
+import { retentionCutoff } from "../../services/tier.js";
 import type { Env, AuthContext } from "../../types.js";
 
 export function registerListConversations(
@@ -41,6 +42,12 @@ export function registerListConversations(
               message_count: z.number().optional(),
               created_at: z.string().optional(),
               updated_at: z.string().optional(),
+              archived: z
+                .boolean()
+                .optional()
+                .describe(
+                  "Outside the free plan's memory window — hidden from search/recall, never deleted; upgrading unlocks it",
+                ),
             })
             .passthrough(),
         ),
@@ -84,12 +91,22 @@ export function registerListConversations(
         order: params.order,
       });
 
+      // Memory window (engram#252): archived conversations stay listed —
+      // seeing what exists is part of the upgrade story — but are flagged.
+      const cutoff = retentionCutoff(auth.tier);
+      const cutoffMs = cutoff ? Date.parse(cutoff) : NaN;
       const conversations = (result.results as Array<Record<string, unknown>>).map(
-        ({ organization_id: _o, ...c }) => ({
-          ...c,
-          tags: JSON.parse((c.tags as string) || "[]"),
-          metadata: JSON.parse((c.metadata as string) || "{}"),
-        }),
+        ({ organization_id: _o, ...c }) => {
+          const ts = c.updated_at ? Date.parse(c.updated_at as string) : NaN;
+          const archived =
+            !Number.isNaN(cutoffMs) && !Number.isNaN(ts) && ts < cutoffMs;
+          return {
+            ...c,
+            tags: JSON.parse((c.tags as string) || "[]"),
+            metadata: JSON.parse((c.metadata as string) || "{}"),
+            ...(archived ? { archived: true } : {}),
+          };
+        },
       );
 
       return {

--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -1,7 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { searchConversations } from "../../services/search.js";
-import { trackSearchRun } from "../../services/tier.js";
+import { trackSearchRun, retentionCutoff } from "../../services/tier.js";
+import { retentionNotice } from "../usage-messaging.js";
+import { isExternalOAuthClient } from "../auth-kind.js";
+import { TIER_LIMITS } from "@getengram/shared";
 import { audit } from "../../services/audit.js";
 import {
   loadPrivacy,
@@ -63,6 +66,16 @@ export function registerSearch(
           )
           .describe("Relevant conversation snippets, best match first"),
         total: z.number(),
+        archived_conversations: z
+          .number()
+          .optional()
+          .describe(
+            "Matching conversations hidden by the free plan's rolling memory window — archived, never deleted; upgrading unlocks them",
+          ),
+        retention_notice: z
+          .string()
+          .optional()
+          .describe("Present when archived matches were withheld — relay this to the user"),
       },
       annotations: {
         title: "Search memory",
@@ -93,7 +106,7 @@ export function registerSearch(
         };
       }
 
-      const raw = await searchConversations(
+      const outcome = await searchConversations(
         env,
         auth.organizationId,
         params.query,
@@ -104,7 +117,9 @@ export function registerSearch(
         undefined, // minScore
         undefined, // dedupe
         params.project,
+        retentionCutoff(auth.tier),
       );
+      const raw = outcome.results;
 
       // When bodies are hidden, return the matching conversations'
       // metadata (title, tags, score) but drop the verbatim snippet.
@@ -117,11 +132,23 @@ export function registerSearch(
       audit(env.DB, auth.organizationId, auth.apiKeyId, "search", undefined, undefined, {
         query: params.query,
         results: results.length,
+        archived: outcome.archived_conversations,
       });
 
-      const payload = privacy.canReadBodies
+      const payload: Record<string, unknown> = privacy.canReadBodies
         ? { results, total: results.length }
         : { results, total: results.length, privacy_notice: PRIVACY_BODIES_NOTICE };
+
+      // Memory window (engram#252): tell the model — and through it the
+      // user — that older matches exist and are safe, not gone.
+      if (outcome.archived_conversations > 0) {
+        payload.archived_conversations = outcome.archived_conversations;
+        payload.retention_notice = retentionNotice({
+          archivedCount: outcome.archived_conversations,
+          retentionDays: TIER_LIMITS[auth.tier].retention_days,
+          isOAuth: isExternalOAuthClient(auth),
+        });
+      }
 
       return {
         content: [

--- a/apps/mcp-server/src/mcp/usage-messaging.ts
+++ b/apps/mcp-server/src/mcp/usage-messaging.ts
@@ -61,3 +61,26 @@ export function approachingLimitNotice(
     `To avoid interruption, ${where}.`
   );
 }
+
+/**
+ * Notice when archived (memory-window) results were withheld (engram#252).
+ * Tone: nothing is lost, upgrading unlocks — never "deleted".
+ */
+export function retentionNotice(opts: {
+  archivedCount: number;
+  retentionDays: number;
+  isOAuth: boolean;
+}): string {
+  const { archivedCount, retentionDays, isOAuth } = opts;
+  const what =
+    archivedCount === 1
+      ? "1 older conversation matched"
+      : `${archivedCount} older conversations matched`;
+  const where = isOAuth
+    ? `sign in at ${DASHBOARD} with the email used to connect this app and upgrade`
+    : `upgrade at ${PRICING}`;
+  return (
+    `${what} but ${archivedCount === 1 ? "is" : "are"} archived — the free plan keeps a rolling ` +
+    `${retentionDays}-day memory window. Nothing is deleted: ${where} to unlock your full history instantly.`
+  );
+}

--- a/apps/mcp-server/src/services/search.ts
+++ b/apps/mcp-server/src/services/search.ts
@@ -49,6 +49,15 @@ export function queryTerms(query: string): string[] {
   return [...new Set(query.toLowerCase().match(/[a-z0-9]{3,}/g) ?? [])];
 }
 
+export interface SearchOutcome {
+  results: SearchResult[];
+  /**
+   * Distinct matching conversations hidden by the org's memory window
+   * (engram#252) — archived, not deleted; unlocked on upgrade.
+   */
+  archived_conversations: number;
+}
+
 export async function searchConversations(
   env: Env,
   organizationId: string,
@@ -59,8 +68,9 @@ export async function searchConversations(
   snippetChars: number = DEFAULT_SNIPPET_CHARS,
   minScore: number = DEFAULT_MIN_SCORE,
   dedupe: boolean = true,
-  project?: string
-): Promise<SearchResult[]> {
+  project?: string,
+  retentionCutoffIso?: string | null
+): Promise<SearchOutcome> {
   const cappedSnippet = Math.min(
     Math.max(snippetChars, 0),
     MAX_SNIPPET_CHARS
@@ -106,7 +116,7 @@ export async function searchConversations(
   const ftsMatches = ftsResults.results ?? [];
 
   if (vectorMatches.length === 0 && ftsMatches.length === 0) {
-    return [];
+    return { results: [], archived_conversations: 0 };
   }
 
   // Build rank maps (0-indexed position)
@@ -224,6 +234,28 @@ export async function searchConversations(
     });
   }
 
+  // Memory window (engram#252): drop results whose conversation was last
+  // updated before the org's retention cutoff, counting the distinct
+  // conversations withheld so the caller can tell the user what's archived.
+  // Missing/invalid timestamps are treated as accessible (never over-hide).
+  let archivedConversations = 0;
+  if (retentionCutoffIso) {
+    const cutoffMs = Date.parse(retentionCutoffIso);
+    if (!Number.isNaN(cutoffMs)) {
+      const archived = new Set<string>();
+      results = results.filter((r) => {
+        const updatedAt = convMeta.get(r.conversation_id)?.updatedAt;
+        const ts = updatedAt ? Date.parse(updatedAt) : NaN;
+        if (!Number.isNaN(ts) && ts < cutoffMs) {
+          archived.add(r.conversation_id);
+          return false;
+        }
+        return true;
+      });
+      archivedConversations = archived.size;
+    }
+  }
+
   // Sort by score descending
   results.sort((a, b) => b.score - a.score);
 
@@ -261,5 +293,8 @@ export async function searchConversations(
     });
   }
 
-  return results.slice(0, limit);
+  return {
+    results: results.slice(0, limit),
+    archived_conversations: archivedConversations,
+  };
 }

--- a/apps/mcp-server/src/services/tier.ts
+++ b/apps/mcp-server/src/services/tier.ts
@@ -1,4 +1,4 @@
-import { TIER_LIMITS, type Tier } from "@getengram/shared";
+import { TIER_LIMITS, RETENTION_ENFORCEMENT_DATE, type Tier } from "@getengram/shared";
 import { getOrCreateUsage, atomicIncrementMessages, incrementMessagesStored, incrementSearchesRun } from "@getengram/db";
 import { generateId } from "@getengram/shared";
 
@@ -150,4 +150,19 @@ export function checkConversationLimit(
 
 export function checkFeatureAccess(tier: Tier, feature: "webhooks" | "usage_dashboard"): boolean {
   return TIER_LIMITS[tier][feature];
+}
+
+/**
+ * Memory-window cutoff for a tier (engram#252). Conversations last updated
+ * before this ISO timestamp are ARCHIVED for the org: hidden from search and
+ * recall, never deleted, instantly unlocked on upgrade.
+ *
+ * Returns null when the tier has permanent retention, or before the announced
+ * enforcement date (14-day notice for existing free orgs).
+ */
+export function retentionCutoff(tier: Tier, now: number = Date.now()): string | null {
+  const days = TIER_LIMITS[tier].retention_days;
+  if (days <= 0) return null;
+  if (now < Date.parse(RETENTION_ENFORCEMENT_DATE)) return null;
+  return new Date(now - days * 86_400_000).toISOString();
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -18,6 +18,7 @@ export const TIER_LIMITS: Record<Tier, {
   api_keys: number;
   webhooks: boolean;
   usage_dashboard: boolean;
+  retention_days: number;
 }> = {
   free: {
     messages_per_month: 1_000,
@@ -26,6 +27,10 @@ export const TIER_LIMITS: Record<Tier, {
     api_keys: -1, // unlimited — usage caps are the billing gate, not key count
     webhooks: false,
     usage_dashboard: false,
+    // Rolling memory window (engram#252): conversations not updated within
+    // this many days are ARCHIVED — hidden from search/recall, never deleted.
+    // Upgrading unlocks them instantly. Export is always available.
+    retention_days: 30,
   },
   pro: {
     messages_per_month: 100_000,
@@ -34,6 +39,7 @@ export const TIER_LIMITS: Record<Tier, {
     api_keys: -1,
     webhooks: false,
     usage_dashboard: false,
+    retention_days: -1, // permanent
   },
   team: {
     messages_per_month: 500_000,
@@ -42,6 +48,7 @@ export const TIER_LIMITS: Record<Tier, {
     api_keys: -1,
     webhooks: true,
     usage_dashboard: true,
+    retention_days: -1, // permanent
   },
   enterprise: {
     messages_per_month: -1, // unlimited
@@ -50,5 +57,11 @@ export const TIER_LIMITS: Record<Tier, {
     api_keys: -1,
     webhooks: true,
     usage_dashboard: true,
+    retention_days: -1, // permanent
   },
 };
+
+// Free-tier memory-window enforcement starts after a 14-day public notice
+// (announced 2026-07-14; engram#252). Before this instant the window is not
+// applied, so existing free orgs get the promised grace period.
+export const RETENTION_ENFORCEMENT_DATE = "2026-07-28T00:00:00Z";


### PR DESCRIPTION
## What

Implements the retention half of #252 (decisions: **archive/lock, 30 days, everyone after a 14-day notice**).

- Free tier: conversations not updated in 30 days are **archived** — hidden from `search`/`get_conversation`, flagged in `list_conversations`. **Never deleted**; upgrading unlocks instantly. Paid tiers permanent.
- Enforcement begins **2026-07-28** (`RETENTION_ENFORCEMENT_DATE`) — 14-day grace, announced 2026-07-14.
- `search` returns `archived_conversations` + a `retention_notice` the model relays ("Nothing is deleted… upgrade to unlock your full history"); OAuth users → dashboard, API-key users → pricing (matches the #207 messaging split).
- `get_conversation` returns metadata-only for archived conversations (no side door); `list_conversations` keeps archived items visible with `archived: true` — seeing what exists is part of the upgrade story.
- Fail-open on missing/invalid timestamps (never over-hide).

## Why

Volume limits only convert heavy users; ChatGPT sends light users who never touch 1,000 msgs/mo and thus never see an upgrade reason. Permanence is what light users value — so permanence is the paid feature.

## Verification
- New `retention.test.ts` (cutoff logic, search filtering + counts, notice copy)
- 158 tests pass, typecheck clean, worker build clean

## Follow-ups (same issue)
- Website/whitepaper/blog copy — engram-web PR incoming
- Dashboard banner + changelog announcement (in the web PR)

Refs #252