### PR TITLE
feat(admin): email observability — log + open-tracking pixel

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -141,6 +141,35 @@ app.get("/email/unsubscribe", async (c) => {
   );
 });
 
+// Open-tracking pixel (migration 0029) — referenced from transactional
+// emails. Public by necessity (mail clients fetch it); the id is an
+// unguessable UUID minted at send time, and a miss is a silent no-op.
+// Always returns the 1x1 GIF regardless, so nothing renders as broken.
+const PIXEL_GIF = Uint8Array.from([
+  0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0x21, 0xf9, 0x04, 0x01, 0x00,
+  0x00, 0x00, 0x00, 0x2c, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+  0x00, 0x02, 0x02, 0x44, 0x01, 0x00, 0x3b,
+]);
+app.get("/email/open", async (c) => {
+  const id = c.req.query("id") ?? "";
+  if (/^[0-9a-f-]{36}$/i.test(id)) {
+    try {
+      await c.env.DB.prepare(
+        "UPDATE email_log SET opened_at = datetime('now') WHERE id = ? AND opened_at IS NULL",
+      )
+        .bind(id)
+        .run();
+    } catch {
+      // Table may not exist yet mid-deploy; the pixel must never error.
+    }
+  }
+  return c.body(PIXEL_GIF, 200, {
+    "Content-Type": "image/gif",
+    "Cache-Control": "no-store, max-age=0",
+  });
+});
+
 // Team invite accept flow (engram#263) — public routes keyed by an
 // unguessable single-use token; POST verifies the invitee's Supabase JWT.
 app.use(

--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -391,6 +391,61 @@ admin.post("/daily-report/send", async (c) => {
   return c.json({ sent: true });
 });
 
+// ---------------------------------------------------------------------------
+// Email observability (migration 0029): engram-web's sendEmail() records
+// every transactional send here; the public /email/open pixel stamps opens.
+// ---------------------------------------------------------------------------
+
+// POST /admin/email-log — record a sent email { id, recipient, type, org_id? }
+admin.post("/email-log", async (c) => {
+  const body = await c.req
+    .json<{ id?: string; recipient?: string; type?: string; org_id?: string }>()
+    .catch(() => ({}) as Record<string, never>);
+  if (!body.id || !body.recipient || !body.type) {
+    return c.json({ error: "id, recipient, and type are required" }, 400);
+  }
+  await c.env.DB.prepare(
+    "INSERT OR IGNORE INTO email_log (id, org_id, recipient, type) VALUES (?, ?, ?, ?)",
+  )
+    .bind(body.id, body.org_id ?? null, body.recipient, body.type)
+    .run();
+  return c.json({ logged: true });
+});
+
+// GET /admin/email-log — by-type stats + recent sends for the admin dashboard
+admin.get("/email-log", async (c) => {
+  const days = Math.min(Number(c.req.query("days") || "30"), 365);
+  const [byType, recent] = await Promise.all([
+    c.env.DB.prepare(
+      `SELECT type,
+              COUNT(*) as sent,
+              SUM(CASE WHEN opened_at IS NOT NULL THEN 1 ELSE 0 END) as opened,
+              MAX(sent_at) as last_sent
+       FROM email_log
+       WHERE sent_at >= datetime('now', '-' || ? || ' days')
+       GROUP BY type ORDER BY sent DESC`,
+    )
+      .bind(days)
+      .all<{ type: string; sent: number; opened: number; last_sent: string }>(),
+    c.env.DB.prepare(
+      `SELECT id, org_id, recipient, type, sent_at, opened_at
+       FROM email_log ORDER BY sent_at DESC LIMIT 50`,
+    ).all<{
+      id: string;
+      org_id: string | null;
+      recipient: string;
+      type: string;
+      sent_at: string;
+      opened_at: string | null;
+    }>(),
+  ]);
+  return c.json({
+    days,
+    by_type: byType.results ?? [],
+    recent: recent.results ?? [],
+  });
+});
+
 // GET /admin/audit/:orgId — query audit logs for an organization
 admin.get("/audit/:orgId", async (c) => {
   const orgId = c.req.param("orgId");

--- a/packages/db/migrations/0029_email_log.sql
+++ b/packages/db/migrations/0029_email_log.sql
@@ -1,0 +1,15 @@
+-- Email observability: one row per transactional email sent by engram-web's
+-- sendEmail() (welcome, nudges, digests, reports, invites...). opened_at is
+-- stamped by the tracking pixel (GET /email/open?id=) — approximate by
+-- nature: image-blocking clients undercount, Apple MPP prefetch overcounts.
+CREATE TABLE email_log (
+  id TEXT PRIMARY KEY,
+  org_id TEXT,
+  recipient TEXT NOT NULL,
+  type TEXT NOT NULL,
+  sent_at TEXT NOT NULL DEFAULT (datetime('now')),
+  opened_at TEXT
+);
+
+CREATE INDEX idx_email_log_type ON email_log (type, sent_at);
+CREATE INDEX idx_email_log_sent ON email_log (sent_at);


### PR DESCRIPTION
Worker half of email observability (pairs with the engram-web PR).

- **Migration 0029**: `email_log` — one row per transactional email (id, org_id, recipient, type, sent_at, opened_at).
- **POST /admin/email-log** — engram-web's `sendEmail()` records every send (admin-secret auth).
- **GET /admin/email-log** — by-type stats (sent / opened / open-rate / last) + 50 most recent sends, for the /admin dashboard.
- **GET /email/open?id=** — public 1×1 GIF pixel stamping `opened_at`; UUID ids, never errors (safe mid-deploy).

Verified: tsc clean, 189 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)