### PR TITLE
feat: enterprise custom data retention (per-org auto-purge policy)

### DIFF
--- a/apps/mcp-server/src/__tests__/retention-policy.test.ts
+++ b/apps/mcp-server/src/__tests__/retention-policy.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { admin } from "../routes/admin.js";
+import { createMockD1, createMockEnv } from "./helpers.js";
+import type { Env } from "../types.js";
+
+// ADMIN_SECRET auth lives in index.ts middleware; mounting the router
+// directly tests the handler logic (same approach as export.test.ts).
+function createApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.route("/admin", admin);
+  return app;
+}
+
+describe("PATCH /admin/users/:id — retention_policy_days", () => {
+  it("rejects a window below the 7-day floor", async () => {
+    const env = createMockEnv(createMockD1());
+    const res = await createApp().request(
+      "/admin/users/org_x",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ retention_policy_days: 3 }),
+        headers: { "Content-Type": "application/json" },
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; min: number };
+    expect(body.error).toBe("invalid_retention_policy_days");
+    expect(body.min).toBe(7);
+  });
+
+  it("rejects a non-integer window", async () => {
+    const env = createMockEnv(createMockD1());
+    const res = await createApp().request(
+      "/admin/users/org_x",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ retention_policy_days: 30.5 }),
+        headers: { "Content-Type": "application/json" },
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts a valid window", async () => {
+    const env = createMockEnv(createMockD1());
+    const res = await createApp().request(
+      "/admin/users/org_x",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ retention_policy_days: 90 }),
+        headers: { "Content-Type": "application/json" },
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { updated: boolean; retention_policy_days: number };
+    expect(body.updated).toBe(true);
+    expect(body.retention_policy_days).toBe(90);
+  });
+
+  it("accepts null to clear the policy", async () => {
+    const env = createMockEnv(createMockD1());
+    const res = await createApp().request(
+      "/admin/users/org_x",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ retention_policy_days: null }),
+        headers: { "Content-Type": "application/json" },
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { updated: boolean; retention_policy_days: null };
+    expect(body.updated).toBe(true);
+    expect(body.retention_policy_days).toBeNull();
+  });
+});

--- a/apps/mcp-server/src/cron/retention-policy.ts
+++ b/apps/mcp-server/src/cron/retention-policy.ts
@@ -1,0 +1,57 @@
+import { deleteConversation } from "../services/conversation.js";
+import { audit } from "../services/audit.js";
+import type { Env } from "../types.js";
+
+// Bound the daily sweep so a huge backlog can't blow the cron budget;
+// anything left is picked up on subsequent days.
+const MAX_DELETES_PER_ORG = 50;
+
+/**
+ * Enforce per-org retention policies (engram#289). Only orgs where an
+ * admin explicitly set organizations.retention_policy_days are touched —
+ * for everyone else memory never expires. Semantics: a conversation
+ * whose updated_at is older than the policy window is deleted whole
+ * (messages, chunks, vectors, storage accounting) via the same
+ * deleteConversation path the user-facing delete uses. Keying on
+ * updated_at means an actively-used conversation never expires
+ * mid-thread.
+ */
+export async function enforceRetentionPolicies(env: Env): Promise<number> {
+  const orgs = await env.DB.prepare(
+    `SELECT id, retention_policy_days FROM organizations
+     WHERE retention_policy_days IS NOT NULL AND deleted_at IS NULL`,
+  ).all<{ id: string; retention_policy_days: number }>();
+
+  let deleted = 0;
+  for (const org of orgs.results ?? []) {
+    const days = org.retention_policy_days;
+    if (!Number.isInteger(days) || days < 7) continue; // defensive: never honor a foot-gun value
+
+    const stale = await env.DB.prepare(
+      `SELECT id FROM conversations
+       WHERE organization_id = ?
+         AND updated_at < datetime('now', '-' || ? || ' days')
+       ORDER BY updated_at ASC
+       LIMIT ?`,
+    )
+      .bind(org.id, days, MAX_DELETES_PER_ORG)
+      .all<{ id: string }>();
+
+    for (const conv of stale.results ?? []) {
+      const ok = await deleteConversation(env, org.id, conv.id).catch(() => false);
+      if (ok) {
+        deleted++;
+        await audit(
+          env.DB,
+          org.id,
+          null,
+          "conversation.retention_purge",
+          "conversation",
+          conv.id,
+          { policy_days: days },
+        ).catch(() => {});
+      }
+    }
+  }
+  return deleted;
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -21,6 +21,7 @@ import { v1 } from "./routes/v1.js";
 import { meterApiRequest } from "./middleware/meter.js";
 import { purgeDeletedOrganizations } from "./cron/purge-deleted.js";
 import { expireGracePeriods } from "./cron/expire-grace.js";
+import { enforceRetentionPolicies } from "./cron/retention-policy.js";
 import { sendDailyReport } from "./services/daily-report.js";
 import { oauth } from "./oauth/router.js";
 import {
@@ -206,6 +207,12 @@ export default {
     const graceExpired = await expireGracePeriods(env);
     if (graceExpired > 0) {
       console.log(`[cron] Expired ${graceExpired} grace period(s)`);
+    }
+    // Enterprise custom-retention policies (engram#289) — no-op unless an
+    // admin has explicitly set retention_policy_days on an org.
+    const retentionDeleted = await enforceRetentionPolicies(env);
+    if (retentionDeleted > 0) {
+      console.log(`[cron] Retention policy deleted ${retentionDeleted} conversation(s)`);
     }
   },
 };

--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -211,7 +211,9 @@ admin.get("/users", async (c) => {
 // ---------------------------------------------------------------------------
 admin.patch("/users/:id", async (c) => {
   const id = c.req.param("id");
-  const body = await c.req.json<{ tier?: string }>().catch(() => ({} as { tier?: string }));
+  const body = await c.req
+    .json<{ tier?: string; retention_policy_days?: number | null }>()
+    .catch(() => ({} as { tier?: string; retention_policy_days?: number | null }));
   const tier = body.tier;
 
   if (tier && ["free", "pro", "team", "enterprise"].includes(tier)) {
@@ -219,6 +221,20 @@ admin.patch("/users/:id", async (c) => {
       "UPDATE organizations SET tier = ? WHERE id = ?"
     ).bind(tier, id).run();
     return c.json({ updated: true, id, tier });
+  }
+
+  // Custom retention policy (engram#289) — enterprise contracts only.
+  // null clears the policy (memory never expires again); an integer ≥ 7
+  // sets the idle-conversation purge window in days.
+  if ("retention_policy_days" in body) {
+    const days = body.retention_policy_days;
+    if (days !== null && (!Number.isInteger(days) || (days as number) < 7)) {
+      return c.json({ error: "invalid_retention_policy_days", min: 7 }, 400);
+    }
+    await c.env.DB.prepare(
+      "UPDATE organizations SET retention_policy_days = ? WHERE id = ?"
+    ).bind(days, id).run();
+    return c.json({ updated: true, id, retention_policy_days: days });
   }
 
   return c.json({ error: "invalid_tier" }, 400);

--- a/apps/mcp-server/src/services/audit.ts
+++ b/apps/mcp-server/src/services/audit.ts
@@ -7,6 +7,7 @@ export type AuditAction =
   | "conversation.read"
   | "conversation.list"
   | "conversation.delete"
+  | "conversation.retention_purge"
   | "messages.append"
   | "account.update_email"
   | "account.delete"

--- a/packages/db/migrations/0023_retention_policy.sql
+++ b/packages/db/migrations/0023_retention_policy.sql
@@ -1,0 +1,5 @@
+-- Custom data retention (engram#289): per-org auto-purge policy for
+-- Enterprise contracts. NULL (the default, and the only value self-serve
+-- orgs ever have) means memory never expires. When set by admin, the
+-- daily cron deletes conversations idle longer than this many days.
+ALTER TABLE organizations ADD COLUMN retention_policy_days INTEGER;


### PR DESCRIPTION
Closes #289 — the last Enterprise pricing promise with a code surface (SSO/SAML is Supabase configuration per contract; SLA/SOC 2 are contractual).

- **Default is untouched:** `retention_policy_days` is NULL for every org and can only be set via the admin API — self-serve users keep "memory never expires" exactly as before.
- **Admin:** `PATCH /admin/users/:id` with `{retention_policy_days: 90}` (≥ 7, validated) or `null` to clear.
- **Enforcement:** daily cron deletes conversations whose `updated_at` is older than the window, whole-conversation granularity via the existing `deleteConversation` service (vectors, chunks, storage accounting all handled), audit-logged as `conversation.retention_purge`, bounded at 50 conversations/org/run so a backlog can't blow the cron budget. A defensive floor in the cron re-checks `days >= 7` before deleting anything.

Tests: PATCH validation (floor, non-integer, valid, clear) — 179 total pass. Migration auto-applies on merge via the deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52