### PR TITLE
chore: server.json 1.1.0 (memory_status)

### DIFF
--- a/apps/mcp-server/server.json
+++ b/apps/mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.debragail/engram",
   "title": "Engram",
   "description": "Persistent memory for AI agents — verbatim conversations, searchable by meaning.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "websiteUrl": "https://getengram.app",
   "repository": {
     "url": "https://github.com/get-engram/engram",


### PR DESCRIPTION
Registry version bump for the new memory_status tool — minor per semver. Already republished to the official MCP registry (1.1.0 live, isLatest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)