### PR TITLE
feat: value nudges — storage milestones + weekly digest (worker half, #256)

### DIFF
--- a/apps/mcp-server/src/__tests__/milestones.test.ts
+++ b/apps/mcp-server/src/__tests__/milestones.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { checkMilestone } from "../services/milestones.js";
+import { unsubscribeSig } from "../cron/weekly-digest.js";
+import { createMockD1, createMockEnv } from "./helpers.js";
+import type { Env } from "../types.js";
+
+describe("checkMilestone (engram#256)", () => {
+  it("returns nothing below the first threshold", async () => {
+    const env = createMockEnv(createMockD1()) as unknown as Env;
+    expect(await checkMilestone(env, "org_m", 99)).toBeUndefined();
+    expect(await checkMilestone(env, "org_m", 0)).toBeUndefined();
+    expect(await checkMilestone(env, "org_m", undefined)).toBeUndefined();
+  });
+
+  it("announces the highest crossed threshold", async () => {
+    const env = createMockEnv(createMockD1()) as unknown as Env;
+    const msg = await checkMilestone(env, "org_m", 12_500);
+    expect(msg).toContain("10,000");
+  });
+
+  it("announces the first threshold exactly at the boundary", async () => {
+    const env = createMockEnv(createMockD1()) as unknown as Env;
+    const msg = await checkMilestone(env, "org_m", 100);
+    expect(msg).toContain("100");
+  });
+});
+
+describe("unsubscribeSig", () => {
+  it("is deterministic and secret-dependent", async () => {
+    const a = await unsubscribeSig("org_1", "secret-a");
+    const b = await unsubscribeSig("org_1", "secret-a");
+    const c = await unsubscribeSig("org_1", "secret-b");
+    const d = await unsubscribeSig("org_2", "secret-a");
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).not.toBe(d);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/apps/mcp-server/src/cron/weekly-digest.ts
+++ b/apps/mcp-server/src/cron/weekly-digest.ts
@@ -1,0 +1,92 @@
+import type { Env } from "../types.js";
+
+/**
+ * Weekly memory digest (engram#256), sent Mondays from the 13:00 cron.
+ * Only orgs that were ACTIVE this week (stored at least one message) and
+ * haven't opted out get one — a quiet week sends nothing, so the digest
+ * can't become spam. engram-web renders and sends the branded email.
+ */
+
+/** HMAC-signed opt-out token so the unsubscribe link needs no login. */
+export async function unsubscribeSig(orgId: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(`digest:${orgId}`));
+  return Array.from(new Uint8Array(sig), (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+interface WeeklyRow {
+  id: string;
+  name: string;
+  email: string;
+  saved: number;
+}
+
+export async function sendWeeklyDigests(env: Env): Promise<number> {
+  if (!env.APP_URL) return 0;
+  const secret = (env as Env & { ADMIN_SECRET?: string }).ADMIN_SECRET;
+  if (!secret) return 0;
+
+  // Orgs with activity in the last 7 days, an email, and no opt-out.
+  const active = await env.DB.prepare(
+    `SELECT o.id, o.name, o.email, COUNT(m.id) AS saved
+     FROM organizations o
+     JOIN messages m ON m.organization_id = o.id
+       AND m.created_at >= datetime('now', '-7 days')
+     WHERE o.deleted_at IS NULL
+       AND o.email IS NOT NULL
+       AND o.digest_opt_out = 0
+     GROUP BY o.id
+     HAVING saved > 0
+     LIMIT 500`,
+  ).all<WeeklyRow>();
+
+  let sent = 0;
+  for (const org of active.results ?? []) {
+    try {
+      const [searches, titles] = await Promise.all([
+        env.DB.prepare(
+          `SELECT COUNT(*) AS n FROM audit_log
+           WHERE organization_id = ? AND action = 'search'
+             AND created_at >= datetime('now', '-7 days')`,
+        )
+          .bind(org.id)
+          .first<{ n: number }>(),
+        env.DB.prepare(
+          `SELECT title FROM conversations
+           WHERE organization_id = ? AND updated_at >= datetime('now', '-7 days')
+             AND title IS NOT NULL AND title != ''
+           ORDER BY updated_at DESC LIMIT 3`,
+        )
+          .bind(org.id)
+          .all<{ title: string }>(),
+      ]);
+
+      const sig = await unsubscribeSig(org.id, secret);
+      const res = await fetch(`${env.APP_URL}/api/email/weekly-digest`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${secret}`,
+        },
+        body: JSON.stringify({
+          to: org.email,
+          name: org.name,
+          saved: org.saved,
+          searches: searches?.n ?? 0,
+          highlights: (titles.results ?? []).map((t) => t.title),
+          unsubscribe_url: `https://mcp.getengram.app/email/unsubscribe?org=${encodeURIComponent(org.id)}&sig=${sig}`,
+        }),
+      });
+      if (res.ok) sent++;
+    } catch (err) {
+      console.error(`[digest] Failed for ${org.email}:`, err);
+    }
+  }
+  return sent;
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -24,6 +24,7 @@ import { purgeDeletedOrganizations } from "./cron/purge-deleted.js";
 import { expireGracePeriods } from "./cron/expire-grace.js";
 import { enforceRetentionPolicies } from "./cron/retention-policy.js";
 import { sendImportNudges } from "./cron/import-nudge.js";
+import { sendWeeklyDigests } from "./cron/weekly-digest.js";
 import { sendDailyReport } from "./services/daily-report.js";
 import { oauth } from "./oauth/router.js";
 import {
@@ -121,6 +122,24 @@ app.use(
 );
 app.route("/signup", signup);
 
+// One-click digest unsubscribe (engram#256) — signed link from the
+// weekly email; no login required. GET so it works from any mail client.
+app.get("/email/unsubscribe", async (c) => {
+  const org = c.req.query("org") ?? "";
+  const sig = c.req.query("sig") ?? "";
+  const secret = (c.env as Env & { ADMIN_SECRET?: string }).ADMIN_SECRET;
+  if (!org || !sig || !secret) return c.text("Invalid link.", 400);
+  const { unsubscribeSig } = await import("./cron/weekly-digest.js");
+  const expected = await unsubscribeSig(org, secret);
+  if (sig !== expected) return c.text("Invalid link.", 400);
+  await c.env.DB.prepare("UPDATE organizations SET digest_opt_out = 1 WHERE id = ?")
+    .bind(org)
+    .run();
+  return c.html(
+    "<!doctype html><meta charset=utf-8><title>Unsubscribed</title><body style=\"font-family:sans-serif;max-width:32rem;margin:4rem auto;color:#27272a\"><h1 style=\"font-size:1.4rem\">You're unsubscribed</h1><p>No more weekly digest emails. Account and security emails still arrive when needed.</p><p><a href=\"https://getengram.app\">getengram.app</a></p>",
+  );
+});
+
 // Team invite accept flow (engram#263) — public routes keyed by an
 // unguessable single-use token; POST verifies the invitee's Supabase JWT.
 app.use(
@@ -212,6 +231,11 @@ export default {
     //   13:00 UTC — daily ops report, emailed via engram-web
     if (event.cron === "0 13 * * *") {
       await sendDailyReport(env);
+      // Weekly memory digest (engram#256) — Mondays only.
+      if (new Date(event.scheduledTime).getUTCDay() === 1) {
+        const digests = await sendWeeklyDigests(env);
+        if (digests > 0) console.log(`[cron] Sent ${digests} weekly digest(s)`);
+      }
       return;
     }
     const purged = await purgeDeletedOrganizations(env);

--- a/apps/mcp-server/src/mcp/tools/append-messages.ts
+++ b/apps/mcp-server/src/mcp/tools/append-messages.ts
@@ -20,6 +20,7 @@ import {
   releaseStorage,
 } from "../../services/tier.js";
 import { fireWebhooks } from "../../services/webhooks.js";
+import { checkMilestone } from "../../services/milestones.js";
 import { audit } from "../../services/audit.js";
 import { hasScope, scopeError } from "../scopes.js";
 import type { Env, AuthContext } from "../../types.js";
@@ -90,6 +91,7 @@ export function registerAppendMessages(
           .optional()
           .describe("Lifetime memory storage for the org (capped tiers only) — memory never expires; it fills up"),
         notice: z.string().optional().describe("Heads-up shown when approaching the plan limit"),
+        milestone: z.string().optional().describe("One-time notice when lifetime storage crosses a threshold — worth relaying to the user"),
         storage_notice: z.string().optional().describe("Heads-up shown when memory storage is nearly full"),
       },
       annotations: {
@@ -234,6 +236,9 @@ export function registerAppendMessages(
       // Coaching keys off lifetime storage — the count that exists on
       // every tier (free has no monthly meter anymore).
       const tip = newUserAppendTip(auth, storageCheck.used ?? tierCheck.used);
+      // One-time storage milestones (engram#256) — ambient proof the
+      // memory is growing; fires once per threshold per org.
+      const milestone = await checkMilestone(env, auth.organizationId, storageCheck.used);
       const payload = {
         conversation_id: conversationId,
         appended: messages.length,
@@ -243,6 +248,7 @@ export function registerAppendMessages(
         ...(storageMeterVal ? { storage: storageMeterVal } : {}),
         ...(notice ? { notice } : {}),
         ...(storageNotice ? { storage_notice: storageNotice } : {}),
+        ...(milestone ? { milestone } : {}),
         ...(tip ? { tip } : {}),
       };
 

--- a/apps/mcp-server/src/services/milestones.ts
+++ b/apps/mcp-server/src/services/milestones.ts
@@ -1,0 +1,41 @@
+import type { Env } from "../types.js";
+
+// Ascending storage thresholds worth celebrating (engram#256). The
+// highest announced one is stored per org, so each fires exactly once
+// and a bulk import that blows through several announces only the
+// largest.
+const THRESHOLDS = [100, 1_000, 10_000, 100_000, 1_000_000] as const;
+
+function milestoneMessage(threshold: number): string {
+  return `Milestone: your Engram memory just passed ${threshold.toLocaleString("en-US")} messages — all of it permanent and searchable from every AI you've connected.`;
+}
+
+/**
+ * Returns a one-time milestone notice when this append pushed lifetime
+ * storage across a threshold, else undefined. Best-effort: any DB
+ * hiccup just skips the notice (never the append).
+ */
+export async function checkMilestone(
+  env: Env,
+  organizationId: string,
+  storedTotal: number | undefined,
+): Promise<string | undefined> {
+  if (typeof storedTotal !== "number" || storedTotal < THRESHOLDS[0]) return undefined;
+
+  const crossed = [...THRESHOLDS].reverse().find((t) => storedTotal >= t);
+  if (!crossed) return undefined;
+
+  try {
+    // Atomic claim: only one concurrent append wins the announcement.
+    const updated = await env.DB.prepare(
+      `UPDATE organizations SET milestone_announced = ?
+       WHERE id = ? AND milestone_announced < ?`,
+    )
+      .bind(crossed, organizationId, crossed)
+      .run();
+    if (updated.meta?.changes === 0) return undefined;
+    return milestoneMessage(crossed);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/db/migrations/0026_value_nudges.sql
+++ b/packages/db/migrations/0026_value_nudges.sql
@@ -1,0 +1,5 @@
+-- Value nudges (engram#256): milestone notices fire once per threshold
+-- (highest announced stored per org), and the weekly digest email is
+-- default-on with a signed one-click unsubscribe.
+ALTER TABLE organizations ADD COLUMN milestone_announced INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE organizations ADD COLUMN digest_opt_out INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
Worker half of #256 (engram-web email route/template PR follows).

**Milestones** — append responses gain a one-time `milestone` field when lifetime storage crosses 100/1k/10k/100k/1M. Exactly-once via an atomic `UPDATE … WHERE milestone_announced < ?` claim; concurrent appends can't double-fire, and bulk imports announce only the largest threshold crossed. In-chat, the model relays it: "your Engram memory just passed 1,000 messages."

**Weekly digest** — Mondays on the existing 13:00 cron: orgs with ≥1 message stored in the last 7 days and no opt-out get saved/search counts + up to 3 recent conversation titles, rendered/sent by engram-web (same admin-secret pattern as the daily report and import nudge). Inactive week → no email, by construction.

**Unsubscribe** — public `GET /email/unsubscribe?org&sig` with an HMAC-SHA256 sig keyed on `ADMIN_SECRET`; flips `digest_opt_out`, renders a plain confirmation page. Default-on with one-click out was a deliberate call (owner preference: no signup friction; issue text said opt-in) — flagged in the session.

Tests: threshold boundaries, highest-crossed selection, signature determinism/secret-dependence — 183 pass. Migration 0026 auto-applies on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52