### PR TITLE
feat: visual usage meters — bars in ChatGPT responses and engram usage CLI

### DIFF
--- a/apps/cli/src/__tests__/cli.test.ts
+++ b/apps/cli/src/__tests__/cli.test.ts
@@ -178,3 +178,13 @@ describe("import — storage_full error parsing", () => {
     expect(parseStorageFullError("")).toBeNull();
   });
 });
+
+describe("usage bars", () => {
+  it("renders proportional bars with padded percentages", async () => {
+    const { renderBar } = await import("../commands/usage.js");
+    expect(renderBar(6_200, 10_000)).toBe("[████████████░░░░░░░░]  62%");
+    expect(renderBar(0, 10_000)).toBe("[░░░░░░░░░░░░░░░░░░░░]   0%");
+    expect(renderBar(10_000, 10_000)).toBe("[████████████████████] 100%");
+    expect(renderBar(20_000, 10_000)).toBe("[████████████████████] 100%");
+  });
+});

--- a/apps/cli/src/commands/usage.ts
+++ b/apps/cli/src/commands/usage.ts
@@ -1,0 +1,85 @@
+import { loadConfig, getBaseUrl } from "../config.js";
+import { bold, dim, red, json as printJson } from "../output.js";
+
+const API_URL = process.env.ENGRAM_BASE_URL ?? getBaseUrl();
+
+/** Render a progress bar like "[████████████░░░░░░░░] 62%". Exported for tests. */
+export function renderBar(used: number, limit: number, width = 20): string {
+  const pct = limit > 0 ? Math.min(100, Math.round((used / limit) * 100)) : 0;
+  const filled = Math.min(width, Math.round((pct / 100) * width));
+  return `[${"█".repeat(filled)}${"░".repeat(width - filled)}] ${String(pct).padStart(3)}%`;
+}
+
+const fmt = (n: number) => n.toLocaleString("en-US");
+
+interface UsageResponse {
+  tier: string;
+  period: string | null;
+  messages: { used: number; limit: number };
+  storage?: { used: number; limit: number };
+  searches: { used: number };
+}
+
+/**
+ * `engram usage` — show memory storage and monthly usage with visual bars.
+ */
+export async function usage(
+  _args: string[],
+  flags: Record<string, string>,
+): Promise<void> {
+  const config = await loadConfig();
+  const apiKey = process.env.ENGRAM_API_KEY ?? config.apiKey;
+
+  if (!apiKey) {
+    console.error(red("Not authenticated. Run 'engram signup' first."));
+    process.exit(1);
+  }
+
+  const res = await fetch(`${API_URL}/api/usage`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  if (!res.ok) {
+    console.error(red(`Failed to fetch usage (${res.status}).`));
+    process.exit(1);
+  }
+
+  const data = (await res.json()) as UsageResponse;
+
+  if ("json" in flags) {
+    printJson(data);
+    return;
+  }
+
+  console.log(`\n${bold("Plan:")} ${data.tier}\n`);
+
+  if (data.storage) {
+    if (data.storage.limit === -1) {
+      console.log(`  ${bold("Memory")}       unlimited ${dim(`· ${fmt(data.storage.used)} messages stored · never expires`)}`);
+    } else {
+      console.log(
+        `  ${bold("Memory")}       ${renderBar(data.storage.used, data.storage.limit)}  ` +
+          `${fmt(data.storage.used)} / ${fmt(data.storage.limit)} messages ${dim("· never expires")}`,
+      );
+    }
+  }
+
+  if (data.messages.limit !== -1) {
+    console.log(
+      `  ${bold("This month")}   ${renderBar(data.messages.used, data.messages.limit)}  ` +
+        `${fmt(data.messages.used)} / ${fmt(data.messages.limit)} messages`,
+    );
+  }
+
+  console.log(`  ${bold("Searches")}     ${fmt(data.searches.used)} this month\n`);
+
+  if (data.storage && data.storage.limit > 0) {
+    const pct = data.storage.used / data.storage.limit;
+    if (pct >= 1) {
+      console.log(dim("  Memory is full — nothing expires, but new saves are paused."));
+      console.log(dim("  Free space by deleting conversations, or upgrade: engram upgrade\n"));
+    } else if (pct >= 0.8) {
+      console.log(dim("  Heads up: memory is over 80% full. More room: engram upgrade\n"));
+    }
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -16,6 +16,7 @@ import { log as showLog } from "./commands/log.js";
 import { importHistory } from "./commands/import.js";
 import { daemonStart, daemonStop, daemonStatus, daemonInstall, daemonUninstall } from "./daemon/index.js";
 import { upgrade } from "./commands/upgrade.js";
+import { usage as showUsage } from "./commands/usage.js";
 import { vaultKeygen, vaultStatus, loadVaultKey, vaultSet, vaultGet, vaultList, vaultDelete } from "./commands/vault.js";
 import { bold, dim } from "./output.js";
 
@@ -139,6 +140,7 @@ ${bold("COMMANDS")}
   ${bold("import")} <file.json>       Import a ChatGPT or Claude data export
   ${bold("log")}                      Show recent AI conversation activity
   ${bold("upgrade")} [pro|team]       Upgrade your plan (opens Stripe checkout)
+  ${bold("usage")}                    Show memory storage and monthly usage meters
 
   ${bold("vault keygen")}             Generate a new vault encryption key
   ${bold("vault keygen --save")}      Generate and save key to ~/.engram/vault-key
@@ -276,6 +278,11 @@ async function main(): Promise<void> {
 
       case "upgrade":
         await upgrade(args, flags);
+        break;
+
+      case "usage":
+      case "status":
+        await showUsage(args, flags);
         break;
 
       // Vault commands

--- a/apps/mcp-server/src/__tests__/storage-cap.test.ts
+++ b/apps/mcp-server/src/__tests__/storage-cap.test.ts
@@ -3,6 +3,7 @@ import { TIER_LIMITS } from "@getengram/shared";
 import { storageLimitFor } from "../services/tier.js";
 import {
   usageMeter,
+  meterBar,
   storageFullMessage,
   approachingStorageNotice,
 } from "../mcp/usage-messaging.js";
@@ -64,5 +65,14 @@ describe("storage messaging", () => {
     expect(
       approachingStorageNotice(usageMeter(9_500, 10_000), true),
     ).toMatch(/dashboard/);
+  });
+
+  it("meterBar renders a 10-segment bar with percentage", () => {
+    expect(meterBar(8_200, 10_000)).toBe("[████████░░] 82%");
+    expect(meterBar(0, 10_000)).toBe("[░░░░░░░░░░] 0%");
+    expect(meterBar(10_000, 10_000)).toBe("[██████████] 100%");
+    expect(meterBar(15_000, 10_000)).toBe("[██████████] 100%");
+    expect(meterBar(5, -1)).toBeUndefined();
+    expect(meterBar(undefined, 10_000)).toBeUndefined();
   });
 });

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -5,6 +5,7 @@ import { registerSearch } from "./tools/search.js";
 import { registerGetConversation } from "./tools/get-conversation.js";
 import { registerListConversations } from "./tools/list-conversations.js";
 import { registerDeleteConversation } from "./tools/delete-conversation.js";
+import { registerMemoryStatus } from "./tools/memory-status.js";
 import { registerResolveVault } from "./tools/resolve-vault.js";
 import { registerVaultSet } from "./tools/vault-set.js";
 import { registerVaultGet } from "./tools/vault-get.js";
@@ -25,6 +26,7 @@ const SERVER_INSTRUCTIONS = `Engram is persistent, searchable memory. Use it pro
 - "Remember this / save this chat": store the messages already in THIS conversation. You cannot retrieve the user's past or external conversations — so if they ask you to remember their whole history, save the current exchange, then tell them Engram records going forward and that they can bulk-import their full history by exporting their ChatGPT (or Claude) data and running \`engram import\` (see getengram.app/docs). Do not attempt to gather, reconstruct, or forward their entire chat history — you don't have access to it.
 - "Remember everything from this point forward": treat this as standing consent — keep calling \`append_messages\` with the substantive turns as the conversation develops, without asking again. Confirm briefly each time so the user knows what was saved.
 - "What do you remember about ___?": call \`search\` and answer strictly from the results — that shows what is actually stored, not what only exists in the current chat.
+- "How full is my memory?" / plan or usage questions: call \`memory_status\` and show the user the bar line verbatim (e.g. [████████░░] 82%).
 - Images and screenshots: Engram stores text. Write out what the image shows or means (names, facts, quotes), then store that text.
 - Skip trivial chatter (greetings, acknowledgements). Storage is verbatim and searchable by meaning.`;
 
@@ -45,6 +47,7 @@ export function createMcpServer(env: Env, auth: AuthContext): McpServer {
   registerGetConversation(server, env, auth);
   registerListConversations(server, env, auth);
   registerDeleteConversation(server, env, auth);
+  registerMemoryStatus(server, env, auth);
 
   // First-party-only tools. External OAuth clients (auth.apiKeyId is
   // "oauth:<client_id>") get the memory-only surface: the secrets vault

--- a/apps/mcp-server/src/mcp/tools/append-messages.ts
+++ b/apps/mcp-server/src/mcp/tools/append-messages.ts
@@ -8,6 +8,7 @@ import { isExternalOAuthClient } from "../auth-kind.js";
 import { newUserAppendTip } from "../coaching.js";
 import {
   usageMeter,
+  meterBar,
   limitMessage,
   approachingLimitNotice,
   storageFullMessage,
@@ -80,7 +81,12 @@ export function registerAppendMessages(
           .optional()
           .describe("Monthly message usage for the org (limited tiers only)"),
         storage: z
-          .object({ used: z.number(), limit: z.number(), remaining: z.number() })
+          .object({
+            used: z.number(),
+            limit: z.number(),
+            remaining: z.number(),
+            bar: z.string().optional().describe("Ready-to-display progress bar, e.g. [████████░░] 82%"),
+          })
           .optional()
           .describe("Lifetime memory storage for the org (capped tiers only) — memory never expires; it fills up"),
         notice: z.string().optional().describe("Heads-up shown when approaching the plan limit"),
@@ -219,8 +225,11 @@ export function registerAppendMessages(
       // the user.
       const meter = usageMeter(tierCheck.used, tierCheck.limit);
       const notice = approachingLimitNotice(meter, isOAuth);
-      const storageMeterVal = usageMeter(storageCheck.used, storageCheck.limit);
-      const storageNotice = approachingStorageNotice(storageMeterVal, isOAuth);
+      const storageMeterBase = usageMeter(storageCheck.used, storageCheck.limit);
+      const storageNotice = approachingStorageNotice(storageMeterBase, isOAuth);
+      const storageMeterVal = storageMeterBase
+        ? { ...storageMeterBase, bar: meterBar(storageCheck.used, storageCheck.limit) }
+        : undefined;
 
       // Coaching keys off lifetime storage — the count that exists on
       // every tier (free has no monthly meter anymore).

--- a/apps/mcp-server/src/mcp/tools/memory-status.ts
+++ b/apps/mcp-server/src/mcp/tools/memory-status.ts
@@ -1,0 +1,107 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { TIER_LIMITS } from "@getengram/shared";
+import { getUsage, getOrganizationById, getStorageUsed } from "@getengram/db";
+import { storageLimitFor } from "../../services/tier.js";
+import { usageMeter, meterBar } from "../usage-messaging.js";
+import { isExternalOAuthClient } from "../auth-kind.js";
+import type { Env, AuthContext } from "../../types.js";
+
+/**
+ * memory_status — "how full is my memory?" Read-only usage meter for any
+ * client. ChatGPT/Claude relay the bar string verbatim, which gives users
+ * a visual without any UI surface.
+ */
+export function registerMemoryStatus(
+  server: McpServer,
+  env: Env,
+  auth: AuthContext,
+) {
+  server.registerTool(
+    "memory_status",
+    {
+      description:
+        "Show how full the user's Engram memory is: lifetime storage used vs their plan's capacity, with a ready-to-display progress bar. Call this when the user asks how much memory/space they have, how full Engram is, or about their plan usage. Show the bar line to the user verbatim.",
+      inputSchema: {},
+      outputSchema: {
+        tier: z.string(),
+        storage: z.object({
+          used: z.number(),
+          limit: z.number().describe("-1 means unlimited"),
+          remaining: z.number().optional(),
+          bar: z.string().optional().describe("e.g. [████████░░] 82%"),
+        }),
+        monthly: z
+          .object({
+            used: z.number(),
+            limit: z.number(),
+            remaining: z.number(),
+            bar: z.string().optional(),
+          })
+          .optional()
+          .describe("Monthly velocity meter — only present on tiers with a monthly limit"),
+        note: z.string(),
+      },
+      annotations: {
+        title: "Memory status",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async () => {
+      const [org, usage, storageRow] = await Promise.all([
+        getOrganizationById(env.DB, auth.organizationId) as Promise<{
+          seat_limit?: number;
+        } | null>,
+        getUsage(env.DB, auth.organizationId) as Promise<{
+          messages_stored: number;
+        } | null>,
+        getStorageUsed(env.DB, auth.organizationId),
+      ]);
+
+      const storageUsed = storageRow?.messages_stored_total ?? 0;
+      const storageLimit = storageLimitFor(auth.tier, org?.seat_limit ?? 1);
+      const monthlyLimit = TIER_LIMITS[auth.tier].messages_per_month;
+      const monthlyUsed = usage?.messages_stored ?? 0;
+
+      const isOAuth = isExternalOAuthClient(auth);
+      const upgradeAt = isOAuth
+        ? "getengram.app/dashboard (sign in with the email used to connect this app)"
+        : "getengram.app/pricing";
+
+      const monthlyMeter = usageMeter(monthlyUsed, monthlyLimit);
+      const payload = {
+        tier: auth.tier,
+        storage: {
+          used: storageUsed,
+          limit: storageLimit,
+          ...(storageLimit > 0
+            ? { remaining: Math.max(0, storageLimit - storageUsed) }
+            : {}),
+          ...(storageLimit > 0
+            ? { bar: meterBar(storageUsed, storageLimit) }
+            : {}),
+        },
+        ...(monthlyMeter
+          ? {
+              monthly: {
+                ...monthlyMeter,
+                bar: meterBar(monthlyUsed, monthlyLimit),
+              },
+            }
+          : {}),
+        note:
+          storageLimit > 0
+            ? `Memory never expires — deleting conversations frees space. More room: upgrade at ${upgradeAt}.`
+            : "Memory never expires. This plan has unlimited storage.",
+      };
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+        structuredContent: payload,
+      };
+    },
+  );
+}

--- a/apps/mcp-server/src/mcp/usage-messaging.ts
+++ b/apps/mcp-server/src/mcp/usage-messaging.ts
@@ -12,6 +12,19 @@ export interface UsageMeter {
   remaining: number;
 }
 
+/**
+ * Render a 10-segment progress bar like "[████████░░] 82%" — readable in
+ * chat surfaces (ChatGPT relays it verbatim) and terminals alike.
+ */
+export function meterBar(used?: number, limit?: number): string | undefined {
+  if (typeof used !== "number" || typeof limit !== "number" || limit <= 0) {
+    return undefined;
+  }
+  const pct = Math.min(100, Math.round((used / limit) * 100));
+  const filled = Math.min(10, Math.round(pct / 10));
+  return `[${"█".repeat(filled)}${"░".repeat(10 - filled)}] ${pct}%`;
+}
+
 /** Build a usage meter when the tier is limited; undefined for unlimited tiers. */
 export function usageMeter(used?: number, limit?: number): UsageMeter | undefined {
   if (typeof used !== "number" || typeof limit !== "number" || limit < 0) {


### PR DESCRIPTION
The user-facing half of the storage cap: make fullness visible.

- **ChatGPT (and any MCP client)**: append responses now carry a ready-to-display bar on the storage meter, and a new read-only `memory_status` tool answers 'how full is my memory?' with `[████████░░] 82%` — server instructions tell the model to show the bar verbatim.
- **CLI**: `engram usage` (alias `status`) renders 20-segment bars for lifetime memory and the monthly meter, with 80%/full nudges and `--json` mode.

Tests: worker 162 passed, CLI 20 passed, typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)