### PR TITLE
feat: import nudges — in-chat tip + 24h email cron (#253)

### DIFF
--- a/apps/mcp-server/src/cron/import-nudge.ts
+++ b/apps/mcp-server/src/cron/import-nudge.ts
@@ -1,0 +1,40 @@
+import type { Env } from "../types.js";
+
+/**
+ * Import-first onboarding, email leg (engram#253): orgs that signed up
+ * 1–2 days ago and still have an essentially empty memory (only the
+ * seeded welcome note) get one nudge to import their ChatGPT history —
+ * the single action that fills their account with value. The 24h–48h
+ * window means the daily cron fires it exactly once per org.
+ */
+export async function sendImportNudges(env: Env): Promise<number> {
+  if (!env.APP_URL) return 0;
+
+  const idle = await env.DB.prepare(
+    `SELECT id, name, email FROM organizations
+     WHERE deleted_at IS NULL
+       AND email IS NOT NULL
+       AND messages_stored_total <= 1
+       AND created_at <= datetime('now', '-1 day')
+       AND created_at > datetime('now', '-2 days')
+     LIMIT 100`,
+  ).all<{ id: string; name: string; email: string }>();
+
+  let sent = 0;
+  for (const org of idle.results ?? []) {
+    try {
+      const res = await fetch(`${env.APP_URL}/api/email/import-nudge`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${(env as Env & { ADMIN_SECRET: string }).ADMIN_SECRET}`,
+        },
+        body: JSON.stringify({ to: org.email, name: org.name }),
+      });
+      if (res.ok) sent++;
+    } catch (err) {
+      console.error(`[import-nudge] Failed for ${org.email}:`, err);
+    }
+  }
+  return sent;
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -23,6 +23,7 @@ import { meterApiRequest } from "./middleware/meter.js";
 import { purgeDeletedOrganizations } from "./cron/purge-deleted.js";
 import { expireGracePeriods } from "./cron/expire-grace.js";
 import { enforceRetentionPolicies } from "./cron/retention-policy.js";
+import { sendImportNudges } from "./cron/import-nudge.js";
 import { sendDailyReport } from "./services/daily-report.js";
 import { oauth } from "./oauth/router.js";
 import {
@@ -226,6 +227,12 @@ export default {
     const retentionDeleted = await enforceRetentionPolicies(env);
     if (retentionDeleted > 0) {
       console.log(`[cron] Retention policy deleted ${retentionDeleted} conversation(s)`);
+    }
+    // Import-first onboarding (engram#253): one nudge email per org that
+    // signed up yesterday and hasn't stored anything yet.
+    const nudged = await sendImportNudges(env);
+    if (nudged > 0) {
+      console.log(`[cron] Sent ${nudged} import-nudge email(s)`);
     }
   },
 };

--- a/apps/mcp-server/src/mcp/coaching.ts
+++ b/apps/mcp-server/src/mcp/coaching.ts
@@ -10,7 +10,7 @@ import type { AuthContext } from "../types.js";
 const NEW_USER_MESSAGE_THRESHOLD = 20;
 
 const CONTINUOUS_MEMORY_TIP =
-  'Saved. Tip to pass on: the user can say "remember everything from this point forward" and you should keep saving the important turns automatically as the conversation develops. They can check what\'s stored anytime by asking "what do you remember about ___?".';
+  'Saved. Tip to pass on: the user can say "remember everything from this point forward" and you should keep saving the important turns automatically as the conversation develops. They can check what\'s stored anytime by asking "what do you remember about ___?". Also worth mentioning once: their entire ChatGPT history can be imported in one step at getengram.app/chatgpt/import — everything they\'ve ever discussed becomes searchable from here.';
 
 const SEARCH_EMPTY_TIP =
   'Nothing stored on this topic yet. The user can say "remember this" to save the current exchange, or "remember everything from this point forward" for continuous saving. Their full ChatGPT history can also be imported in one step at getengram.app/dashboard.';


### PR DESCRIPTION
Worker half of the remaining #253 pieces (pairs with the engram-web import-first PR, which adds the /api/email/import-nudge route + template):

- **In-chat**: the existing new-user coaching tip (shown on appends while an account has <20 messages, OAuth clients only) now also passes on the one-step history import link. Uses the shipped coaching system — no new surface.
- **24h email**: daily cron selects orgs created 24–48h ago with `messages_stored_total <= 1` (nothing beyond the welcome seed) and fires one nudge each via engram-web with the admin secret — same call pattern as the payment reminder. The 24h window makes it exactly-once without any new state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52