### PR TITLE
fix: usage bars show a minimum tick for nonzero usage

### DIFF
--- a/apps/cli/src/__tests__/cli.test.ts
+++ b/apps/cli/src/__tests__/cli.test.ts
@@ -187,6 +187,12 @@ describe("usage bars", () => {
     expect(renderBar(10_000, 10_000)).toBe("[████████████████████] 100%");
     expect(renderBar(20_000, 10_000)).toBe("[████████████████████] 100%");
   });
+
+  it("shows at least one filled segment for any nonzero usage", async () => {
+    const { renderBar } = await import("../commands/usage.js");
+    expect(renderBar(1, 10_000)).toBe("[█░░░░░░░░░░░░░░░░░░░]   0%");
+    expect(renderBar(65, 10_000)).toBe("[█░░░░░░░░░░░░░░░░░░░]   1%");
+  });
 });
 
 describe("import fingerprints (engram#254)", () => {

--- a/apps/cli/src/commands/usage.ts
+++ b/apps/cli/src/commands/usage.ts
@@ -6,7 +6,10 @@ const API_URL = process.env.ENGRAM_BASE_URL ?? getBaseUrl();
 /** Render a progress bar like "[████████████░░░░░░░░] 62%". Exported for tests. */
 export function renderBar(used: number, limit: number, width = 20): string {
   const pct = limit > 0 ? Math.min(100, Math.round((used / limit) * 100)) : 0;
-  const filled = Math.min(width, Math.round((pct / 100) * width));
+  // Any nonzero usage shows at least one filled segment so the bar never
+  // reads as empty (an all-░ bar renders as a blank grey pill in many fonts).
+  const minFilled = used > 0 && limit > 0 ? 1 : 0;
+  const filled = Math.max(minFilled, Math.min(width, Math.round((pct / 100) * width)));
   return `[${"█".repeat(filled)}${"░".repeat(width - filled)}] ${String(pct).padStart(3)}%`;
 }
 

--- a/apps/mcp-server/src/__tests__/storage-cap.test.ts
+++ b/apps/mcp-server/src/__tests__/storage-cap.test.ts
@@ -70,6 +70,9 @@ describe("storage messaging", () => {
   it("meterBar renders a 10-segment bar with percentage", () => {
     expect(meterBar(8_200, 10_000)).toBe("[████████░░] 82%");
     expect(meterBar(0, 10_000)).toBe("[░░░░░░░░░░] 0%");
+    // nonzero usage always shows at least one filled segment
+    expect(meterBar(1, 10_000)).toBe("[█░░░░░░░░░] 0%");
+    expect(meterBar(65, 10_000)).toBe("[█░░░░░░░░░] 1%");
     expect(meterBar(10_000, 10_000)).toBe("[██████████] 100%");
     expect(meterBar(15_000, 10_000)).toBe("[██████████] 100%");
     expect(meterBar(5, -1)).toBeUndefined();

--- a/apps/mcp-server/src/mcp/usage-messaging.ts
+++ b/apps/mcp-server/src/mcp/usage-messaging.ts
@@ -21,7 +21,9 @@ export function meterBar(used?: number, limit?: number): string | undefined {
     return undefined;
   }
   const pct = Math.min(100, Math.round((used / limit) * 100));
-  const filled = Math.min(10, Math.round(pct / 10));
+  // Any nonzero usage shows at least one filled segment so the bar never
+  // reads as empty (an all-░ bar renders as a blank grey pill in many fonts).
+  const filled = Math.max(used > 0 ? 1 : 0, Math.min(10, Math.round(pct / 10)));
   return `[${"█".repeat(filled)}${"░".repeat(10 - filled)}] ${pct}%`;
 }
 


### PR DESCRIPTION
Fixes #309.

At low usage (65/10,000 = 1%) both usage bars rounded to zero filled segments and rendered as an all-░ blank grey pill.

- `meterBar` (mcp-server `usage-messaging.ts`): nonzero usage now renders ≥1 filled segment → `[█░░░░░░░░░] 1%`
- `renderBar` (CLI `usage.ts`): same rule at 20-segment width
- Tests added in both suites; zero usage still renders fully empty
- Full `pnpm test` (189 tests) and `pnpm typecheck` pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FNqj8eVD64hY9MpDZZDWw