### PR TITLE
feat(billing): churn tracking — cancelling / cancelled states

### DIFF
--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -172,6 +172,8 @@ admin.get("/users", async (c) => {
       o.referral_source,
       o.stripe_customer_id,
       o.created_at,
+      o.cancel_at_period_end,
+      o.churned_at,
       COUNT(c.id) as conversations,
       COALESCE(SUM(c.message_count), 0) as total_messages
     FROM organizations o
@@ -190,6 +192,8 @@ admin.get("/users", async (c) => {
       referral_source: string | null;
       stripe_customer_id: string | null;
       created_at: string;
+      cancel_at_period_end: number;
+      churned_at: string | null;
       conversations: number;
       total_messages: number;
     }>();

--- a/apps/mcp-server/src/routes/billing.ts
+++ b/apps/mcp-server/src/routes/billing.ts
@@ -15,6 +15,20 @@ import type { Env, AuthContext } from "../types.js";
 
 type HonoEnv = { Bindings: Env; Variables: { auth: AuthContext } };
 
+/**
+ * Stamp churned_at when a PAYING org loses its subscription (migration
+ * 0030). Guarded on tier so free orgs bouncing through cancel events don't
+ * get marked; the flag clears again if they later resubscribe.
+ */
+async function markChurned(db: Env["DB"], orgId: string): Promise<void> {
+  await db
+    .prepare(
+      "UPDATE organizations SET churned_at = datetime('now'), cancel_at_period_end = 0 WHERE id = ? AND tier != 'free'",
+    )
+    .bind(orgId)
+    .run();
+}
+
 const billing = new Hono<HonoEnv>();
 
 // POST /api/billing/checkout
@@ -315,12 +329,20 @@ billingWebhook.post("/", async (c) => {
       ) {
         const seatLimit = newTier === "team" ? quantity : 1;
         await setOrganizationTier(c.env.DB, orgId, newTier, subscriptionId, seatLimit);
+        // Track scheduled cancellation ("pro but cancelling" in admin). An
+        // active sub also clears any past churn stamp — they came back.
+        await c.env.DB.prepare(
+          "UPDATE organizations SET cancel_at_period_end = ?, churned_at = CASE WHEN ? = 0 THEN NULL ELSE churned_at END WHERE id = ?",
+        )
+          .bind(obj.cancel_at_period_end ? 1 : 0, obj.cancel_at_period_end ? 1 : 0, orgId)
+          .run();
       } else if (
         status === "canceled" ||
         status === "incomplete_expired" ||
         status === "unpaid" ||
         status === "past_due"
       ) {
+        await markChurned(c.env.DB, orgId);
         await setOrganizationTier(c.env.DB, orgId, "free", null, 1);
       }
       break;
@@ -329,6 +351,7 @@ billingWebhook.post("/", async (c) => {
     case "customer.subscription.deleted": {
       const orgId = await resolveOrgIdFromEvent(c.env, obj);
       if (orgId) {
+        await markChurned(c.env.DB, orgId);
         await setOrganizationTier(c.env.DB, orgId, "free", null, 1);
       }
       break;

--- a/packages/db/migrations/0030_churn_state.sql
+++ b/packages/db/migrations/0030_churn_state.sql
@@ -1,0 +1,6 @@
+-- Churn visibility: distinguish "never paid" from "paid and left".
+-- cancel_at_period_end mirrors Stripe (they cancelled but keep paid access
+-- until the period ends); churned_at is stamped when a paying org is
+-- actually downgraded to free. Cleared again if they resubscribe.
+ALTER TABLE organizations ADD COLUMN cancel_at_period_end INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE organizations ADD COLUMN churned_at TEXT;


### PR DESCRIPTION
Worker half (pairs with the engram-web badge PR).

- **Migration 0030**: `cancel_at_period_end` + `churned_at` on organizations.
- **Webhook**: `subscription.updated` records scheduled cancellation (still paid → “cancelling”); the downgrade paths (`deleted`/`canceled`/`unpaid`/`past_due`) stamp `churned_at` first — guarded on `tier != 'free'` so never-paid orgs can't be marked churned. Resubscribing clears the stamp.
- **/admin/users** returns both fields.

tsc + 189 tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)