### PR TITLE
feat: team invite accept flow (tokens + public accept endpoint)

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -17,6 +17,7 @@ import { privacy } from "./routes/privacy.js";
 import { dataExport } from "./routes/export.js";
 import { oauthConnections } from "./routes/oauth-connections.js";
 import { memories } from "./routes/memories.js";
+import { invites } from "./routes/invites.js";
 import { v1 } from "./routes/v1.js";
 import { meterApiRequest } from "./middleware/meter.js";
 import { purgeDeletedOrganizations } from "./cron/purge-deleted.js";
@@ -118,6 +119,18 @@ app.use(
   }),
 );
 app.route("/signup", signup);
+
+// Team invite accept flow (engram#263) — public routes keyed by an
+// unguessable single-use token; POST verifies the invitee's Supabase JWT.
+app.use(
+  "/invites/*",
+  cors({
+    origin: BROWSER_ORIGINS,
+    allowMethods: ["GET", "POST", "OPTIONS"],
+    allowHeaders: ["Content-Type", "Authorization"],
+  }),
+);
+app.route("/invites", invites);
 
 // Stripe webhook — public, verified by HMAC signature instead of API key.
 // Mounted BEFORE the /api/* auth middleware so it isn't gated.

--- a/apps/mcp-server/src/routes/invites.ts
+++ b/apps/mcp-server/src/routes/invites.ts
@@ -1,0 +1,132 @@
+import { Hono } from "hono";
+import { generateId, generateApiKeyRaw, hashApiKey } from "@getengram/shared";
+import { insertApiKey, acceptSeat, getOrganizationById } from "@getengram/db";
+import { verifySupabaseJwt } from "../utils/jwt.js";
+import { audit } from "../services/audit.js";
+import type { Env } from "../types.js";
+
+type HonoEnv = { Bindings: Env };
+
+const INVITE_TTL_DAYS = 14;
+
+/**
+ * Team invite acceptance (engram#263). Public routes keyed by an
+ * unguessable invite token (only its hash is stored, like API keys):
+ *
+ *   GET  /invites/:token  — preview (org name, invited email, state)
+ *   POST /invites/accept  — accept; auth = the invitee's Supabase JWT
+ *                           (same verification as /signup), body {token}
+ *
+ * Accepting marks the seat, mints a seat-bound API key on the team org,
+ * and returns it so engram-web can point the user's profile at the team.
+ */
+export const invites = new Hono<HonoEnv>();
+
+interface SeatRow {
+  id: string;
+  organization_id: string;
+  email: string;
+  role: string;
+  invited_at: string;
+  accepted_at: string | null;
+}
+
+async function findSeatByToken(db: D1Database, token: string): Promise<SeatRow | null> {
+  const hash = await hashApiKey(token);
+  return db
+    .prepare("SELECT * FROM seats WHERE invite_token_hash = ?")
+    .bind(hash)
+    .first<SeatRow>();
+}
+
+function isExpired(seat: SeatRow): boolean {
+  const invited = new Date(seat.invited_at + "Z").getTime();
+  return Date.now() - invited > INVITE_TTL_DAYS * 24 * 60 * 60 * 1000;
+}
+
+invites.get("/:token", async (c) => {
+  const seat = await findSeatByToken(c.env.DB, c.req.param("token"));
+  if (!seat) return c.json({ error: "invite_not_found" }, 404);
+
+  const org = (await getOrganizationById(c.env.DB, seat.organization_id)) as
+    | { name: string; tier: string }
+    | null;
+
+  return c.json({
+    org_name: org?.name ?? "an Engram team",
+    email: seat.email,
+    role: seat.role,
+    accepted: !!seat.accepted_at,
+    expired: isExpired(seat),
+  });
+});
+
+invites.post("/accept", async (c) => {
+  const jwtSecret = c.env.SUPABASE_JWT_SECRET;
+  if (!jwtSecret) {
+    return c.json({ error: "server_misconfigured" }, 500);
+  }
+
+  const token = (c.req.header("authorization") ?? "").replace(/^Bearer\s+/i, "");
+  if (!token) return c.json({ error: "unauthorized" }, 401);
+
+  let claims;
+  try {
+    claims = await verifySupabaseJwt(token, jwtSecret, c.env.SUPABASE_URL);
+  } catch {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+  const email = claims.email;
+  if (!email) return c.json({ error: "invalid_token" }, 400);
+
+  const body = await c.req.json<{ token?: string }>().catch(() => ({}) as { token?: string });
+  if (!body.token) return c.json({ error: "missing_invite_token" }, 400);
+
+  const seat = await findSeatByToken(c.env.DB, body.token);
+  if (!seat) return c.json({ error: "invite_not_found" }, 404);
+  if (seat.accepted_at) return c.json({ error: "already_accepted" }, 409);
+  if (isExpired(seat)) return c.json({ error: "invite_expired" }, 410);
+
+  const org = (await getOrganizationById(c.env.DB, seat.organization_id)) as
+    | { id: string; name: string; tier: string; deleted_at: string | null }
+    | null;
+  if (!org || org.deleted_at) return c.json({ error: "organization_gone" }, 410);
+
+  // Accept + mint a seat-bound API key on the team org. The token hash is
+  // cleared so the invite link is single-use.
+  await acceptSeat(c.env.DB, seat.id);
+  await c.env.DB.prepare(
+    "UPDATE seats SET invite_token_hash = NULL, email = ? WHERE id = ?",
+  )
+    .bind(email, seat.id)
+    .run();
+
+  const { raw, prefix } = generateApiKeyRaw();
+  const keyId = generateId("key");
+  await insertApiKey(
+    c.env.DB,
+    keyId,
+    seat.organization_id,
+    await hashApiKey(raw),
+    prefix,
+    `Seat — ${email}`,
+    "read,write,search,delete",
+  );
+  await c.env.DB.prepare("UPDATE api_keys SET seat_id = ? WHERE id = ?")
+    .bind(seat.id, keyId)
+    .run();
+
+  await audit(c.env.DB, seat.organization_id, keyId, "seat.accepted", "seat", seat.id, {
+    email,
+    invited_email: seat.email,
+  });
+
+  return c.json({
+    organization_id: seat.organization_id,
+    org_name: org.name,
+    tier: org.tier,
+    api_key: raw,
+    seat_id: seat.id,
+    role: seat.role,
+  });
+});

--- a/apps/mcp-server/src/routes/seats.ts
+++ b/apps/mcp-server/src/routes/seats.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { generateId } from "@getengram/shared";
+import { generateId, hashApiKey } from "@getengram/shared";
 import { insertSeat, getSeatsByOrg, getSeatCount, getSeatByEmail, deleteSeat, acceptSeat, getOrganizationById, revokeApiKeysBySeat } from "@getengram/db";
 import type { Env, AuthContext } from "../types.js";
 
@@ -49,7 +49,21 @@ seats.post("/", async (c) => {
     throw e;
   }
 
-  return c.json({ id, email: body.email, role, status: "invited" }, 201);
+  // Single-use invite token (engram#263) — returned raw exactly once so
+  // the caller (engram-web) can email an accept link; only the hash is
+  // stored. Accepting happens on the public /invites routes.
+  const tokenBytes = new Uint8Array(24);
+  crypto.getRandomValues(tokenBytes);
+  const inviteToken =
+    "inv_" + Array.from(tokenBytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  await c.env.DB.prepare("UPDATE seats SET invite_token_hash = ? WHERE id = ?")
+    .bind(await hashApiKey(inviteToken), id)
+    .run();
+
+  return c.json(
+    { id, email: body.email, role, status: "invited", invite_token: inviteToken },
+    201,
+  );
 });
 
 // Accept a seat invitation

--- a/apps/mcp-server/src/services/audit.ts
+++ b/apps/mcp-server/src/services/audit.ts
@@ -25,7 +25,8 @@ export type AuditAction =
   | "subscription.portal"
   | "subscription.checkout"
   | "subscription.upgrade_redirect"
-  | "oauth.connection.revoked";
+  | "oauth.connection.revoked"
+  | "seat.accepted";
 
 /**
  * Audit log entry. Never throws — audit logging should not break the

--- a/packages/db/migrations/0024_invite_tokens.sql
+++ b/packages/db/migrations/0024_invite_tokens.sql
@@ -1,0 +1,4 @@
+-- Team invite tokens (engram#263): the invite email carries an unguessable
+-- token; only its hash is stored, same discipline as API keys.
+ALTER TABLE seats ADD COLUMN invite_token_hash TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_seats_invite_token ON seats(invite_token_hash);


### PR DESCRIPTION
Closes #263, closes #243. Worker half of making Team invites real (engram-web half — email + accept page — follows).

**Before:** `POST /api/seats` wrote an `invited` row; nothing emailed the invitee, and `POST /api/seats/:id/accept` sat behind the org's own auth — an invitee could never call it.

**Now:**
- Invite creation also mints `inv_…` (192-bit random), returned raw once for the email link; only its hash is stored (migration `0024`, unique index).
- `GET /invites/:token` — public preview (org name, invited email, expired/accepted state).
- `POST /invites/accept` — auth is the invitee's own Supabase JWT (verified exactly like `/signup`); enforces single use (hash cleared) + 14-day TTL; marks the seat accepted; mints a **seat-bound** API key (`api_keys.seat_id` set — so removing the seat revokes it, which `DELETE /api/seats/:id` already does); returns org + key + tier for the web app to attach to the user's profile.
- Audit: `seat.accepted` with invited vs. actual email.

Typecheck, 179 tests, wrangler dry-run build pass. Migration auto-applies on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52