### PR TITLE
feat: idempotent import — fingerprint dedupe on re-run

### DIFF
--- a/apps/cli/src/__tests__/cli.test.ts
+++ b/apps/cli/src/__tests__/cli.test.ts
@@ -188,3 +188,28 @@ describe("usage bars", () => {
     expect(renderBar(20_000, 10_000)).toBe("[████████████████████] 100%");
   });
 });
+
+describe("import fingerprints (engram#254)", () => {
+  it("carries the ChatGPT conversation id as sourceId", () => {
+    const { conversations } = normalizeExport([
+      { id: "abc-123", title: "T", mapping: {}, current_node: null },
+    ]);
+    expect(conversations[0].sourceId).toBe("abc-123");
+  });
+
+  it("falls back to conversation_id and null when absent", () => {
+    const { conversations } = normalizeExport([
+      { conversation_id: "xyz", mapping: {}, current_node: null },
+      { mapping: {}, current_node: null },
+    ]);
+    expect(conversations[0].sourceId).toBe("xyz");
+    expect(conversations[1].sourceId).toBeNull();
+  });
+
+  it("carries the Claude uuid as sourceId", () => {
+    const { conversations } = normalizeExport([
+      { uuid: "u-1", name: "N", chat_messages: [] },
+    ]);
+    expect(conversations[0].sourceId).toBe("u-1");
+  });
+});

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -35,6 +35,8 @@ interface ChatNode {
 }
 
 export interface ChatConversation {
+  id?: string | null;
+  conversation_id?: string | null;
   title?: string | null;
   create_time?: number | null;
   current_node?: string | null;
@@ -50,6 +52,7 @@ interface ClaudeMessage {
 }
 
 export interface ClaudeConversation {
+  uuid?: string | null;
   name?: string | null;
   created_at?: string | null;
   chat_messages?: ClaudeMessage[];
@@ -61,6 +64,12 @@ export interface NormalizedConversation {
   title: string;
   created: string | number | null;
   messages: MessageInput[];
+  /**
+   * Stable id from the source export (ChatGPT conversation id / Claude
+   * uuid). Drives idempotent re-imports (engram#254); null when the
+   * export doesn't carry one.
+   */
+  sourceId: string | null;
 }
 
 const STORE_BATCH = 100;
@@ -136,6 +145,7 @@ export function normalizeExport(parsed: unknown): {
         title: (c.title || "Untitled").slice(0, 200),
         created: c.create_time ?? null,
         messages: linearize(c),
+        sourceId: c.id ?? c.conversation_id ?? null,
       })),
     };
   }
@@ -147,6 +157,7 @@ export function normalizeExport(parsed: unknown): {
         title: (c.name || "Untitled").slice(0, 200),
         created: c.created_at ?? null,
         messages: linearizeClaude(c),
+        sourceId: c.uuid ?? null,
       })),
     };
   }
@@ -371,12 +382,23 @@ export async function importHistory(
 
     try {
       const tags = [source, ...(extraTag ? [extraTag] : [])];
-      const { conversationId } = await engram.createConversation({
+      const { conversationId, existing } = await engram.createConversation({
         title: convo.title,
         agentId: source,
         tags,
-        metadata: { source: `${format}-export`, original_create_time: convo.created },
+        metadata: {
+          source: `${format}-export`,
+          original_create_time: convo.created,
+          // Stable fingerprint → re-imports reuse the same conversation
+          // instead of duplicating it (engram#254).
+          ...(convo.sourceId ? { import_fingerprint: `${format}:${convo.sourceId}` } : {}),
+        },
       });
+      if (existing) {
+        console.log(`  ${dim("↷ already imported")} ${label}`);
+        skipped++;
+        continue;
+      }
       for (let b = 0; b < convo.messages.length; b += STORE_BATCH) {
         await engram.store({
           conversationId,

--- a/apps/mcp-server/src/mcp/tools/create-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/create-conversation.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { createConversation } from "../../services/conversation.js";
+import { createConversationDedup } from "../../services/conversation.js";
 import { getOrgConversationCount } from "@getengram/db";
 import { checkConversationLimit } from "../../services/tier.js";
 import { fireWebhooks } from "../../services/webhooks.js";
@@ -28,6 +28,11 @@ export function registerCreateConversation(
       },
       outputSchema: {
         conversation_id: z.string().describe("The id of the created conversation"),
+        existing: z
+          .boolean()
+          .optional()
+          .describe("True when an import_fingerprint matched a previously imported conversation"),
+        message_count: z.number().optional(),
       },
       annotations: {
         title: "Create conversation",
@@ -71,7 +76,7 @@ export function registerCreateConversation(
         };
       }
 
-      const id = await createConversation(
+      const created = await createConversationDedup(
         env.DB,
         auth.organizationId,
         params.title,
@@ -79,23 +84,28 @@ export function registerCreateConversation(
         params.tags,
         params.metadata as Record<string, unknown>
       );
+      const id = created.id;
 
-      await audit(env.DB, auth.organizationId, auth.apiKeyId, "conversation.create", "conversation", id);
+      if (!created.existing) {
+        await audit(env.DB, auth.organizationId, auth.apiKeyId, "conversation.create", "conversation", id);
+        // Fire webhooks (non-blocking)
+        fireWebhooks(env.DB, auth.organizationId, "conversation.created", {
+          conversation_id: id,
+          title: params.title ?? null,
+        }).catch(() => {});
+      }
 
-      // Fire webhooks (non-blocking)
-      fireWebhooks(env.DB, auth.organizationId, "conversation.created", {
+      // `existing` lets importers skip conversations already imported
+      // (engram#254 — same import_fingerprint in metadata).
+      const payload = {
         conversation_id: id,
-        title: params.title ?? null,
-      }).catch(() => {});
-
+        ...(created.existing
+          ? { existing: true, message_count: created.message_count }
+          : {}),
+      };
       return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({ conversation_id: id }),
-          },
-        ],
-        structuredContent: { conversation_id: id },
+        content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+        structuredContent: payload,
       };
     }
   );

--- a/apps/mcp-server/src/routes/v1.ts
+++ b/apps/mcp-server/src/routes/v1.ts
@@ -5,7 +5,7 @@ import {
   getOrgConversationCount,
 } from "@getengram/db";
 import {
-  createConversation,
+  createConversationDedup,
   getConversation,
   deleteConversation,
   appendMessages,
@@ -92,7 +92,7 @@ v1.post("/conversations", async (c) => {
     );
   }
 
-  const id = await createConversation(
+  const created = await createConversationDedup(
     c.env.DB,
     auth.organizationId,
     parsed.data.title,
@@ -100,16 +100,23 @@ v1.post("/conversations", async (c) => {
     parsed.data.tags,
     parsed.data.metadata as Record<string, unknown>,
   );
+  if (created.existing) {
+    // Idempotent import (engram#254): fingerprint matched — no new row.
+    return c.json(
+      { conversation_id: created.id, existing: true, message_count: created.message_count },
+      200,
+    );
+  }
 
-  await audit(c.env.DB, auth.organizationId, auth.apiKeyId, "conversation.create", "conversation", id, {
+  await audit(c.env.DB, auth.organizationId, auth.apiKeyId, "conversation.create", "conversation", created.id, {
     source: "rest",
   });
   fireWebhooks(c.env.DB, auth.organizationId, "conversation.created", {
-    conversation_id: id,
+    conversation_id: created.id,
     title: parsed.data.title ?? null,
   }).catch(() => {});
 
-  return c.json({ conversation_id: id }, 201);
+  return c.json({ conversation_id: created.id }, 201);
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/mcp-server/src/services/conversation.ts
+++ b/apps/mcp-server/src/services/conversation.ts
@@ -10,6 +10,7 @@ import {
 import {
   insertConversation,
   getConversationById,
+  getConversationByFingerprint,
   getDefaultConversationId,
   DEFAULT_CONVERSATION_TAG,
   listConversations as dbListConversations,
@@ -35,6 +36,37 @@ export async function createConversation(
   tags?: string[],
   metadata?: Record<string, unknown>
 ): Promise<string> {
+  const created = await createConversationDedup(
+    db, organizationId, title, agentId, tags, metadata,
+  );
+  return created.id;
+}
+
+/**
+ * Create a conversation, honoring importer idempotency (engram#254):
+ * when metadata.import_fingerprint is present and a conversation with
+ * that fingerprint already exists for the org, return it instead of
+ * creating a duplicate. The fingerprint is also promoted to its indexed
+ * column on insert.
+ */
+export async function createConversationDedup(
+  db: D1Database,
+  organizationId: string,
+  title?: string,
+  agentId?: string,
+  tags?: string[],
+  metadata?: Record<string, unknown>
+): Promise<{ id: string; existing: boolean; message_count: number }> {
+  const fingerprint =
+    typeof metadata?.import_fingerprint === "string" && metadata.import_fingerprint
+      ? metadata.import_fingerprint.slice(0, 200)
+      : null;
+
+  if (fingerprint) {
+    const dupe = await getConversationByFingerprint(db, organizationId, fingerprint);
+    if (dupe) return { id: dupe.id, existing: true, message_count: dupe.message_count ?? 0 };
+  }
+
   const id = generateId("conv");
   await insertConversation(
     db,
@@ -45,7 +77,13 @@ export async function createConversation(
     tags ?? [],
     metadata ?? {}
   );
-  return id;
+  if (fingerprint) {
+    await db
+      .prepare("UPDATE conversations SET import_fingerprint = ? WHERE id = ?")
+      .bind(fingerprint, id)
+      .run();
+  }
+  return { id, existing: false, message_count: 0 };
 }
 
 /**

--- a/packages/db/migrations/0025_import_fingerprint.sql
+++ b/packages/db/migrations/0025_import_fingerprint.sql
@@ -1,0 +1,7 @@
+-- Idempotent imports (engram#254): importers stamp conversations with a
+-- stable fingerprint derived from the source export (e.g. chatgpt:<id>).
+-- Re-importing the same export finds the existing conversation instead of
+-- duplicating it.
+ALTER TABLE conversations ADD COLUMN import_fingerprint TEXT;
+CREATE INDEX IF NOT EXISTS idx_conversations_org_fingerprint
+  ON conversations(organization_id, import_fingerprint);

--- a/packages/db/src/queries/conversations.ts
+++ b/packages/db/src/queries/conversations.ts
@@ -143,3 +143,20 @@ export function deleteConversationById(db: D1Database, id: string, organizationI
     db.prepare("UPDATE organizations SET conversation_count = MAX(conversation_count - 1, 0) WHERE id = ?").bind(organizationId),
   ]);
 }
+
+/**
+ * Find a conversation previously imported with this fingerprint
+ * (engram#254). Fingerprints are only set by importers.
+ */
+export function getConversationByFingerprint(
+  db: D1Database,
+  organizationId: string,
+  fingerprint: string
+) {
+  return db
+    .prepare(
+      "SELECT id, message_count FROM conversations WHERE organization_id = ? AND import_fingerprint = ? LIMIT 1"
+    )
+    .bind(organizationId, fingerprint)
+    .first<{ id: string; message_count: number }>();
+}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -109,7 +109,19 @@ export class Engram {
 
     const raw = await this.transport.callTool("create_conversation", args);
     const data = JSON.parse(raw);
-    return { conversationId: data.conversation_id };
+    return {
+      conversationId: data.conversation_id,
+      // Present only when metadata.import_fingerprint matched a
+      // previously imported conversation (engram#254).
+      ...(data.existing === true
+        ? {
+            existing: true,
+            ...(typeof data.message_count === "number"
+              ? { messageCount: data.message_count }
+              : {}),
+          }
+        : {}),
+    };
   }
 
   /**

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -119,6 +119,13 @@ export interface ListConversationsParams {
 
 export interface CreateConversationResponse {
   conversationId: string;
+  /**
+   * True when metadata.import_fingerprint matched a previously imported
+   * conversation — the returned id is the existing one (engram#254).
+   */
+  existing?: boolean;
+  /** Message count of the existing conversation, when existing is true. */
+  messageCount?: number;
 }
 
 export interface StoreResponse {


### PR DESCRIPTION
Closes #254; unblocks #253 (import-first onboarding — if we push everyone to import, re-runs must not duplicate).

**Mechanism:** ChatGPT and Claude exports carry a stable per-conversation id. Importers now stamp it into `metadata.import_fingerprint` (`chatgpt:<id>` / `claude:<uuid>`); the worker promotes it to an indexed `conversations.import_fingerprint` column and, on a repeat, returns the existing conversation (`existing: true`, `message_count`) instead of creating a duplicate — no audit/webhook noise on dedupe hits.

- MCP `create_conversation` and REST `POST /api/v1/conversations` (200 vs 201) both surface the flag.
- CLI `engram import`: skips matches with an "↷ already imported" line; summary counts them as skipped. Exports without ids (old formats) keep today's behavior.
- SDK response is additive-only — new fields appear only on dedupe hits, so existing callers (including the published npm version's consumers) are unaffected.
- Tests: parser sourceId coverage (ChatGPT id / conversation_id fallback / Claude uuid / absent → null); 222 total across workspace pass.

The dashboard importer (engram-web) gets the same fingerprint pass-through in the #253 web PR, where its create call switches to the REST endpoint to read the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52