### PR TITLE
feat: shared vs private memory spaces + seat role management (closes #264)

### DIFF
--- a/apps/mcp-server/src/__tests__/spaces.test.ts
+++ b/apps/mcp-server/src/__tests__/spaces.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { canAccessConversation, parseVisibility } from "../services/spaces.js";
+import type { AuthContext } from "../types.js";
+
+const seatAuth = (seatId: string | null): AuthContext => ({
+  organizationId: "org_1",
+  apiKeyId: "key_1",
+  tier: "team",
+  scopes: ["read", "write", "search", "delete"],
+  seatId,
+});
+
+describe("canAccessConversation (engram#264)", () => {
+  it("shared conversations are visible to everyone", () => {
+    expect(canAccessConversation(seatAuth("seat_a"), { visibility: "shared", seat_id: "seat_b" })).toBe(true);
+    expect(canAccessConversation(seatAuth(null), { visibility: "shared", seat_id: "seat_b" })).toBe(true);
+  });
+
+  it("legacy rows without visibility behave as shared", () => {
+    expect(canAccessConversation(seatAuth("seat_a"), {})).toBe(true);
+    expect(canAccessConversation(seatAuth("seat_a"), { visibility: null })).toBe(true);
+  });
+
+  it("private conversations are only visible to their seat", () => {
+    expect(canAccessConversation(seatAuth("seat_a"), { visibility: "private", seat_id: "seat_a" })).toBe(true);
+    expect(canAccessConversation(seatAuth("seat_b"), { visibility: "private", seat_id: "seat_a" })).toBe(false);
+    expect(canAccessConversation(seatAuth(null), { visibility: "private", seat_id: "seat_a" })).toBe(false);
+  });
+
+  it("owner-key private conversations (seat null) are private to owner keys", () => {
+    expect(canAccessConversation(seatAuth(null), { visibility: "private", seat_id: null })).toBe(true);
+    expect(canAccessConversation(seatAuth("seat_a"), { visibility: "private", seat_id: null })).toBe(false);
+  });
+
+  it("admin bypasses", () => {
+    const admin = { ...seatAuth(null), isAdmin: true };
+    expect(canAccessConversation(admin, { visibility: "private", seat_id: "seat_a" })).toBe(true);
+  });
+});
+
+describe("parseVisibility", () => {
+  it("accepts only valid values", () => {
+    expect(parseVisibility("shared")).toBe("shared");
+    expect(parseVisibility("private")).toBe("private");
+    expect(parseVisibility("public")).toBeUndefined();
+    expect(parseVisibility(undefined)).toBeUndefined();
+  });
+});

--- a/apps/mcp-server/src/mcp/tools/append-messages.ts
+++ b/apps/mcp-server/src/mcp/tools/append-messages.ts
@@ -21,6 +21,8 @@ import {
 } from "../../services/tier.js";
 import { fireWebhooks } from "../../services/webhooks.js";
 import { checkMilestone } from "../../services/milestones.js";
+import { canAccessConversation } from "../../services/spaces.js";
+import { getConversationById } from "@getengram/db";
 import { audit } from "../../services/audit.js";
 import { hasScope, scopeError } from "../scopes.js";
 import type { Env, AuthContext } from "../../types.js";
@@ -182,6 +184,21 @@ export function registerAppendMessages(
       const conversationId =
         params.conversation_id ??
         (await getOrCreateDefaultConversation(env.DB, auth.organizationId));
+
+      // Private-space enforcement (engram#264): appending into another
+      // seat's private conversation is refused as not-found.
+      if (params.conversation_id) {
+        const conv = await getConversationById(env.DB, params.conversation_id, auth.organizationId);
+        if (conv && !canAccessConversation(auth, conv as { visibility?: string | null; seat_id?: string | null })) {
+          await releaseStorage(env.DB, auth.organizationId, count);
+          return {
+            content: [
+              { type: "text" as const, text: JSON.stringify({ error: "Conversation not found" }) },
+            ],
+            isError: true,
+          };
+        }
+      }
 
       let messages;
       try {

--- a/apps/mcp-server/src/mcp/tools/create-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/create-conversation.ts
@@ -25,6 +25,10 @@ export function registerCreateConversation(
         agent_id: z.string().optional().describe("Agent identifier (e.g. \"chatgpt\")"),
         tags: z.array(z.string()).optional().describe("Tags for filtering"),
         metadata: z.record(z.unknown()).optional().describe("Arbitrary metadata"),
+        visibility: z
+          .enum(["shared", "private"])
+          .optional()
+          .describe("Team accounts: 'private' keeps this conversation visible only to the seat that created it. Default 'shared' (org-wide)."),
       },
       outputSchema: {
         conversation_id: z.string().describe("The id of the created conversation"),
@@ -82,7 +86,8 @@ export function registerCreateConversation(
         params.title,
         params.agent_id,
         params.tags,
-        params.metadata as Record<string, unknown>
+        params.metadata as Record<string, unknown>,
+        { seatId: auth.seatId, visibility: params.visibility }
       );
       const id = created.id;
 

--- a/apps/mcp-server/src/mcp/tools/delete-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/delete-conversation.ts
@@ -33,7 +33,8 @@ export function registerDeleteConversation(
       const deleted = await deleteConversation(
         env,
         auth.organizationId,
-        params.conversation_id
+        params.conversation_id,
+        auth
       );
 
       await audit(env.DB, auth.organizationId, auth.apiKeyId, "conversation.delete", "conversation", params.conversation_id);

--- a/apps/mcp-server/src/mcp/tools/get-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/get-conversation.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getConversation } from "../../services/conversation.js";
 import { audit } from "../../services/audit.js";
 import { loadPrivacy, PRIVACY_BODIES_NOTICE } from "../../services/privacy.js";
+import { canAccessConversation } from "../../services/spaces.js";
 import { hasScope, scopeError } from "../scopes.js";
 import type { Env, AuthContext } from "../../types.js";
 
@@ -79,7 +80,11 @@ export function registerGetConversation(
         params.message_offset
       );
 
-      if (!result) {
+      if (
+        !result ||
+        !canAccessConversation(auth, result.conversation as { visibility?: string | null; seat_id?: string | null })
+      ) {
+        // Private to another seat is indistinguishable from absent (engram#264).
         return {
           content: [
             {

--- a/apps/mcp-server/src/mcp/tools/list-conversations.ts
+++ b/apps/mcp-server/src/mcp/tools/list-conversations.ts
@@ -82,6 +82,8 @@ export function registerListConversations(
         tags: params.tags,
         sort: params.sort,
         order: params.order,
+        viewerSeatId: auth.seatId ?? null,
+        filterVisibility: true,
       });
 
       const conversations = (result.results as Array<Record<string, unknown>>).map(

--- a/apps/mcp-server/src/mcp/tools/search.ts
+++ b/apps/mcp-server/src/mcp/tools/search.ts
@@ -105,6 +105,7 @@ export function registerSearch(
         undefined, // minScore
         undefined, // dedupe
         params.project,
+        auth.seatId, // private-space filter (engram#264)
       );
 
       // When bodies are hidden, return the matching conversations'

--- a/apps/mcp-server/src/middleware/auth.ts
+++ b/apps/mcp-server/src/middleware/auth.ts
@@ -84,6 +84,7 @@ export async function authMiddleware(
     apiKeyId: row.key_id,
     tier: (row.tier ?? "free") as AuthContext["tier"],
     scopes: parseScopes(row.scopes),
+    seatId: row.seat_id ?? null,
   });
 
   // Update last_used_at non-blocking

--- a/apps/mcp-server/src/routes/memories.ts
+++ b/apps/mcp-server/src/routes/memories.ts
@@ -112,7 +112,7 @@ memories.get("/search", async (c) => {
     return c.json({ results: [], total: 0, privacy_notice: PRIVACY_CROSS_CONVERSATION_NOTICE });
   }
 
-  const raw = await searchConversations(c.env, auth.organizationId, query, limit);
+  const raw = await searchConversations(c.env, auth.organizationId, query, limit, undefined, undefined, undefined, undefined, undefined, undefined, auth.seatId);
   const results = privacy.canReadBodies
     ? raw
     : raw.map(({ chunk_text: _c, ...rest }) => rest);

--- a/apps/mcp-server/src/routes/seats.ts
+++ b/apps/mcp-server/src/routes/seats.ts
@@ -88,6 +88,50 @@ seats.post("/:id/accept", async (c) => {
   return c.json({ id: seatId, status: "accepted" });
 });
 
+// Update a seat's role (engram-web#92). Owner isn't assignable — it
+// belongs to the org account itself, not a seat.
+seats.patch("/:id", async (c) => {
+  const auth = c.get("auth");
+  const seatId = c.req.param("id");
+  const body = await c.req.json<{ role?: string }>().catch(() => ({}) as { role?: string });
+  if (body.role !== "admin" && body.role !== "member") {
+    return c.json({ error: "invalid_role", allowed: ["admin", "member"] }, 400);
+  }
+  const result = await c.env.DB.prepare(
+    "UPDATE seats SET role = ? WHERE id = ? AND organization_id = ?",
+  )
+    .bind(body.role, seatId, auth.organizationId)
+    .run();
+  if (result.meta?.changes === 0) return c.json({ error: "seat_not_found" }, 404);
+  return c.json({ id: seatId, role: body.role });
+});
+
+// Re-send an invite (engram#263): mint a fresh single-use token for a
+// still-pending seat. The caller (engram-web) emails the new link.
+seats.post("/:id/resend", async (c) => {
+  const auth = c.get("auth");
+  const seatId = c.req.param("id");
+  const seat = await c.env.DB.prepare(
+    "SELECT id, email, accepted_at FROM seats WHERE id = ? AND organization_id = ?",
+  )
+    .bind(seatId, auth.organizationId)
+    .first<{ id: string; email: string; accepted_at: string | null }>();
+  if (!seat) return c.json({ error: "seat_not_found" }, 404);
+  if (seat.accepted_at) return c.json({ error: "already_accepted" }, 409);
+
+  const tokenBytes = new Uint8Array(24);
+  crypto.getRandomValues(tokenBytes);
+  const inviteToken =
+    "inv_" + Array.from(tokenBytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  await c.env.DB.prepare(
+    "UPDATE seats SET invite_token_hash = ?, invited_at = datetime('now') WHERE id = ?",
+  )
+    .bind(await hashApiKey(inviteToken), seatId)
+    .run();
+
+  return c.json({ id: seatId, email: seat.email, invite_token: inviteToken });
+});
+
 // Remove a seat (and revoke its API keys)
 seats.delete("/:id", async (c) => {
   const auth = c.get("auth");

--- a/apps/mcp-server/src/routes/v1.ts
+++ b/apps/mcp-server/src/routes/v1.ts
@@ -27,6 +27,7 @@ import {
 import { fireWebhooks } from "../services/webhooks.js";
 import { audit } from "../services/audit.js";
 import { hasScope, type Scope } from "../mcp/scopes.js";
+import { canAccessConversation } from "../services/spaces.js";
 import { usageMeter } from "../mcp/usage-messaging.js";
 import type { Env, AuthContext } from "../types.js";
 import type { Context } from "hono";
@@ -64,6 +65,7 @@ const createConversationSchema = z.object({
   agent_id: z.string().optional(),
   tags: z.array(z.string()).optional(),
   metadata: z.record(z.unknown()).optional(),
+  visibility: z.enum(["shared", "private"]).optional(),
 });
 
 v1.post("/conversations", async (c) => {
@@ -99,6 +101,7 @@ v1.post("/conversations", async (c) => {
     parsed.data.agent_id,
     parsed.data.tags,
     parsed.data.metadata as Record<string, unknown>,
+    { seatId: auth.seatId, visibility: parsed.data.visibility },
   );
   if (created.existing) {
     // Idempotent import (engram#254): fingerprint matched — no new row.
@@ -152,6 +155,8 @@ v1.get("/conversations", async (c) => {
     tags: tagsParam ? tagsParam.split(",").map((t) => t.trim()).filter(Boolean) : undefined,
     sort,
     order,
+    viewerSeatId: auth.seatId ?? null,
+    filterVisibility: true,
   });
 
   const conversations = (result.results as Array<Record<string, unknown>>).map(
@@ -192,6 +197,10 @@ v1.get("/conversations/:id", async (c) => {
     messageOffset,
   );
   if (!result) return c.json({ error: "conversation_not_found" }, 404);
+  if (!canAccessConversation(auth, result.conversation as { visibility?: string | null; seat_id?: string | null })) {
+    // Private to another seat — indistinguishable from absent (engram#264).
+    return c.json({ error: "conversation_not_found" }, 404);
+  }
 
   // Strip internal fields and honor the org's privacy setting, exactly
   // like the MCP tool.
@@ -227,7 +236,7 @@ v1.delete("/conversations/:id", async (c) => {
   if (!hasScope(auth, "delete")) return scopeError(c, "delete");
 
   const conversationId = c.req.param("id");
-  const deleted = await deleteConversation(c.env, auth.organizationId, conversationId);
+  const deleted = await deleteConversation(c.env, auth.organizationId, conversationId, auth);
 
   await audit(c.env.DB, auth.organizationId, auth.apiKeyId, "conversation.delete", "conversation", conversationId, {
     source: "rest",
@@ -374,6 +383,7 @@ v1.get("/search", async (c) => {
     undefined, // minScore
     undefined, // dedupe
     project,
+    auth.seatId, // private-space filter (engram#264)
   );
   const results = privacy.canReadBodies
     ? raw

--- a/apps/mcp-server/src/services/conversation.ts
+++ b/apps/mcp-server/src/services/conversation.ts
@@ -26,7 +26,8 @@ import {
 import { generateEmbeddings } from "./embedding.js";
 import { releaseStorage } from "./tier.js";
 import { compressContent, decompressContent } from "../utils/compress.js";
-import type { Env } from "../types.js";
+import type { Env, AuthContext } from "../types.js";
+import { canAccessConversation } from "./spaces.js";
 
 export async function createConversation(
   db: D1Database,
@@ -34,10 +35,11 @@ export async function createConversation(
   title?: string,
   agentId?: string,
   tags?: string[],
-  metadata?: Record<string, unknown>
+  metadata?: Record<string, unknown>,
+  space?: { seatId?: string | null; visibility?: "shared" | "private" }
 ): Promise<string> {
   const created = await createConversationDedup(
-    db, organizationId, title, agentId, tags, metadata,
+    db, organizationId, title, agentId, tags, metadata, space,
   );
   return created.id;
 }
@@ -55,7 +57,8 @@ export async function createConversationDedup(
   title?: string,
   agentId?: string,
   tags?: string[],
-  metadata?: Record<string, unknown>
+  metadata?: Record<string, unknown>,
+  space?: { seatId?: string | null; visibility?: "shared" | "private" }
 ): Promise<{ id: string; existing: boolean; message_count: number }> {
   const fingerprint =
     typeof metadata?.import_fingerprint === "string" && metadata.import_fingerprint
@@ -75,7 +78,9 @@ export async function createConversationDedup(
     title ?? null,
     agentId ?? null,
     tags ?? [],
-    metadata ?? {}
+    metadata ?? {},
+    space?.seatId ?? null,
+    space?.visibility ?? "shared"
   );
   if (fingerprint) {
     await db
@@ -313,10 +318,16 @@ export async function getConversation(
 export async function deleteConversation(
   env: Env,
   organizationId: string,
-  conversationId: string
+  conversationId: string,
+  viewer?: AuthContext
 ): Promise<boolean> {
   const conv = await getConversationById(env.DB, conversationId, organizationId);
   if (!conv) return false;
+  // Private-space enforcement (engram#264): only the owning seat can
+  // delete a private conversation; report it as absent to others.
+  if (viewer && !canAccessConversation(viewer, conv as { visibility?: string | null; seat_id?: string | null })) {
+    return false;
+  }
 
   // Get vectorize IDs to delete from Vectorize
   const chunksResult = await getVectorizeIdsByConversation(

--- a/apps/mcp-server/src/services/search.ts
+++ b/apps/mcp-server/src/services/search.ts
@@ -59,7 +59,8 @@ export async function searchConversations(
   snippetChars: number = DEFAULT_SNIPPET_CHARS,
   minScore: number = DEFAULT_MIN_SCORE,
   dedupe: boolean = true,
-  project?: string
+  project?: string,
+  viewerSeatId?: string | null
 ): Promise<SearchResult[]> {
   const cappedSnippet = Math.min(
     Math.max(snippetChars, 0),
@@ -178,16 +179,30 @@ export async function searchConversations(
     string,
     { title: string; tags: string[]; updatedAt: string | null }
   >();
+  // Conversations the caller may NOT see (engram#264) — explicit
+  // blocklist so chunks with merely-missing metadata keep the legacy
+  // behavior of passing through.
+  const blockedConvIds = new Set<string>();
 
   if (uniqueConvIds.length > 0) {
     const placeholders = uniqueConvIds.map(() => "?").join(",");
     const rows = await env.DB.prepare(
-      `SELECT id, title, tags, updated_at FROM conversations WHERE id IN (${placeholders}) AND organization_id = ?`
+      `SELECT id, title, tags, updated_at, visibility, seat_id FROM conversations WHERE id IN (${placeholders}) AND organization_id = ?`
     )
       .bind(...uniqueConvIds, organizationId)
-      .all<{ id: string; title: string; tags: string; updated_at: string | null }>();
+      .all<{ id: string; title: string; tags: string; updated_at: string | null; visibility?: string | null; seat_id?: string | null }>();
 
     for (const row of rows.results) {
+      // Private-space enforcement (engram#264): a chunk whose
+      // conversation is private to a different seat is invisible to
+      // this caller.
+      if (
+        (row.visibility ?? "shared") === "private" &&
+        (row.seat_id ?? null) !== (viewerSeatId ?? null)
+      ) {
+        blockedConvIds.add(row.id);
+        continue;
+      }
       convMeta.set(row.id, {
         title: row.title,
         tags: row.tags ? JSON.parse(row.tags) : [],
@@ -204,6 +219,7 @@ export async function searchConversations(
     const chunk = chunkMap.get(chunkId);
     if (!chunk) continue;
     const meta = convMeta.get(chunk.conversation_id);
+    if (blockedConvIds.has(chunk.conversation_id)) continue; // private to another seat (engram#264)
     const titleHit =
       !!meta?.title &&
       terms.some((t) => meta.title.toLowerCase().includes(t));

--- a/apps/mcp-server/src/services/spaces.ts
+++ b/apps/mcp-server/src/services/spaces.ts
@@ -1,0 +1,34 @@
+import type { AuthContext } from "../types.js";
+
+/**
+ * Shared vs private memory spaces (engram#264).
+ *
+ * Model: every conversation is 'shared' (org-wide — the default and the
+ * pre-#264 behavior) or 'private' to the seat that created it. Owner
+ * keys and OAuth connections have no seat (seatId null); their private
+ * conversations carry seat_id NULL, so "same identity" means seat ids
+ * match including the null case. Org data export remains org-wide (the
+ * account owner's GDPR surface).
+ */
+
+export interface ConversationVisibilityRow {
+  visibility?: string | null;
+  seat_id?: string | null;
+}
+
+export function canAccessConversation(
+  auth: AuthContext,
+  conv: ConversationVisibilityRow,
+): boolean {
+  if (auth.isAdmin) return true;
+  if ((conv.visibility ?? "shared") !== "private") return true;
+  return (conv.seat_id ?? null) === (auth.seatId ?? null);
+}
+
+/** Normalize + validate a requested visibility value. */
+export function parseVisibility(
+  value: unknown,
+): "shared" | "private" | undefined {
+  if (value === "shared" || value === "private") return value;
+  return undefined;
+}

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -29,4 +29,7 @@ export interface AuthContext {
   scopes: Scope[];
   /** True when authenticated via ADMIN_SECRET — grants cross-org visibility. */
   isAdmin?: boolean;
+  /** Seat the API key is bound to (engram#264) — null for owner keys and
+   * OAuth connections. Drives private-memory visibility. */
+  seatId?: string | null;
 }

--- a/packages/db/migrations/0027_memory_spaces.sql
+++ b/packages/db/migrations/0027_memory_spaces.sql
@@ -1,0 +1,7 @@
+-- Shared vs private memory spaces (engram#264): conversations remember
+-- which seat created them and whether they're team-shared (default,
+-- today's behavior) or private to that seat.
+ALTER TABLE conversations ADD COLUMN seat_id TEXT;
+ALTER TABLE conversations ADD COLUMN visibility TEXT NOT NULL DEFAULT 'shared';
+CREATE INDEX IF NOT EXISTS idx_conversations_org_visibility
+  ON conversations(organization_id, visibility);

--- a/packages/db/src/queries/api-keys.ts
+++ b/packages/db/src/queries/api-keys.ts
@@ -31,7 +31,7 @@ export function getApiKeyByHash(db: D1Database, keyHash: string) {
 export function getApiKeyWithOrg(db: D1Database, keyHash: string) {
   return db
     .prepare(
-      `SELECT k.id AS key_id, k.organization_id, k.scopes, o.tier
+      `SELECT k.id AS key_id, k.organization_id, k.scopes, k.seat_id, o.tier
        FROM api_keys k
        JOIN organizations o ON o.id = k.organization_id
        WHERE k.key_hash = ?
@@ -39,7 +39,7 @@ export function getApiKeyWithOrg(db: D1Database, keyHash: string) {
          AND (k.expires_at IS NULL OR k.expires_at > datetime('now'))`
     )
     .bind(keyHash)
-    .first<{ key_id: string; organization_id: string; scopes: string; tier: string }>();
+    .first<{ key_id: string; organization_id: string; scopes: string; seat_id: string | null; tier: string }>();
 }
 
 export function updateApiKeyLastUsed(db: D1Database, id: string) {

--- a/packages/db/src/queries/conversations.ts
+++ b/packages/db/src/queries/conversations.ts
@@ -5,16 +5,18 @@ export function insertConversation(
   title: string | null,
   agentId: string | null,
   tags: string[],
-  metadata: Record<string, unknown>
+  metadata: Record<string, unknown>,
+  seatId: string | null = null,
+  visibility: "shared" | "private" = "shared"
 ) {
   // Insert the row, bump the denormalized org counter (engram#41), and populate
   // the conversation_tags junction index (engram#42) — all atomically.
   const statements = [
     db
       .prepare(
-        "INSERT INTO conversations (id, organization_id, title, agent_id, tags, metadata) VALUES (?, ?, ?, ?, ?, ?)"
+        "INSERT INTO conversations (id, organization_id, title, agent_id, tags, metadata, seat_id, visibility) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
       )
-      .bind(id, organizationId, title, agentId, JSON.stringify(tags), JSON.stringify(metadata)),
+      .bind(id, organizationId, title, agentId, JSON.stringify(tags), JSON.stringify(metadata), seatId, visibility),
     db
       .prepare(
         "UPDATE organizations SET conversation_count = conversation_count + 1 WHERE id = ?"
@@ -70,10 +72,23 @@ export function listConversations(
     tags?: string[];
     sort: string;
     order: string;
+    /** Seat of the caller (engram#264): private conversations belonging
+     * to other seats are hidden. Omit to skip filtering (admin/export). */
+    viewerSeatId?: string | null;
+    filterVisibility?: boolean;
   }
 ) {
   let sql = "SELECT * FROM conversations WHERE organization_id = ?";
   const params: unknown[] = [organizationId];
+
+  if (opts.filterVisibility) {
+    if (opts.viewerSeatId) {
+      sql += " AND (visibility != 'private' OR seat_id = ?)";
+      params.push(opts.viewerSeatId);
+    } else {
+      sql += " AND (visibility != 'private' OR seat_id IS NULL)";
+    }
+  }
 
   if (opts.agentId) {
     sql += " AND agent_id = ?";


### PR DESCRIPTION
Memory spaces (engram#264):
- conversations gain seat_id (creator) + visibility ('shared' default —
  today's behavior — or 'private'); migration 0027.
- AuthContext carries the key's seat (api_keys.seat_id via auth); owner
  keys and OAuth connections have no seat.
- create_conversation (MCP + REST) accepts visibility; private
  conversations are visible ONLY to the creating seat: enforced in
  get/list/delete/append (indistinguishable from absent) and in search
  (hydration-stage blocklist — legacy metadata-less chunks unaffected).
  Admin retains cross-org visibility; org data export stays org-wide.

Seat management (engram-web#92 worker half):
- PATCH /api/seats/:id {role: admin|member}
- POST /api/seats/:id/resend — fresh single-use invite token for
  pending seats (engram-web emails the new link).

189 tests pass incl. new access-matrix coverage (shared/private ×
seat/owner/admin, legacy rows).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
