### PR TITLE
feat: CLI limit alerts route through key login

### DIFF
--- a/apps/mcp-server/src/__tests__/storage-cap.test.ts
+++ b/apps/mcp-server/src/__tests__/storage-cap.test.ts
@@ -45,9 +45,9 @@ describe("storage messaging", () => {
     expect(m).toMatch(/don't try to collect payment/i);
   });
 
-  it("memory-full copy points API callers at pricing", () => {
+  it("memory-full copy points API callers at key login", () => {
     const m = storageFullMessage({ limit: 10_000, isOAuth: false });
-    expect(m).toContain("getengram.app/pricing");
+    expect(m).toContain("getengram.app/login");
     expect(m).toMatch(/delete old conversations/i);
   });
 

--- a/apps/mcp-server/src/__tests__/usage-messaging.test.ts
+++ b/apps/mcp-server/src/__tests__/usage-messaging.test.ts
@@ -26,9 +26,9 @@ describe("limitMessage", () => {
     expect(m).toMatch(/sign in/i);
     expect(m).toMatch(/don't try to collect payment/i);
   });
-  it("points API-key users to pricing", () => {
+  it("points API-key users to key login", () => {
     const m = limitMessage({ unit: "messages", tier: "free", limit: 1000, used: 1000, isOAuth: false });
-    expect(m).toContain("getengram.app/pricing");
+    expect(m).toContain("getengram.app/login");
     expect(m).toContain("1000");
   });
 });
@@ -36,7 +36,7 @@ describe("limitMessage", () => {
 describe("approachingLimitNotice", () => {
   it("warns at/above 80% usage", () => {
     expect(approachingLimitNotice({ used: 800, limit: 1000, remaining: 200 }, true)).toMatch(/dashboard/);
-    expect(approachingLimitNotice({ used: 950, limit: 1000, remaining: 50 }, false)).toMatch(/pricing/);
+    expect(approachingLimitNotice({ used: 950, limit: 1000, remaining: 50 }, false)).toMatch(/login/);
   });
   it("stays quiet below 80%", () => {
     expect(approachingLimitNotice({ used: 500, limit: 1000, remaining: 500 }, true)).toBeUndefined();

--- a/apps/mcp-server/src/mcp/usage-messaging.ts
+++ b/apps/mcp-server/src/mcp/usage-messaging.ts
@@ -5,6 +5,10 @@
 
 const DASHBOARD = "https://getengram.app/dashboard";
 const PRICING = "https://getengram.app/pricing";
+// API-key/CLI users may have no email on the account — the dashboard's
+// key login ("Sign in with your API key" at /login) is their upgrade path.
+const KEY_LOGIN =
+  "log in at https://getengram.app/login with your API key (choose \"Sign in with your API key\") and upgrade from your dashboard";
 
 export interface UsageMeter {
   used: number;
@@ -61,7 +65,7 @@ export function limitMessage(opts: {
   return (
     `${unit === "messages" ? "Message" : "Conversation"} limit reached ` +
     `(${used ?? "?"}/${limit ?? "?"} this month on the ${tier ?? "free"} plan). ` +
-    `Upgrade at ${PRICING} to continue.`
+    `To continue, ${KEY_LOGIN}.`
   );
 }
 
@@ -87,7 +91,7 @@ export function storageFullMessage(opts: {
   }
   return (
     `Engram's memory is full (${size}). Everything saved stays safe and searchable. ` +
-    `Upgrade at ${PRICING} for more space, or delete old conversations to free room.`
+    `For more space, ${KEY_LOGIN} — Pro is $9/mo for 1,000,000 messages — or delete old conversations to free room.`
   );
 }
 
@@ -103,7 +107,7 @@ export function approachingStorageNotice(
   if (meter.used / meter.limit < 0.8) return undefined;
   const where = isOAuth
     ? `sign in at ${DASHBOARD} with the email you connected and upgrade for more space`
-    : `upgrade at ${PRICING} for more space`;
+    : `${KEY_LOGIN} ($9/mo for 1,000,000 messages)`;
   return (
     `${meter.used.toLocaleString("en-US")}/${meter.limit.toLocaleString("en-US")} messages of memory used ` +
     `(${meter.remaining.toLocaleString("en-US")} left). Nothing ever expires — but to keep saving new ` +
@@ -120,7 +124,7 @@ export function approachingLimitNotice(
   if (meter.used / meter.limit < 0.8) return undefined;
   const where = isOAuth
     ? `sign in at ${DASHBOARD} with the email you connected and upgrade`
-    : `upgrade at ${PRICING}`;
+    : KEY_LOGIN;
   return (
     `${meter.used}/${meter.limit} included messages used this month (${meter.remaining} left). ` +
     `To avoid interruption, ${where}.`


### PR DESCRIPTION
For CLI users with **no email** (like `anon-SRhnlmnJ`, now 66% full): limit warnings already ride in every save response at ≥80% storage — the user's own AI relays them — but the copy pointed at /pricing, a dead end for someone who can't sign in. Now all non-OAuth limit messages (80% warning, monthly cap, storage-full) route through the new **key login**: `getengram.app/login → "Sign in with your API key"` → upgrade from the dashboard (checkout works on a key session, and the dashboard prompts them to add an email). Tests updated. 189 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)