### PR TITLE
feat(mcp): onboarding coaching for ChatGPT-connected users

### DIFF
--- a/apps/mcp-server/src/__tests__/coaching.test.ts
+++ b/apps/mcp-server/src/__tests__/coaching.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { searchEmptyTip, newUserAppendTip } from "../mcp/coaching.js";
+import type { AuthContext } from "../types.js";
+
+const oauthAuth = {
+  apiKeyId: "oauth:client_abc",
+  organizationId: "org_x",
+  tier: "free",
+} as unknown as AuthContext;
+
+const keyAuth = {
+  apiKeyId: "key_123",
+  organizationId: "org_x",
+  tier: "free",
+} as unknown as AuthContext;
+
+describe("coaching tips", () => {
+  it("teaches on empty search results for OAuth clients only", () => {
+    expect(searchEmptyTip(oauthAuth)).toMatch(/remember everything/i);
+    expect(searchEmptyTip(keyAuth)).toBeUndefined();
+  });
+
+  it("tips new OAuth users on append; silent for veterans and API-key callers", () => {
+    expect(newUserAppendTip(oauthAuth, 3)).toMatch(/remember everything/i);
+    expect(newUserAppendTip(oauthAuth, 500)).toBeUndefined();
+    expect(newUserAppendTip(oauthAuth, undefined)).toBeUndefined();
+    expect(newUserAppendTip(keyAuth, 3)).toBeUndefined();
+  });
+});

--- a/apps/mcp-server/src/mcp/coaching.ts
+++ b/apps/mcp-server/src/mcp/coaching.ts
@@ -1,0 +1,39 @@
+import { isExternalOAuthClient } from "./auth-kind.js";
+import type { AuthContext } from "../types.js";
+
+// Onboarding coaching for OAuth-connected apps (ChatGPT etc.). Hosted apps
+// can't auto-capture, so new users have to learn the save-on-request
+// patterns — otherwise they assume memory is automatic, discover it isn't,
+// and churn. Tips surface in tool responses while the account is new and
+// go silent once the user clearly has the hang of it.
+
+const NEW_USER_MESSAGE_THRESHOLD = 20;
+
+const CONTINUOUS_MEMORY_TIP =
+  'Saved. Tip to pass on: the user can say "remember everything from this point forward" and you should keep saving the important turns automatically as the conversation develops. They can check what\'s stored anytime by asking "what do you remember about ___?".';
+
+const SEARCH_EMPTY_TIP =
+  'Nothing stored on this topic yet. The user can say "remember this" to save the current exchange, or "remember everything from this point forward" for continuous saving. Their full ChatGPT history can also be imported in one step at getengram.app/dashboard.';
+
+/**
+ * Coaching line for an empty search result — the highest-intent teaching
+ * moment: the user asked for a memory that doesn't exist yet.
+ */
+export function searchEmptyTip(auth: AuthContext): string | undefined {
+  return isExternalOAuthClient(auth) ? SEARCH_EMPTY_TIP : undefined;
+}
+
+/**
+ * Coaching line on a successful append while the account is new (fewer
+ * than NEW_USER_MESSAGE_THRESHOLD messages stored this month). Veterans
+ * don't see it.
+ */
+export function newUserAppendTip(
+  auth: AuthContext,
+  usedThisMonth?: number,
+): string | undefined {
+  if (!isExternalOAuthClient(auth)) return undefined;
+  if (typeof usedThisMonth !== "number") return undefined;
+  if (usedThisMonth > NEW_USER_MESSAGE_THRESHOLD) return undefined;
+  return CONTINUOUS_MEMORY_TIP;
+}

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -23,6 +23,9 @@ const SERVER_INSTRUCTIONS = `Engram is persistent, searchable memory. Use it pro
 - Recall: at the start of a task, call \`search\` with a short summary of the user's request to surface relevant prior context, and use what you find.
 - Store: when something worth remembering is established — a decision, preference, fact, or useful context — call \`append_messages\` with the relevant messages from the current conversation, verbatim. conversation_id is OPTIONAL — omit it to use the user's default memory; never ask the user for one. Use \`create_conversation\` first only to group a distinct topic, then reuse that id.
 - "Remember this / save this chat": store the messages already in THIS conversation. You cannot retrieve the user's past or external conversations — so if they ask you to remember their whole history, save the current exchange, then tell them Engram records going forward and that they can bulk-import their full history by exporting their ChatGPT (or Claude) data and running \`engram import\` (see getengram.app/docs). Do not attempt to gather, reconstruct, or forward their entire chat history — you don't have access to it.
+- "Remember everything from this point forward": treat this as standing consent — keep calling \`append_messages\` with the substantive turns as the conversation develops, without asking again. Confirm briefly each time so the user knows what was saved.
+- "What do you remember about ___?": call \`search\` and answer strictly from the results — that shows what is actually stored, not what only exists in the current chat.
+- Images and screenshots: Engram stores text. Write out what the image shows or means (names, facts, quotes), then store that text.
 - Skip trivial chatter (greetings, acknowledgements). Storage is verbatim and searchable by meaning.`;
 
 export function createMcpServer(env: Env, auth: AuthContext): McpServer {

--- a/apps/mcp-server/src/mcp/tools/append-messages.ts
+++ b/apps/mcp-server/src/mcp/tools/append-messages.ts
@@ -5,6 +5,7 @@ import {
   getOrCreateDefaultConversation,
 } from "../../services/conversation.js";
 import { isExternalOAuthClient } from "../auth-kind.js";
+import { newUserAppendTip } from "../coaching.js";
 import {
   usageMeter,
   limitMessage,
@@ -164,6 +165,7 @@ export function registerAppendMessages(
       const meter = usageMeter(tierCheck.used, tierCheck.limit);
       const notice = approachingLimitNotice(meter, isOAuth);
 
+      const tip = newUserAppendTip(auth, tierCheck.used);
       const payload = {
         conversation_id: conversationId,
         appended: messages.length,
@@ -171,6 +173,7 @@ export function registerAppendMessages(
         vault_entries_stored: params.vault_entries?.length ?? 0,
         ...(meter ? { usage: meter } : {}),
         ...(notice ? { notice } : {}),
+        ...(tip ? { tip } : {}),
       };
 
       return {

--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -9,6 +9,7 @@ import {
   PRIVACY_CROSS_CONVERSATION_NOTICE,
 } from "../../services/privacy.js";
 import { hasScope, scopeError } from "../scopes.js";
+import { searchEmptyTip } from "../coaching.js";
 import type { Env, AuthContext } from "../../types.js";
 
 export function registerSearch(
@@ -119,9 +120,13 @@ export function registerSearch(
         results: results.length,
       });
 
-      const payload = privacy.canReadBodies
-        ? { results, total: results.length }
-        : { results, total: results.length, privacy_notice: PRIVACY_BODIES_NOTICE };
+      const emptyTip = results.length === 0 ? searchEmptyTip(auth) : undefined;
+      const payload = {
+        results,
+        total: results.length,
+        ...(privacy.canReadBodies ? {} : { privacy_notice: PRIVACY_BODIES_NOTICE }),
+        ...(emptyTip ? { tip: emptyTip } : {}),
+      };
 
       return {
         content: [

--- a/apps/mcp-server/src/mcp/usage-messaging.ts
+++ b/apps/mcp-server/src/mcp/usage-messaging.ts
@@ -30,11 +30,15 @@ export function limitMessage(opts: {
 }): string {
   const { unit, tier, limit, used, isOAuth } = opts;
   if (isOAuth) {
+    const planName = tier && tier !== "free" ? `${tier} plan's` : "free plan's";
+    const remedy =
+      tier && tier !== "free"
+        ? `open ${DASHBOARD}, sign in with the email they used to connect this app, and manage their plan (add capacity or seats)`
+        : `open ${DASHBOARD}, sign in with the email they used to connect this app, and choose Upgrade`;
     return (
-      `You've reached the free plan's monthly limit (${limit ?? "the included"} ${unit}). ` +
+      `You've reached the ${planName} monthly limit (${limit ?? "the included"} ${unit}). ` +
       `Everything so far is safely saved in Engram. ` +
-      `Tell the user, warmly, that to keep saving memories they can upgrade their own Engram account: ` +
-      `open ${DASHBOARD}, sign in with the email they used to connect this app, and choose Upgrade — ` +
+      `Tell the user, warmly, that to keep saving memories they can ${remedy} — ` +
       `the same account powers this connection, so the higher limit applies right away. ` +
       `Don't try to collect payment here; just point them to their dashboard.`
     );
@@ -57,7 +61,7 @@ export function approachingLimitNotice(
     ? `sign in at ${DASHBOARD} with the email you connected and upgrade`
     : `upgrade at ${PRICING}`;
   return (
-    `${meter.used}/${meter.limit} free messages used this month (${meter.remaining} left). ` +
+    `${meter.used}/${meter.limit} included messages used this month (${meter.remaining} left). ` +
     `To avoid interruption, ${where}.`
   );
 }


### PR DESCRIPTION
Straight from watching a real ChatGPT session: users ask for 'remember everything,' ChatGPT improvises five steps of workaround education, and the expectation gap churns people (our one paying customer cancelled 10 minutes after subscribing).

This moves that education into the product:

- **Server instructions** now cover: treating *'remember everything from this point forward'* as standing consent (keep appending substantive turns, confirm briefly), answering *'what do you remember about ___?'* strictly from `search` results, and writing out image/screenshot content as text before storing.
- **Empty search results** (OAuth clients only) include a tip teaching save-on-request + the one-step history import at getengram.app/dashboard.
- **Appends while the account is new** (<20 messages this month) include a one-line continuous-memory tip. Veterans and API-key/SDK callers never see coaching.
- **Copy bug fix from the promise audit**: the limit + 80% notices told *paying* orgs they were on the free plan; now tier-accurate, and paid orgs are pointed at plan management instead of Upgrade.

Tests: 153 passed (2 new), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)