### PR TITLE
fix: import-nudge respects opt-out + carries an unsubscribe link

### DIFF
--- a/apps/mcp-server/src/cron/import-nudge.ts
+++ b/apps/mcp-server/src/cron/import-nudge.ts
@@ -13,27 +13,37 @@ import type { Env } from "../types.js";
  */
 export async function sendImportNudges(env: Env): Promise<number> {
   if (!env.APP_URL) return 0;
+  const secret = (env as Env & { ADMIN_SECRET?: string }).ADMIN_SECRET;
+  if (!secret) return 0;
 
   const idle = await env.DB.prepare(
     `SELECT id, name, email FROM organizations
      WHERE deleted_at IS NULL
        AND email IS NOT NULL
        AND messages_stored_total <= 1
+       AND digest_opt_out = 0
        AND created_at <= datetime('now', '-3 days')
        AND created_at > datetime('now', '-4 days')
      LIMIT 100`,
   ).all<{ id: string; name: string; email: string }>();
 
+  const { unsubscribeSig } = await import("./weekly-digest.js");
+
   let sent = 0;
   for (const org of idle.results ?? []) {
     try {
+      const sig = await unsubscribeSig(org.id, secret);
       const res = await fetch(`${env.APP_URL}/api/email/import-nudge`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${(env as Env & { ADMIN_SECRET: string }).ADMIN_SECRET}`,
+          Authorization: `Bearer ${secret}`,
         },
-        body: JSON.stringify({ to: org.email, name: org.name }),
+        body: JSON.stringify({
+          to: org.email,
+          name: org.name,
+          unsubscribe_url: `https://mcp.getengram.app/email/unsubscribe?org=${encodeURIComponent(org.id)}&sig=${sig}`,
+        }),
       });
       if (res.ok) sent++;
     } catch (err) {


### PR DESCRIPTION
The nudge cron didn't check digest_opt_out and its email had no
unsubscribe — the digest already had both. Now it skips opted-out orgs
and passes the same signed one-click unsubscribe URL so one opt-out
covers both recurring lifecycle emails. Transactional emails (welcome,
payment reminder, invite) intentionally excluded — those are account
messages, not marketing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
