### PR TITLE
feat: public REST API (/api/v1) + API usage metering

### DIFF
--- a/apps/mcp-server/src/__tests__/v1-rest.test.ts
+++ b/apps/mcp-server/src/__tests__/v1-rest.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { v1 } from "../routes/v1.js";
+import { meterApiRequest } from "../middleware/meter.js";
+import { createMockD1, createMockEnv } from "./helpers.js";
+import { insertOrganization } from "@getengram/db";
+import type { Env, AuthContext } from "../types.js";
+import type { Scope } from "../mcp/scopes.js";
+
+type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
+
+function createApp(orgId: string, scopes: Scope[] = ["read", "write", "search", "delete"]) {
+  const app = new Hono<HonoEnv>();
+  app.use("*", async (c, next) => {
+    c.set("auth", {
+      organizationId: orgId,
+      apiKeyId: "key_test",
+      scopes,
+      tier: "free" as const,
+    });
+    await next();
+  });
+  app.route("/api/v1", v1);
+  return app;
+}
+
+describe("REST v1 — scopes", () => {
+  it("rejects create without the write scope", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    const app = createApp("org_scope", ["read"]);
+
+    const res = await app.request(
+      "/api/v1/conversations",
+      { method: "POST", body: JSON.stringify({}), headers: { "Content-Type": "application/json" } },
+      env,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; required: string };
+    expect(body.error).toBe("insufficient_scope");
+    expect(body.required).toBe("write");
+  });
+
+  it("rejects delete without the delete scope", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    const app = createApp("org_scope", ["read", "write", "search"]);
+
+    const res = await app.request("/api/v1/conversations/conv_x", { method: "DELETE" }, env);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("REST v1 — conversations", () => {
+  it("creates a conversation and returns 201", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    await insertOrganization(db, "org_v1", "V1 Org");
+    const app = createApp("org_v1");
+
+    const res = await app.request(
+      "/api/v1/conversations",
+      {
+        method: "POST",
+        body: JSON.stringify({ title: "REST chat", tags: ["api"] }),
+        headers: { "Content-Type": "application/json" },
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { conversation_id: string };
+    expect(body.conversation_id).toMatch(/^conv_/);
+  });
+
+  it("rejects an invalid create body", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    const app = createApp("org_v1");
+
+    const res = await app.request(
+      "/api/v1/conversations",
+      {
+        method: "POST",
+        body: JSON.stringify({ tags: "not-an-array" }),
+        headers: { "Content-Type": "application/json" },
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_body");
+  });
+
+  it("lists conversations for the org", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    await insertOrganization(db, "org_list", "List Org");
+    const app = createApp("org_list");
+
+    await app.request(
+      "/api/v1/conversations",
+      {
+        method: "POST",
+        body: JSON.stringify({ title: "One" }),
+        headers: { "Content-Type": "application/json" },
+      },
+      env,
+    );
+
+    const res = await app.request("/api/v1/conversations", { method: "GET" }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { conversations: unknown[]; total: number };
+    expect(body.total).toBe(1);
+  });
+
+  it("returns 404 for a missing conversation", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    const app = createApp("org_404");
+
+    const res = await app.request("/api/v1/conversations/conv_missing", { method: "GET" }, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 deleting a missing conversation", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    const app = createApp("org_404");
+
+    const res = await app.request("/api/v1/conversations/conv_missing", { method: "DELETE" }, env);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("REST v1 — search", () => {
+  it("requires a query", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    const app = createApp("org_search");
+
+    const res = await app.request("/api/v1/search", { method: "GET" }, env);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("missing_query");
+  });
+
+  it("returns an empty result set", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    await insertOrganization(db, "org_search", "Search Org");
+    const app = createApp("org_search");
+
+    const res = await app.request("/api/v1/search?q=hello", { method: "GET" }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: unknown[]; total: number };
+    expect(body.results).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+});
+
+describe("meterApiRequest middleware", () => {
+  function meteredApp(auth: AuthContext | null) {
+    const app = new Hono<HonoEnv>();
+    if (auth) {
+      app.use("*", async (c, next) => {
+        c.set("auth", auth);
+        await next();
+      });
+    }
+    app.use("*", meterApiRequest);
+    app.get("/ping", (c) => c.json({ ok: true }));
+    return app;
+  }
+
+  it("counts an authenticated request via waitUntil", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    const waited: Promise<unknown>[] = [];
+    const ctx = {
+      waitUntil: (p: Promise<unknown>) => waited.push(p),
+      passThroughOnException: () => {},
+      props: {},
+    } as unknown as ExecutionContext;
+
+    const app = meteredApp({
+      organizationId: "org_meter",
+      apiKeyId: "key_m",
+      scopes: ["read"],
+      tier: "free",
+    });
+    const res = await app.fetch(new Request("http://localhost/ping"), env, ctx);
+    expect(res.status).toBe(200);
+    expect(waited.length).toBe(1);
+    await Promise.all(waited);
+  });
+
+  it("does not count admin requests", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    const waited: Promise<unknown>[] = [];
+    const ctx = {
+      waitUntil: (p: Promise<unknown>) => waited.push(p),
+      passThroughOnException: () => {},
+      props: {},
+    } as unknown as ExecutionContext;
+
+    const app = meteredApp({
+      organizationId: "admin",
+      apiKeyId: "admin",
+      scopes: ["read"],
+      tier: "enterprise",
+      isAdmin: true,
+    });
+    const res = await app.fetch(new Request("http://localhost/ping"), env, ctx);
+    expect(res.status).toBe(200);
+    expect(waited.length).toBe(0);
+  });
+});

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -17,6 +17,8 @@ import { privacy } from "./routes/privacy.js";
 import { dataExport } from "./routes/export.js";
 import { oauthConnections } from "./routes/oauth-connections.js";
 import { memories } from "./routes/memories.js";
+import { v1 } from "./routes/v1.js";
+import { meterApiRequest } from "./middleware/meter.js";
 import { purgeDeletedOrganizations } from "./cron/purge-deleted.js";
 import { expireGracePeriods } from "./cron/expire-grace.js";
 import { sendDailyReport } from "./services/daily-report.js";
@@ -79,7 +81,7 @@ app.get("/mcp", (c) =>
 app.delete("/mcp", (c) =>
   c.json({ error: "method_not_allowed", message: "This server is stateless. Session deletion is not supported." }, 405),
 );
-app.post("/mcp", authMiddleware, rateLimitMiddleware, async (c) => {
+app.post("/mcp", authMiddleware, rateLimitMiddleware, meterApiRequest, async (c) => {
   const auth = c.get("auth");
   const server = createMcpServer(c.env, auth);
 
@@ -181,6 +183,11 @@ app.route("/api/privacy", privacy);
 app.route("/api/export", dataExport);
 app.route("/api/oauth/connections", oauthConnections);
 app.route("/api/memories", memories);
+
+// Public REST API (engram#287) — the six MCP memory tools as REST
+// endpoints, metered as API usage.
+app.use("/api/v1/*", meterApiRequest);
+app.route("/api/v1", v1);
 
 export default {
   fetch: app.fetch,

--- a/apps/mcp-server/src/middleware/meter.ts
+++ b/apps/mcp-server/src/middleware/meter.ts
@@ -1,0 +1,22 @@
+import type { Context, Next } from "hono";
+import { trackApiRequest } from "../services/tier.js";
+import type { Env, AuthContext } from "../types.js";
+
+/**
+ * Count data-plane API usage (engram#287) — applied to /mcp and /api/v1
+ * only, so account-management calls from the dashboard don't inflate the
+ * "API requests" number a customer sees. Runs after authMiddleware: if
+ * auth was rejected nothing was set and nothing is counted. Admin
+ * requests are cross-org and excluded.
+ */
+export async function meterApiRequest(
+  c: Context<{ Bindings: Env; Variables: { auth: AuthContext } }>,
+  next: Next
+) {
+  await next();
+  const auth = c.get("auth");
+  if (!auth || auth.isAdmin) return;
+  c.executionCtx.waitUntil(
+    trackApiRequest(c.env.DB, auth.organizationId).catch(() => {})
+  );
+}

--- a/apps/mcp-server/src/routes/usage.ts
+++ b/apps/mcp-server/src/routes/usage.ts
@@ -25,7 +25,12 @@ usage.get("/", async (c) => {
     } | null>,
   ]);
 
-  const u = currentUsage as { messages_stored: number; searches_run: number; period: string } | null;
+  const u = currentUsage as {
+    messages_stored: number;
+    searches_run: number;
+    api_requests?: number;
+    period: string;
+  } | null;
   // For team tier, seat limit comes from Stripe subscription quantity
   const seatLimit = limits.seats === -1 ? (org?.seat_limit ?? 1) : limits.seats;
   const storageLimit = storageLimitFor(auth.tier, org?.seat_limit ?? 1);
@@ -47,6 +52,10 @@ usage.get("/", async (c) => {
     },
     searches: {
       used: u?.searches_run ?? 0,
+    },
+    // Data-plane requests (/mcp + /api/v1) this period (engram#287).
+    api_requests: {
+      used: u?.api_requests ?? 0,
     },
     api_keys: {
       used: keyCount?.count ?? 0,

--- a/apps/mcp-server/src/routes/v1.ts
+++ b/apps/mcp-server/src/routes/v1.ts
@@ -1,0 +1,387 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  listConversations as dbListConversations,
+  getOrgConversationCount,
+} from "@getengram/db";
+import {
+  createConversation,
+  getConversation,
+  deleteConversation,
+  appendMessages,
+  getOrCreateDefaultConversation,
+} from "../services/conversation.js";
+import {
+  checkConversationLimit,
+  checkAndTrackMessages,
+  checkAndTrackStorage,
+  releaseStorage,
+  trackSearchRun,
+} from "../services/tier.js";
+import { searchConversations } from "../services/search.js";
+import {
+  loadPrivacy,
+  PRIVACY_BODIES_NOTICE,
+  PRIVACY_CROSS_CONVERSATION_NOTICE,
+} from "../services/privacy.js";
+import { fireWebhooks } from "../services/webhooks.js";
+import { audit } from "../services/audit.js";
+import { hasScope, type Scope } from "../mcp/scopes.js";
+import { usageMeter } from "../mcp/usage-messaging.js";
+import type { Env, AuthContext } from "../types.js";
+import type { Context } from "hono";
+
+type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
+
+/**
+ * Public REST API (engram#287) — the pricing page promises "MCP + REST
+ * API", so the six MCP memory tools are mirrored here 1:1 for callers
+ * that can't (or don't want to) drive the MCP protocol: backends, cron
+ * jobs, curl. Same services, same scope checks, same storage/monthly
+ * gates, same privacy settings, same audit + webhooks — different
+ * transport. Versioned under /api/v1 so the shape can evolve without
+ * breaking the account-management routes that live at /api/*.
+ */
+export const v1 = new Hono<HonoEnv>();
+
+function scopeError(c: Context<HonoEnv>, scope: Scope) {
+  return c.json(
+    {
+      error: "insufficient_scope",
+      required: scope,
+      message: `This API key does not have the '${scope}' permission. Create a key with this scope at getengram.app/dashboard.`,
+    },
+    403,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/conversations — mirror of create_conversation
+// ---------------------------------------------------------------------------
+
+const createConversationSchema = z.object({
+  title: z.string().optional(),
+  agent_id: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+v1.post("/conversations", async (c) => {
+  const auth = c.get("auth");
+  if (!hasScope(auth, "write")) return scopeError(c, "write");
+
+  const parsed = createConversationSchema.safeParse(
+    await c.req.json().catch(() => ({})),
+  );
+  if (!parsed.success) {
+    return c.json({ error: "invalid_body", details: parsed.error.flatten() }, 400);
+  }
+
+  const countResult = await getOrgConversationCount(c.env.DB, auth.organizationId);
+  const tierCheck = checkConversationLimit(auth.tier, countResult?.count ?? 0);
+  if (!tierCheck.allowed) {
+    return c.json(
+      {
+        error: tierCheck.error,
+        limit: tierCheck.limit,
+        used: tierCheck.used,
+        tier: tierCheck.tier,
+        upgrade_url: "https://getengram.app/pricing",
+      },
+      402,
+    );
+  }
+
+  const id = await createConversation(
+    c.env.DB,
+    auth.organizationId,
+    parsed.data.title,
+    parsed.data.agent_id,
+    parsed.data.tags,
+    parsed.data.metadata as Record<string, unknown>,
+  );
+
+  await audit(c.env.DB, auth.organizationId, auth.apiKeyId, "conversation.create", "conversation", id, {
+    source: "rest",
+  });
+  fireWebhooks(c.env.DB, auth.organizationId, "conversation.created", {
+    conversation_id: id,
+    title: parsed.data.title ?? null,
+  }).catch(() => {});
+
+  return c.json({ conversation_id: id }, 201);
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/conversations — mirror of list_conversations
+// ---------------------------------------------------------------------------
+
+v1.get("/conversations", async (c) => {
+  const auth = c.get("auth");
+  if (!hasScope(auth, "read")) return scopeError(c, "read");
+
+  const privacy = await loadPrivacy(c.env.DB, auth.organizationId);
+  if (!privacy.canReadCrossConversation) {
+    return c.json({ conversations: [], total: 0, privacy_notice: PRIVACY_CROSS_CONVERSATION_NOTICE });
+  }
+
+  const limit = Math.min(Math.max(Number(c.req.query("limit") ?? "20") || 20, 1), 100);
+  const offset = Math.max(Number(c.req.query("offset") ?? "0") || 0, 0);
+  const sortParam = c.req.query("sort");
+  const sort = (["created_at", "updated_at", "message_count"] as const).find(
+    (s) => s === sortParam,
+  ) ?? "updated_at";
+  const order = c.req.query("order") === "asc" ? "asc" : "desc";
+  const tagsParam = c.req.query("tags");
+
+  await audit(c.env.DB, auth.organizationId, auth.apiKeyId, "conversation.list", undefined, undefined, {
+    source: "rest",
+  });
+
+  const result = await dbListConversations(c.env.DB, auth.organizationId, {
+    limit,
+    offset,
+    agentId: c.req.query("agent_id") || undefined,
+    tags: tagsParam ? tagsParam.split(",").map((t) => t.trim()).filter(Boolean) : undefined,
+    sort,
+    order,
+  });
+
+  const conversations = (result.results as Array<Record<string, unknown>>).map(
+    ({ organization_id: _o, ...conv }) => ({
+      ...conv,
+      tags: JSON.parse((conv.tags as string) || "[]"),
+      metadata: JSON.parse((conv.metadata as string) || "{}"),
+    }),
+  );
+
+  return c.json({ conversations, total: conversations.length });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/conversations/:id — mirror of get_conversation
+// ---------------------------------------------------------------------------
+
+v1.get("/conversations/:id", async (c) => {
+  const auth = c.get("auth");
+  if (!hasScope(auth, "read")) return scopeError(c, "read");
+
+  const conversationId = c.req.param("id");
+  const messageLimit = Math.min(
+    Math.max(Number(c.req.query("message_limit") ?? "100") || 100, 1),
+    500,
+  );
+  const messageOffset = Math.max(Number(c.req.query("message_offset") ?? "0") || 0, 0);
+
+  await audit(c.env.DB, auth.organizationId, auth.apiKeyId, "conversation.read", "conversation", conversationId, {
+    source: "rest",
+  });
+
+  const result = await getConversation(
+    c.env.DB,
+    auth.organizationId,
+    conversationId,
+    messageLimit,
+    messageOffset,
+  );
+  if (!result) return c.json({ error: "conversation_not_found" }, 404);
+
+  // Strip internal fields and honor the org's privacy setting, exactly
+  // like the MCP tool.
+  const { organization_id: _o, ...conversation } = result.conversation;
+  const privacy = await loadPrivacy(c.env.DB, auth.organizationId);
+  const messages = result.messages.map((m) => {
+    const {
+      organization_id: _mo,
+      content_encoding: _enc,
+      content,
+      ...rest
+    } = m as typeof m & {
+      organization_id?: string;
+      content_encoding?: string;
+      content?: string;
+    };
+    return privacy.canReadBodies ? { ...rest, content } : { ...rest, body_hidden: true };
+  });
+
+  return c.json(
+    privacy.canReadBodies
+      ? { conversation, messages }
+      : { conversation, messages, privacy_notice: PRIVACY_BODIES_NOTICE },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/conversations/:id — mirror of delete_conversation
+// ---------------------------------------------------------------------------
+
+v1.delete("/conversations/:id", async (c) => {
+  const auth = c.get("auth");
+  if (!hasScope(auth, "delete")) return scopeError(c, "delete");
+
+  const conversationId = c.req.param("id");
+  const deleted = await deleteConversation(c.env, auth.organizationId, conversationId);
+
+  await audit(c.env.DB, auth.organizationId, auth.apiKeyId, "conversation.delete", "conversation", conversationId, {
+    source: "rest",
+  });
+
+  if (!deleted) return c.json({ error: "conversation_not_found" }, 404);
+  return c.json({ deleted: true });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/messages — mirror of append_messages
+// ---------------------------------------------------------------------------
+
+const appendSchema = z.object({
+  conversation_id: z.string().optional(),
+  messages: z
+    .array(
+      z.object({
+        role: z.enum(["user", "assistant", "system", "tool"]),
+        content: z.string(),
+        tool_call_id: z.string().optional(),
+        tool_name: z.string().optional(),
+        metadata: z.record(z.unknown()).optional(),
+      }),
+    )
+    .min(1),
+});
+
+v1.post("/messages", async (c) => {
+  const auth = c.get("auth");
+  if (!hasScope(auth, "write")) return scopeError(c, "write");
+
+  const parsed = appendSchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return c.json({ error: "invalid_body", details: parsed.error.flatten() }, 400);
+  }
+  const count = parsed.data.messages.length;
+
+  // Primary gate: lifetime storage. Atomically reserves space; released
+  // below if a later step rejects or fails.
+  const storageCheck = await checkAndTrackStorage(c.env.DB, auth.organizationId, auth.tier, count);
+  if (!storageCheck.allowed) {
+    return c.json(
+      {
+        error: storageCheck.error,
+        limit: storageCheck.limit,
+        used: storageCheck.used,
+        tier: storageCheck.tier,
+        upgrade_url: "https://getengram.app/pricing",
+      },
+      402,
+    );
+  }
+
+  // Secondary gate: monthly velocity.
+  const tierCheck = await checkAndTrackMessages(c.env.DB, auth.organizationId, auth.tier, count);
+  if (!tierCheck.allowed) {
+    await releaseStorage(c.env.DB, auth.organizationId, count);
+    return c.json(
+      {
+        error: tierCheck.error,
+        limit: tierCheck.limit,
+        used: tierCheck.used,
+        tier: tierCheck.tier,
+        upgrade_url: "https://getengram.app/pricing",
+      },
+      429,
+    );
+  }
+
+  const conversationId =
+    parsed.data.conversation_id ??
+    (await getOrCreateDefaultConversation(c.env.DB, auth.organizationId));
+
+  let messages;
+  try {
+    messages = await appendMessages(
+      c.env,
+      auth.organizationId,
+      conversationId,
+      parsed.data.messages.map((m) => ({
+        ...m,
+        metadata: m.metadata as Record<string, unknown>,
+      })),
+    );
+  } catch (err) {
+    await releaseStorage(c.env.DB, auth.organizationId, count).catch(() => {});
+    throw err;
+  }
+
+  await audit(c.env.DB, auth.organizationId, auth.apiKeyId, "messages.append", "conversation", conversationId, {
+    count: messages.length,
+    source: "rest",
+  });
+  fireWebhooks(c.env.DB, auth.organizationId, "messages.appended", {
+    conversation_id: conversationId,
+    message_count: messages.length,
+    message_ids: messages.map((m) => m.id),
+  }).catch(() => {});
+
+  const meter = usageMeter(tierCheck.used, tierCheck.limit);
+  const storageMeter = usageMeter(storageCheck.used, storageCheck.limit);
+
+  return c.json({
+    conversation_id: conversationId,
+    appended: messages.length,
+    message_ids: messages.map((m) => m.id),
+    ...(meter ? { usage: meter } : {}),
+    ...(storageMeter ? { storage: storageMeter } : {}),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/search — mirror of search
+// ---------------------------------------------------------------------------
+
+v1.get("/search", async (c) => {
+  const auth = c.get("auth");
+  if (!hasScope(auth, "search")) return scopeError(c, "search");
+
+  const query = c.req.query("q")?.trim();
+  if (!query) return c.json({ error: "missing_query" }, 400);
+  const limit = Math.min(Math.max(Number(c.req.query("limit") ?? "5") || 5, 1), 20);
+  const conversationId = c.req.query("conversation_id") || undefined;
+  const tagsParam = c.req.query("tags");
+  const tags = tagsParam ? tagsParam.split(",").map((t) => t.trim()).filter(Boolean) : undefined;
+  const project = c.req.query("project") || undefined;
+
+  const privacy = await loadPrivacy(c.env.DB, auth.organizationId);
+  // A search without a conversation_id spans all conversations; honor the
+  // org's cross-conversation privacy setting.
+  if (!privacy.canReadCrossConversation && !conversationId) {
+    return c.json({ results: [], total: 0, privacy_notice: PRIVACY_CROSS_CONVERSATION_NOTICE });
+  }
+
+  const raw = await searchConversations(
+    c.env,
+    auth.organizationId,
+    query,
+    limit,
+    conversationId,
+    tags,
+    undefined, // snippetChars
+    undefined, // minScore
+    undefined, // dedupe
+    project,
+  );
+  const results = privacy.canReadBodies
+    ? raw
+    : raw.map(({ chunk_text: _c, ...rest }) => rest);
+
+  await trackSearchRun(c.env.DB, auth.organizationId).catch(() => {});
+  await audit(c.env.DB, auth.organizationId, auth.apiKeyId, "search", undefined, undefined, {
+    query,
+    results: results.length,
+    source: "rest",
+  });
+
+  return c.json(
+    privacy.canReadBodies
+      ? { results, total: results.length }
+      : { results, total: results.length, privacy_notice: PRIVACY_BODIES_NOTICE },
+  );
+});

--- a/apps/mcp-server/src/services/tier.ts
+++ b/apps/mcp-server/src/services/tier.ts
@@ -4,6 +4,7 @@ import {
   atomicIncrementMessages,
   incrementMessagesStored,
   incrementSearchesRun,
+  incrementApiRequests,
   atomicIncrementStorage,
   incrementStorage,
   decrementStorage,
@@ -133,6 +134,14 @@ export async function trackSearchRun(
 ) {
   await ensureUsage(db, organizationId);
   await incrementSearchesRun(db, organizationId);
+}
+
+/**
+ * Count one authenticated data-plane API request (engram#287).
+ * Upsert-based, so no ensureUsage round trip is needed.
+ */
+export async function trackApiRequest(db: D1Database, organizationId: string) {
+  await incrementApiRequests(db, generateId("usg"), organizationId);
 }
 
 /**

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -423,3 +423,36 @@ Common errors:
 | `Conversation not found` | Invalid conversation_id or doesn't belong to your organization |
 | `401 Unauthorized` | Missing or invalid API key |
 | `403 Forbidden` | API key expired or revoked |
+
+---
+
+## REST API
+
+Every memory operation is also available as a plain REST endpoint under `/api/v1` — same behavior, same limits, same API key — for backends, scripts, and anywhere an MCP client isn't practical. Base URL: `https://mcp.getengram.app`.
+
+All requests require the same `Authorization: Bearer engram_sk_live_...` header. Requests to `/mcp` and `/api/v1` count toward your monthly API usage, shown on the dashboard and in `GET /api/usage`.
+
+| Endpoint | MCP equivalent | Description |
+|----------|----------------|-------------|
+| `POST /api/v1/conversations` | `create_conversation` | Create a conversation. Body: `{ title?, agent_id?, tags?, metadata? }` → `201 { conversation_id }` |
+| `GET /api/v1/conversations` | `list_conversations` | List conversations. Query: `limit`, `offset`, `agent_id`, `tags` (comma-separated), `sort`, `order` |
+| `GET /api/v1/conversations/:id` | `get_conversation` | Fetch a conversation with messages. Query: `message_limit`, `message_offset` |
+| `DELETE /api/v1/conversations/:id` | `delete_conversation` | Delete a conversation, its messages, and embeddings |
+| `POST /api/v1/messages` | `append_messages` | Store messages. Body: `{ conversation_id?, messages: [{ role, content, ... }] }` — omit `conversation_id` to use the default memory |
+| `GET /api/v1/search` | `search` | Hybrid search. Query: `q` (required), `limit`, `conversation_id`, `tags`, `project` |
+
+### Example
+
+```bash
+# Store a memory
+curl -X POST https://mcp.getengram.app/api/v1/messages \
+  -H "Authorization: Bearer engram_sk_live_..." \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"We chose Postgres over DynamoDB for the billing service."}]}'
+
+# Search it later
+curl "https://mcp.getengram.app/api/v1/search?q=billing+database+choice" \
+  -H "Authorization: Bearer engram_sk_live_..."
+```
+
+REST error responses use conventional status codes: `400` invalid body/query, `401` bad key, `403` missing scope, `402` storage or plan limit, `404` not found, `429` monthly velocity limit.

--- a/packages/db/migrations/0022_api_requests.sql
+++ b/packages/db/migrations/0022_api_requests.sql
@@ -1,0 +1,4 @@
+-- API request metering (engram#287): count authenticated data-plane
+-- requests (/mcp + /api/v1) per org per period, alongside the existing
+-- messages_stored / searches_run counters.
+ALTER TABLE usage ADD COLUMN api_requests INTEGER NOT NULL DEFAULT 0;

--- a/packages/db/src/queries/usage.ts
+++ b/packages/db/src/queries/usage.ts
@@ -71,6 +71,24 @@ export function incrementSearchesRun(db: D1Database, organizationId: string) {
     .run();
 }
 
+/**
+ * Count one authenticated data-plane API request (engram#287). Single
+ * round trip: creates the period row if needed, else bumps the counter.
+ * The id is only used when this insert creates the row.
+ */
+export function incrementApiRequests(db: D1Database, id: string, organizationId: string) {
+  const period = getCurrentPeriod();
+  return db
+    .prepare(
+      `INSERT INTO usage (id, organization_id, period, api_requests)
+       VALUES (?, ?, ?, 1)
+       ON CONFLICT(organization_id, period)
+       DO UPDATE SET api_requests = api_requests + 1, updated_at = datetime('now')`
+    )
+    .bind(id, organizationId, period)
+    .run();
+}
+
 export function getUsageHistory(db: D1Database, organizationId: string, months: number = 6) {
   return db
     .prepare(


### PR DESCRIPTION
Closes #287. First half of finishing the pricing-page Pro promise "MCP + REST API" (the engram-web half — dashboard card + public docs — follows separately).

## REST API — the six MCP memory tools, now as REST

| Endpoint | MCP equivalent |
|---|---|
| `POST /api/v1/conversations` | `create_conversation` |
| `GET /api/v1/conversations` | `list_conversations` |
| `GET /api/v1/conversations/:id` | `get_conversation` |
| `DELETE /api/v1/conversations/:id` | `delete_conversation` |
| `POST /api/v1/messages` | `append_messages` |
| `GET /api/v1/search` | `search` |

Thin mirrors: same services, same scope checks (`403 insufficient_scope`), same storage gate (`402`), same monthly velocity gate (`429`), same privacy settings, audit rows (`source: "rest"`), and webhook firing as the MCP tools. Mounted behind the existing `/api/*` auth + rate-limit middleware, versioned under `/api/v1` so the shape can evolve independently of the account-management routes.

## API usage metering

- Migration `0022`: `usage.api_requests` counter (per org, per period).
- New `meterApiRequest` middleware on `/mcp` + `/api/v1/*` only — dashboard account-management calls don't inflate the number a customer sees. Increment happens via `waitUntil` (non-blocking, single upsert round trip); unauthenticated requests and admin traffic are excluded.
- `GET /api/usage` now returns `api_requests: { used }`.

## Verification

- 175 tests pass, including new coverage: scope rejection, create/list/404s, search validation, meter counts authed requests / skips admin.
- Typecheck + full build (wrangler dry-run) pass.
- Migration is applied automatically by the deploy workflow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52