### PR TITLE
docs(launch): launch drafts → storage pricing model

### DIFF
--- a/docs/launch/chatgpt-app/README.md
+++ b/docs/launch/chatgpt-app/README.md
@@ -15,7 +15,7 @@ Copy-paste-ready launch posts for **Engram now being live in the ChatGPT App Dir
 ## Accuracy checklist
 
 - Product/repo license is **BSL-1.1**; the SDK + CLI are **MIT**.
-- Free tier = **1,000 messages/month**. Pro = **$9/mo**.
+- Free tier = **10,000 messages of memory, never expires**. Pro = **$9/mo** (1,000,000 messages of memory).
 - You **can** now say "available in the ChatGPT App Directory" (it's live).
 - Don't claim a Homebrew tap until `engram` is actually on homebrew-core (#36).
 

--- a/docs/launch/chatgpt-app/product-hunt.md
+++ b/docs/launch/chatgpt-app/product-hunt.md
@@ -26,7 +26,7 @@ It stores conversations **verbatim** (no lossy summaries) and searches them by m
 
 Being upfront about how it works: in ChatGPT you invoke it ("remember this" / "search Engram"), because ChatGPT gives apps no way to silently record everything — and we wouldn't want it to. On local tools like Claude Code it can capture automatically.
 
-Free tier (1,000 messages/mo) to try it. Would love to hear what context *you* keep re-explaining to your AI tools.
+Free tier (10,000 messages of memory — never expires) to try it. Would love to hear what context *you* keep re-explaining to your AI tools.
 
 ## Topics
 Artificial Intelligence · Productivity · Developer Tools · ChatGPT · Open Source

--- a/docs/launch/chatgpt-app/reddit-chatgpt.md
+++ b/docs/launch/chatgpt-app/reddit-chatgpt.md
@@ -19,7 +19,7 @@ Setup was quick: in ChatGPT it's Settings → Apps & Connectors → add Engram (
 
 Honest caveat so nobody's surprised: ChatGPT doesn't let any app silently record your whole chat in the background (there's no per-turn hook, and OpenAI's policy forbids grabbing your full log). So it's "save what matters + import your history," not magic auto-capture. That was fine for me — the import covers the back-catalog and "remember this" covers going forward.
 
-Free tier is 1,000 messages/month if you want to try it: getengram.app. It's also open source.
+Free tier is 10,000 messages of memory (never expires, no monthly cap) if you want to try it: getengram.app. It's also open source.
 
 Curious what others do here — does anyone else feel the pain of every tool having separate memory, or is ChatGPT's built-in memory enough for you?
 

--- a/docs/launch/chatgpt-app/show-hn.md
+++ b/docs/launch/chatgpt-app/show-hn.md
@@ -23,7 +23,7 @@ How capture works, honestly, because it differs per host:
 
 Under the hood it's stored verbatim (no lossy summarization), chunked, and embedded for semantic search. The whole backend runs on Cloudflare — Workers for the MCP server, D1 for storage, Vectorize for search, Workers AI for embeddings.
 
-Connect in ChatGPT: Settings → Apps & Connectors → add Engram (OAuth, no key to paste). Free tier is 1,000 messages/month; Pro is $9/mo.
+Connect in ChatGPT: Plugin directory → install Engram (OAuth, no key to paste). Free tier is 10,000 messages of memory — never expires; Pro is $9/mo.
 
 Source is BSL-1.1; the SDK + CLI are MIT: https://github.com/get-engram/engram
 Site: https://getengram.app

--- a/docs/launch/devto-blog-post.md
+++ b/docs/launch/devto-blog-post.md
@@ -115,7 +115,7 @@ The whole thing is globally distributed with sub-100ms cold starts.
 
 ## Pricing
 
-- **Free** — 1,000 messages/month (enough to try it out)
+- **Free** — 10,000 messages of memory, free forever (no monthly cap — enough to feel it remember you)
 - **Pro** — $9/month for heavier use
 - **Team** — $27/seat/month with shared memory across your team
 

--- a/docs/launch/marketing-calendar.md
+++ b/docs/launch/marketing-calendar.md
@@ -118,7 +118,7 @@ By now you should have 200-400 free signups. Time to convert.
 
 ### In-product nudges
 - Show usage meter in MCP tool responses (you already built this — issue #208)
-- When they hit 800/1,000 messages, show upgrade prompt
+- Built-in: at 80% of memory (8,000/10,000 messages) the product warns and nudges upgrade
 
 ### Direct outreach
 - Anyone who stores 10+ conversations on free tier = warm lead

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -29,7 +29,7 @@ Backend is Cloudflare Workers + D1 + Vectorize. Globally distributed, no cold st
 
 Server is BSL 1.1 (converts to open source after 4 years). SDK is MPL 2.0. Source: https://github.com/get-engram/engram
 
-Free tier: 1,000 messages/month, unlimited conversations. Pro is $39/mo for heavier use. Teams at $49/seat/mo.
+Free tier: 10,000 messages of memory — never expires, no monthly cap. Pro is $9/mo for 1,000,000 messages of memory. Teams at $27/seat/mo.
 
 I built this because I wanted my coding agent to actually learn from our work together — to remember that we chose Hono over Express, that the prod database needs a specific migration order, that I prefer explicit error handling over try/catch. The kind of context that lives in your head but nowhere in the codebase.
 

--- a/docs/launch/social-posts.md
+++ b/docs/launch/social-posts.md
@@ -29,7 +29,7 @@ What it actually remembers for me:
 
 The backend runs entirely on Cloudflare (Workers, D1, Vectorize). Source is on GitHub under BSL-1.1: https://github.com/get-engram/engram
 
-Free tier is 1,000 messages/month, Pro is $9/mo for heavier use.
+Free tier is 10,000 messages of memory that never expires, Pro is $9/mo for 1,000,000.
 
 Would love to hear how other Claude Code users handle cross-session memory today. What context do you find yourself repeating?
 
@@ -57,7 +57,7 @@ That's it. ChatGPT gets tools to search your memory and store new conversations.
 
 How it works under the hood: conversations get chunked and embedded. When ChatGPT calls `search`, it does semantic matching — so searching "that database migration issue" finds the relevant conversation even if you never used those exact words.
 
-Free tier gives you 1,000 messages/month. Pro is $9/mo if you use it heavily.
+Free tier gives you 10,000 messages of memory — no monthly cap. Pro is $9/mo if you use it heavily.
 
 Source code (BSL-1.1): https://github.com/get-engram/engram
 
@@ -149,7 +149,7 @@ What it remembers for me:
 
 **Tweet 6:**
 
-Free tier: 1,000 messages/month
+Free tier: 10,000 messages of memory, free forever
 Pro: $9/mo
 Team: $27/seat/mo
 


### PR DESCRIPTION
The launch drafts (Show HN, dev.to, Product Hunt, Reddit, social posts, marketing calendar) still pitched the old monthly quota — and show-hn.md still had the pre-July $39/$49 prices. All updated to the storage model so the next copy-paste matches the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)