### PR TITLE
feat(admin): live MRR in /admin/metrics

### DIFF
--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -118,7 +118,59 @@ admin.get("/metrics", async (c) => {
     referralMap[row.source] = row.count;
   }
 
+  // MRR — live from Stripe (real amounts, not hardcoded tier prices). Sums
+  // active subscription items; yearly plans are normalized to monthly.
+  // "external" excludes subs whose customer maps to an internal org (the
+  // owner's own accounts). Fail-soft: metrics must render without Stripe.
+  const mrr = { total_cents: 0, external_cents: 0, subscriptions: 0 };
+  try {
+    if (c.env.STRIPE_SECRET_KEY) {
+      const subsRes = await fetch(
+        "https://api.stripe.com/v1/subscriptions?status=active&limit=100",
+        { headers: { Authorization: `Bearer ${c.env.STRIPE_SECRET_KEY}` } },
+      );
+      if (subsRes.ok) {
+        const subs = (await subsRes.json()) as {
+          data: Array<{
+            customer: string;
+            items: {
+              data: Array<{
+                quantity?: number;
+                price?: { unit_amount?: number | null; recurring?: { interval?: string; interval_count?: number } };
+              }>;
+            };
+          }>;
+        };
+        const internalCustomers = new Set(
+          (
+            await c.env.DB.prepare(
+              "SELECT stripe_customer_id FROM organizations WHERE referral_source = 'internal' AND stripe_customer_id IS NOT NULL",
+            ).all<{ stripe_customer_id: string }>()
+          ).results?.map((r) => r.stripe_customer_id) ?? [],
+        );
+        for (const s of subs.data) {
+          let cents = 0;
+          for (const item of s.items?.data ?? []) {
+            const unit = item.price?.unit_amount ?? 0;
+            const qty = item.quantity ?? 1;
+            const interval = item.price?.recurring?.interval ?? "month";
+            const count = item.price?.recurring?.interval_count ?? 1;
+            const monthly =
+              interval === "year" ? (unit * qty) / (12 * count) : (unit * qty) / count;
+            cents += monthly;
+          }
+          mrr.total_cents += Math.round(cents);
+          mrr.subscriptions += 1;
+          if (!internalCustomers.has(s.customer)) mrr.external_cents += Math.round(cents);
+        }
+      }
+    }
+  } catch {
+    // leave zeros — the dashboard treats 0 subs as "unavailable"
+  }
+
   return c.json({
+    mrr,
     signups: {
       total: orgs?.total ?? 0,
       last_1d: orgs?.last_1d ?? 0,


### PR DESCRIPTION
Adds `mrr: { total_cents, external_cents, subscriptions }` to /admin/metrics — summed live from active Stripe subscriptions (real prices, yearly→monthly normalized). `external` excludes the owner's internal accounts. Fail-soft if Stripe is down. Pairs with the engram-web MRR stat card. tsc + 189 tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)