### PR TITLE
chore: bump CLI to v0.4.0 — ship the secrets vault

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getengram/cli",
-  "version": "0.3.4",
-  "description": "CLI for Engram — persistent memory for AI agents",
+  "version": "0.4.0",
+  "description": "CLI for Engram \u2014 persistent memory for AI agents",
   "type": "module",
   "bin": {
     "engram": "./dist/index.js"


### PR DESCRIPTION
The vault (client-side encrypted, zero-knowledge) shipped in #141 but the CLI version was never bumped past 0.3.4, so it never reached users. This bumps to 0.4.0.

**Published to npm this session:**
- `@getengram/sdk@0.2.0` (adds vault: VaultManager, generateVaultKey)
- `@getengram/cli@0.4.0` (vault keygen/status/set/get/list/delete)

Verified a fresh `npm i @getengram/cli@0.4.0` on Node 20 runs the vault commands (keygen produces a real client-side key).

**Homebrew:** the tap formula is temporarily kept at 0.3.4 because Homebrew's ~24h `min-release-age` guard rejects the just-published npm tarballs (hard error on install). It'll be re-bumped to 0.4.0 (url `cli-0.4.0.tgz`, sha256 `fb8e86057828b56bfae231a0c0f7c2d81e521db4ea3fa995dfd12757ea4fb551`) once the packages age past the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)