### PR TITLE
feat(cli): multi-host capture framework + Codex adapter (closes #261, #260)

### DIFF
--- a/apps/cli/src/__tests__/codex-parser.test.ts
+++ b/apps/cli/src/__tests__/codex-parser.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { CodexParser } from "../daemon/codex-parser.js";
+import type { ParsedMessage, SessionMeta } from "../daemon/types.js";
+
+const PATH =
+  "/Users/x/.codex/sessions/2026/07/23/rollout-2026-07-23T04-46-50-019f8e95-d0a3-70f3-88af-5f96100f86be.jsonl";
+
+function run(lines: object[], filePath = PATH) {
+  const out: { sessionId: string; meta: SessionMeta; messages: ParsedMessage[] }[] = [];
+  const parser = new CodexParser((sessionId, meta, messages) =>
+    out.push({ sessionId, meta, messages }),
+  );
+  for (const l of lines) parser.processLine(JSON.stringify(l), filePath);
+  parser.flush();
+  return out;
+}
+
+const sessionMeta = {
+  type: "session_meta",
+  payload: { session_id: "sess-1", id: "sess-1" },
+};
+const turnCtx = { type: "turn_context", payload: { turn_id: "t1", cwd: "/work/proj" } };
+const userMsg = (t: string) => ({
+  type: "response_item",
+  payload: { type: "message", role: "user", content: [{ type: "input_text", text: t }] },
+});
+const asstMsg = (t: string) => ({
+  type: "response_item",
+  payload: { type: "message", role: "assistant", content: [{ type: "text", text: t }] },
+});
+
+describe("CodexParser (engram#261)", () => {
+  it("extracts user + assistant messages with session id, cwd, and host", () => {
+    const out = run([sessionMeta, turnCtx, userMsg("hello"), asstMsg("hi there")]);
+    expect(out.map((o) => o.messages[0])).toEqual([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+    ]);
+    expect(out[0].sessionId).toBe("sess-1");
+    expect(out[0].meta.host).toBe("codex");
+    expect(out[1].meta.cwd).toBe("/work/proj");
+  });
+
+  it("skips developer/tool roles and Codex's injected context blocks", () => {
+    const out = run([
+      sessionMeta,
+      { type: "response_item", payload: { type: "message", role: "developer", content: [{ text: "sys" }] } },
+      userMsg("<environment_context>\ncwd: /x"),
+      userMsg("<recommended_plugins>\n- foo"),
+      userMsg("a real question"),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].messages[0].content).toBe("a real question");
+  });
+
+  it("skips non-message record types (event_msg, world_state)", () => {
+    const out = run([
+      sessionMeta,
+      { type: "event_msg", payload: { type: "task_started" } },
+      { type: "world_state", payload: { full: true } },
+      asstMsg("done"),
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it("falls back to the uuid in the filename when session_meta is missing (mid-file read)", () => {
+    const out = run([userMsg("mid-file start")]);
+    expect(out[0].sessionId).toBe("019f8e95-d0a3-70f3-88af-5f96100f86be");
+  });
+});

--- a/apps/cli/src/daemon/adapters.ts
+++ b/apps/cli/src/daemon/adapters.ts
@@ -1,0 +1,40 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { HostAdapter, OnMessages } from "./types.js";
+import { Parser } from "./parser.js";
+import { CodexParser } from "./codex-parser.js";
+
+// Registry of capturable hosts (engram#261). Add a host by adding an
+// adapter here — the watcher, syncer, and status are all host-agnostic.
+
+const claudeCodeAdapter: HostAdapter = {
+  id: "claude-code",
+  label: "Claude Code",
+  watchDir: join(homedir(), ".claude", "projects"),
+  available() {
+    return existsSync(this.watchDir);
+  },
+  createParser(onMessages: OnMessages) {
+    return new Parser(onMessages);
+  },
+};
+
+const codexAdapter: HostAdapter = {
+  id: "codex",
+  label: "Codex CLI",
+  watchDir: join(homedir(), ".codex", "sessions"),
+  available() {
+    return existsSync(this.watchDir);
+  },
+  createParser(onMessages: OnMessages) {
+    return new CodexParser(onMessages);
+  },
+};
+
+export const ALL_ADAPTERS: HostAdapter[] = [claudeCodeAdapter, codexAdapter];
+
+/** Adapters whose host is actually installed on this machine. */
+export function availableAdapters(): HostAdapter[] {
+  return ALL_ADAPTERS.filter((a) => a.available());
+}

--- a/apps/cli/src/daemon/codex-parser.ts
+++ b/apps/cli/src/daemon/codex-parser.ts
@@ -1,0 +1,88 @@
+import type { LineParser, OnMessages, SessionMeta, ParsedMessage } from "./types.js";
+
+// Codex writes one complete JSON object per line to
+// ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl. Unlike Claude Code
+// (one line per content block), each Codex line is self-contained, so
+// no cross-line accumulation is needed (engram#261 / #260).
+
+interface RolloutLine {
+  type?: string; // session_meta | response_item | event_msg | turn_context | ...
+  payload?: {
+    type?: string; // for response_item: "message"
+    role?: string; // user | assistant | developer | tool
+    content?: Array<{ text?: string; input_text?: string }>;
+    session_id?: string;
+    id?: string;
+    cwd?: string;
+  };
+}
+
+// Codex injects its own context blocks as "user" messages — skip them.
+const CONTEXT_PREFIX = /^<(environment_context|recommended_plugins|user_instructions)/;
+
+/**
+ * Parses Codex CLI rollout JSONL into Engram messages.
+ * Emits per completed user/assistant message (one line = one message).
+ */
+export class CodexParser implements LineParser {
+  private onMessages: OnMessages;
+  private sessionId: string | null = null;
+  private cwd: string | undefined;
+
+  constructor(onMessages: OnMessages) {
+    this.onMessages = onMessages;
+  }
+
+  processLine(line: string, filePath: string): void {
+    let data: RolloutLine;
+    try {
+      data = JSON.parse(line);
+    } catch {
+      return;
+    }
+    const p = data.payload ?? {};
+
+    if (data.type === "session_meta") {
+      this.sessionId = p.session_id ?? p.id ?? this.sessionId;
+      return;
+    }
+    if (data.type === "turn_context" && p.cwd) {
+      this.cwd = p.cwd;
+      return;
+    }
+    if (data.type !== "response_item" || p.type !== "message") return;
+
+    const role = p.role;
+    if (role !== "user" && role !== "assistant") return; // skip developer/system/tool
+
+    const text = (p.content ?? [])
+      .map((c) => c.text ?? c.input_text ?? "")
+      .join("")
+      .trim();
+    if (!text || CONTEXT_PREFIX.test(text)) return;
+
+    // Fall back to the rollout filename's uuid if session_meta wasn't seen
+    // (offset-based reads can start mid-file).
+    const sessionId = this.sessionId ?? this.sessionIdFromPath(filePath);
+    if (!sessionId) return;
+
+    const meta: SessionMeta = {
+      sessionId,
+      cwd: this.cwd,
+      projectDir: this.cwd ?? "",
+      host: "codex",
+    };
+    const message: ParsedMessage = { role, content: text };
+    this.onMessages(sessionId, meta, [message]);
+  }
+
+  flush(): void {
+    // No buffering — each line emits immediately.
+  }
+
+  /** rollout-2026-07-23T04-46-50-<uuid>.jsonl → <uuid> */
+  private sessionIdFromPath(filePath: string): string | null {
+    const m = filePath.match(/rollout-[\dT-]+-([0-9a-f-]{36})\.jsonl$/i);
+    return m ? m[1] : null;
+  }
+}

--- a/apps/cli/src/daemon/commands.ts
+++ b/apps/cli/src/daemon/commands.ts
@@ -12,6 +12,18 @@ import { join, resolve } from "node:path";
 import { bold, dim, red } from "../output.js";
 import { DaemonDb } from "./db.js";
 import { readStatus, type SyncStatus } from "./status.js";
+import { ALL_ADAPTERS } from "./adapters.js";
+
+/** Render the per-host capture status (engram#261). */
+function printHostStatus(): void {
+  console.log(`${dim("Hosts:")}`);
+  for (const a of ALL_ADAPTERS) {
+    const on = a.available();
+    const mark = on ? "✓" : "·";
+    const state = on ? "capturing" : "not installed";
+    console.log(`  ${mark} ${a.label.padEnd(14)} ${dim(state)}`);
+  }
+}
 
 const ENGRAM_DIR = join(homedir(), ".engram");
 const PID_FILE = join(ENGRAM_DIR, "daemon.pid");
@@ -171,6 +183,8 @@ export async function daemonStatus(): Promise<void> {
     console.log(`${dim("Pending sync:")}      ${stats.pendingMessages} messages`);
     console.log(`${dim("Files tracked:")}     ${stats.trackedFiles}`);
   }
+
+  printHostStatus();
 
   // Show sync health warnings
   const syncStatus = readStatus();

--- a/apps/cli/src/daemon/parser.ts
+++ b/apps/cli/src/daemon/parser.ts
@@ -1,4 +1,4 @@
-import type { ParsedMessage, SessionMeta } from "./types.js";
+import type { ParsedMessage, SessionMeta, OnMessages, LineParser } from "./types.js";
 
 // Line types we skip entirely
 const SKIP_TYPES = new Set([
@@ -41,12 +41,6 @@ interface PendingAssistant {
   toolUses: { name: string; input: unknown }[];
 }
 
-export type OnMessages = (
-  sessionId: string,
-  meta: SessionMeta,
-  messages: ParsedMessage[],
-) => void;
-
 /**
  * Parses Claude Code JSONL transcript lines into Engram messages.
  *
@@ -55,7 +49,7 @@ export type OnMessages = (
  * accumulate blocks and flush when the message is complete (stop_reason
  * is set) or a new message begins.
  */
-export class Parser {
+export class Parser implements LineParser {
   private pending: PendingAssistant | null = null;
   private lastSessionId: string | null = null;
   private lastMeta: SessionMeta | null = null;
@@ -88,6 +82,7 @@ export class Parser {
       gitBranch: data.gitBranch,
       projectDir,
       version: data.version,
+      host: "claude-code",
     };
     this.lastSessionId = sessionId;
     this.lastMeta = meta;

--- a/apps/cli/src/daemon/syncer.ts
+++ b/apps/cli/src/daemon/syncer.ts
@@ -233,14 +233,18 @@ export class Syncer {
     sessionId: string,
     meta: SessionMeta,
   ): Promise<string> {
-    const title = `${meta.projectDir} (${new Date().toISOString().slice(0, 16).replace("T", " ")})`;
+    const host = meta.host ?? "claude-code";
+    const title = `${meta.projectDir || host} (${new Date().toISOString().slice(0, 16).replace("T", " ")})`;
 
     const { conversationId } = await this.client.createConversation({
       title,
-      agentId: "claude-code",
-      tags: ["claude-code", "auto-capture"],
+      // Per-host tagging (engram#261) so captures are attributable and
+      // filterable by source tool.
+      agentId: host,
+      tags: [host, "auto-capture"],
       metadata: {
         sessionId,
+        host,
         projectDir: meta.projectDir,
         cwd: meta.cwd,
         gitBranch: meta.gitBranch,

--- a/apps/cli/src/daemon/types.ts
+++ b/apps/cli/src/daemon/types.ts
@@ -7,13 +7,51 @@ export interface ParsedMessage {
   metadata?: Record<string, unknown>;
 }
 
-/** Metadata extracted from the first line of a Claude Code session. */
+/** Metadata extracted from a captured session (any host). */
 export interface SessionMeta {
   sessionId: string;
   cwd?: string;
   gitBranch?: string;
   projectDir: string;
   version?: string;
+  /** Host that produced the session (engram#261): "claude-code", "codex". */
+  host?: string;
+}
+
+/** Emits fully-parsed messages for a session as they complete. */
+export type OnMessages = (
+  sessionId: string,
+  meta: SessionMeta,
+  messages: ParsedMessage[],
+) => void;
+
+/**
+ * A per-line transcript parser for one host format (engram#261). The
+ * watcher feeds it complete lines from a session file; it emits messages
+ * via the OnMessages callback it was constructed with.
+ */
+export interface LineParser {
+  processLine(line: string, filePath: string): void;
+  /** Flush any buffered partial message (e.g. a multi-block assistant turn). */
+  flush(): void;
+}
+
+/**
+ * A capturable host (engram#261). Each adapter knows where its host
+ * writes session transcripts and how to parse them. New hosts plug in
+ * by adding an adapter — the watcher/syncer are host-agnostic.
+ */
+export interface HostAdapter {
+  /** Stable id, used as the conversation agent_id + tag. */
+  id: string;
+  /** Human label for status output. */
+  label: string;
+  /** Directory watched recursively for *.jsonl session files. */
+  watchDir: string;
+  /** True when this host is actually installed (watchDir exists). */
+  available(): boolean;
+  /** Build a parser bound to this sync callback. */
+  createParser(onMessages: OnMessages): LineParser;
 }
 
 /** Row from the pending_messages table. */

--- a/apps/cli/src/daemon/watcher.ts
+++ b/apps/cli/src/daemon/watcher.ts
@@ -1,24 +1,26 @@
 import { watch, type FSWatcher } from "chokidar";
 import { openSync, readSync, closeSync, statSync } from "node:fs";
 import { DaemonDb } from "./db.js";
-import { Parser } from "./parser.js";
-import type { OnMessages } from "./parser.js";
+import type { OnMessages, LineParser, HostAdapter } from "./types.js";
 
 /**
- * Watches ~/.claude/projects/ for JSONL transcript files and feeds new
- * lines to the parser. Uses byte-offset tracking so it never re-reads
- * already-processed content, even after daemon restart.
+ * Watches one host's session directory for JSONL files and feeds new
+ * lines to that host's parser (engram#261). Uses byte-offset tracking so
+ * it never re-reads already-processed content, even after daemon
+ * restart. One Watcher per host adapter.
  */
 export class Watcher {
   private db: DaemonDb;
-  private parser: Parser;
+  private parser: LineParser;
   private fsWatcher: FSWatcher | null = null;
   private watchDir: string;
+  readonly host: string;
 
-  constructor(db: DaemonDb, onMessages: OnMessages, watchDir: string) {
+  constructor(db: DaemonDb, onMessages: OnMessages, adapter: HostAdapter) {
     this.db = db;
-    this.parser = new Parser(onMessages);
-    this.watchDir = watchDir;
+    this.parser = adapter.createParser(onMessages);
+    this.watchDir = adapter.watchDir;
+    this.host = adapter.id;
   }
 
   start(): void {
@@ -37,7 +39,9 @@ export class Watcher {
       persistent: true,
       ignoreInitial: false,
       awaitWriteFinish: { stabilityThreshold: 500, pollInterval: 100 },
-      depth: 3,
+      // Claude nests ~2 (projects/<proj>/file); Codex nests 4
+      // (sessions/YYYY/MM/DD/file). Cover both (engram#261).
+      depth: 6,
     });
 
     this.fsWatcher.on("add", (path) => this.processFile(path));

--- a/apps/cli/src/daemon/worker.ts
+++ b/apps/cli/src/daemon/worker.ts
@@ -13,12 +13,12 @@ import { loadConfig, getBaseUrl } from "../config.js";
 import { DaemonDb } from "./db.js";
 import { Watcher } from "./watcher.js";
 import { Syncer } from "./syncer.js";
+import { availableAdapters } from "./adapters.js";
 
 const ENGRAM_DIR = join(homedir(), ".engram");
 const PID_FILE = join(ENGRAM_DIR, "daemon.pid");
 const DB_FILE = join(ENGRAM_DIR, "daemon.db");
 const LOG_FILE = join(ENGRAM_DIR, "daemon.log");
-const CLAUDE_PROJECTS_DIR = join(homedir(), ".claude", "projects");
 
 function log(msg: string): void {
   const ts = new Date().toISOString();
@@ -31,7 +31,6 @@ async function main(): Promise<void> {
   writeFileSync(PID_FILE, String(process.pid));
 
   log(`daemon started (pid ${process.pid})`);
-  log(`watching: ${CLAUDE_PROJECTS_DIR}`);
   log(`database: ${DB_FILE}`);
 
   // Load API key
@@ -62,18 +61,27 @@ async function main(): Promise<void> {
     });
   };
 
-  const watcher = new Watcher(db, onMessages, CLAUDE_PROJECTS_DIR);
+  // One watcher per installed host (engram#261). Hosts that aren't
+  // installed are skipped, so this is safe on any machine.
+  const adapters = availableAdapters();
+  if (adapters.length === 0) {
+    log("no supported hosts detected (Claude Code, Codex). Nothing to watch.");
+  }
+  const watchers = adapters.map((a) => {
+    log(`watching ${a.label}: ${a.watchDir}`);
+    return new Watcher(db, onMessages, a);
+  });
 
   // Start
-  watcher.start();
+  for (const w of watchers) w.start();
   syncer.startFlushLoop();
 
-  log("watching for transcripts...");
+  log(`watching for transcripts across ${watchers.length} host(s)...`);
 
   // Graceful shutdown
   const shutdown = async () => {
     log("shutting down...");
-    watcher.stop();
+    for (const w of watchers) w.stop();
     syncer.stopFlushLoop();
 
     // Final flush


### PR DESCRIPTION
The daemon was hardcoded to watch ~/.claude/projects. Generalized it
into a host-adapter framework so any tool that writes local session
transcripts can be auto-captured verbatim — the activation lever
(effortless capture → accumulated memory → conversion).

- HostAdapter interface (id, label, watchDir, available(), createParser)
  + LineParser interface; registry in adapters.ts.
- Claude Code parser now implements LineParser and tags host
  "claude-code"; behavior unchanged.
- Codex adapter + CodexParser: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
  (research #260). Handles the deeper nesting (watcher depth 3→6), skips
  developer/tool roles and Codex's injected <environment_context> /
  <recommended_plugins> blocks, falls back to the filename uuid on
  mid-file reads.
- Watcher takes an adapter; worker runs one watcher per *installed* host
  (skips absent ones); syncer tags conversations per host (agent_id +
  tags) instead of always "claude-code".
- `engram status` shows per-host capture state.

27 CLI tests (4 new Codex-parser) + 189 worker tests pass. Claude Code
capture is unchanged; Codex is additive and only active when installed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
