### PR TITLE
feat(cron): maxout upgrade nudge for free orgs at the storage cap

### DIFF
--- a/apps/mcp-server/src/cron/maxout-nudge.ts
+++ b/apps/mcp-server/src/cron/maxout-nudge.ts
@@ -1,0 +1,67 @@
+import { TIER_LIMITS } from "@getengram/shared";
+import type { Env } from "../types.js";
+
+/**
+ * Maxout upgrade nudge: free orgs that have filled their lifetime memory
+ * (messages_stored_total ≥ the free tier's 10,000-message storage cap) get
+ * one email letting them know they're full and offering Pro. The /pricing
+ * link carries ?ref=maxout for attribution, and we stamp maxout_nudged_at so
+ * the org is never emailed twice — and so we can later measure conversions.
+ *
+ * Runs on the daily cron alongside the import nudge. Respects the same
+ * digest_opt_out unsubscribe flag as the other lifecycle emails.
+ */
+export async function sendMaxoutNudges(env: Env): Promise<number> {
+  if (!env.APP_URL) return 0;
+  const secret = (env as Env & { ADMIN_SECRET?: string }).ADMIN_SECRET;
+  if (!secret) return 0;
+
+  const freeLimit = TIER_LIMITS.free.storage_messages;
+
+  const maxed = await env.DB.prepare(
+    `SELECT id, name, email FROM organizations
+     WHERE deleted_at IS NULL
+       AND email IS NOT NULL
+       AND tier = 'free'
+       AND messages_stored_total >= ?
+       AND maxout_nudged_at IS NULL
+       AND digest_opt_out = 0
+     LIMIT 100`,
+  )
+    .bind(freeLimit)
+    .all<{ id: string; name: string; email: string }>();
+
+  const { unsubscribeSig } = await import("./weekly-digest.js");
+
+  let sent = 0;
+  for (const org of maxed.results ?? []) {
+    try {
+      const sig = await unsubscribeSig(org.id, secret);
+      const res = await fetch(`${env.APP_URL}/api/email/maxout-nudge`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${secret}`,
+        },
+        body: JSON.stringify({
+          to: org.email,
+          name: org.name,
+          unsubscribe_url: `https://mcp.getengram.app/email/unsubscribe?org=${encodeURIComponent(org.id)}&sig=${sig}`,
+        }),
+      });
+      if (res.ok) {
+        // Stamp only after a successful send so a transient failure retries
+        // on the next daily run instead of silently skipping the org.
+        await env.DB.prepare(
+          "UPDATE organizations SET maxout_nudged_at = datetime('now') WHERE id = ?",
+        )
+          .bind(org.id)
+          .run();
+        sent++;
+      }
+    } catch (err) {
+      console.error(`[maxout-nudge] Failed for ${org.email}:`, err);
+    }
+  }
+  return sent;
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -24,6 +24,7 @@ import { purgeDeletedOrganizations } from "./cron/purge-deleted.js";
 import { expireGracePeriods } from "./cron/expire-grace.js";
 import { enforceRetentionPolicies } from "./cron/retention-policy.js";
 import { sendImportNudges } from "./cron/import-nudge.js";
+import { sendMaxoutNudges } from "./cron/maxout-nudge.js";
 import { sendWeeklyDigests } from "./cron/weekly-digest.js";
 import { sendDailyReport } from "./services/daily-report.js";
 import { oauth } from "./oauth/router.js";
@@ -257,6 +258,11 @@ export default {
     const nudged = await sendImportNudges(env);
     if (nudged > 0) {
       console.log(`[cron] Sent ${nudged} import-nudge email(s)`);
+    }
+    // Maxout upgrade nudge: free orgs that filled their 10k-message memory.
+    const maxout = await sendMaxoutNudges(env);
+    if (maxout > 0) {
+      console.log(`[cron] Sent ${maxout} maxout-nudge email(s)`);
     }
   },
 };

--- a/packages/db/migrations/0028_maxout_nudge.sql
+++ b/packages/db/migrations/0028_maxout_nudge.sql
@@ -1,0 +1,5 @@
+-- Maxout nudge: one upgrade email per free org that hits the 10,000-message
+-- storage ceiling (the free tier's storage_messages cap). Stamped with the
+-- send time so the daily cron never emails the same org twice, and so we can
+-- later measure how many nudged orgs converted to Pro.
+ALTER TABLE organizations ADD COLUMN maxout_nudged_at TEXT;


### PR DESCRIPTION
The worker half of the maxed-out upgrade nudge (pairs with get-engram/engram-web#147).

## What
A daily cron finds free orgs that have filled their memory — `messages_stored_total ≥ TIER_LIMITS.free.storage_messages` (10,000) — and sends one upgrade email each via engram-web's `/api/email/maxout-nudge`.

- **`migration 0028`** — adds `organizations.maxout_nudged_at`.
- **`cron/maxout-nudge.ts`** — `sendMaxoutNudges()`: queries eligible orgs (free, at/over cap, not yet nudged, `digest_opt_out = 0`), sends, then **stamps `maxout_nudged_at` only on a successful send** so a transient failure retries next day rather than silently skipping. Once per org.
- **`index.ts`** — runs on the daily cron right after the import nudge.

## Attribution
The email's `/pricing?ref=maxout` link tags clicks; the `maxout_nudged_at` stamp lets us later measure how many nudged orgs converted to Pro.

## Verification
`tsc --noEmit`, `pnpm test` (189 passing), and `wrangler build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)