### PR TITLE
chore: registry metadata — glama.json claim + server.json v1.0.0 (#217)

### DIFF
--- a/apps/mcp-server/server.json
+++ b/apps/mcp-server/server.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.debragail/engram",
+  "title": "Engram",
+  "description": "Persistent memory for AI agents — verbatim conversations, searchable by meaning.",
+  "version": "1.0.0",
+  "websiteUrl": "https://getengram.app",
+  "repository": {
+    "url": "https://github.com/get-engram/engram",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.getengram.app/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer token — use your Engram API key (engram_sk_live_*) or OAuth access token",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["debragail"]
+}


### PR DESCRIPTION
Registry distribution housekeeping for #217: adds the Glama maintainer-claim file (their crawler already indexed us — unclaimed listings get no search placement) and brings server.json to v1.0.0 with websiteUrl + repository links (the official-registry entry published 2026-07-05 lacks both, which is why the PulseMCP listing has no repo link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)