### PR TITLE
feat: track unsubscribes and surface them in the admin email log

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -133,9 +133,25 @@ app.get("/email/unsubscribe", async (c) => {
   const { unsubscribeSig } = await import("./cron/weekly-digest.js");
   const expected = await unsubscribeSig(org, secret);
   if (sig !== expected) return c.text("Invalid link.", 400);
-  await c.env.DB.prepare("UPDATE organizations SET digest_opt_out = 1 WHERE id = ?")
+  await c.env.DB.prepare(
+    "UPDATE organizations SET digest_opt_out = 1, digest_opt_out_at = COALESCE(digest_opt_out_at, datetime('now')) WHERE id = ?",
+  )
     .bind(org)
     .run();
+  // Attribute the unsubscribe to the email that (almost certainly) contained
+  // the link they clicked: the most recent send to this org. Approximate but
+  // link-format-free — nothing needs threading through the senders.
+  try {
+    await c.env.DB.prepare(
+      `UPDATE email_log SET unsubscribed_at = datetime('now')
+       WHERE id = (SELECT id FROM email_log WHERE org_id = ? ORDER BY sent_at DESC LIMIT 1)
+         AND unsubscribed_at IS NULL`,
+    )
+      .bind(org)
+      .run();
+  } catch {
+    // email_log may predate migration 0031 mid-deploy; the opt-out already stuck.
+  }
   return c.html(
     "<!doctype html><meta charset=utf-8><title>Unsubscribed</title><body style=\"font-family:sans-serif;max-width:32rem;margin:4rem auto;color:#27272a\"><h1 style=\"font-size:1.4rem\">You're unsubscribed</h1><p>No more weekly digest emails. Account and security emails still arrive when needed.</p><p><a href=\"https://getengram.app\">getengram.app</a></p>",
   );

--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -530,18 +530,25 @@ admin.delete("/email-log", async (c) => {
 // GET /admin/email-log — by-type stats + recent sends for the admin dashboard
 admin.get("/email-log", async (c) => {
   const days = Math.min(Number(c.req.query("days") || "30"), 365);
-  const [byType, recent] = await Promise.all([
+  const [byType, recent, unsub, unsubCount] = await Promise.all([
     c.env.DB.prepare(
       `SELECT type,
               COUNT(*) as sent,
               SUM(CASE WHEN opened_at IS NOT NULL THEN 1 ELSE 0 END) as opened,
+              SUM(CASE WHEN unsubscribed_at IS NOT NULL THEN 1 ELSE 0 END) as unsubscribed,
               MAX(sent_at) as last_sent
        FROM email_log
        WHERE sent_at >= datetime('now', '-' || ? || ' days')
        GROUP BY type ORDER BY sent DESC`,
     )
       .bind(days)
-      .all<{ type: string; sent: number; opened: number; last_sent: string }>(),
+      .all<{
+        type: string;
+        sent: number;
+        opened: number;
+        unsubscribed: number;
+        last_sent: string;
+      }>(),
     c.env.DB.prepare(
       `SELECT id, org_id, recipient, type, sent_at, opened_at
        FROM email_log ORDER BY sent_at DESC LIMIT 50`,
@@ -553,11 +560,23 @@ admin.get("/email-log", async (c) => {
       sent_at: string;
       opened_at: string | null;
     }>(),
+    // Who opted out of lifecycle email, newest first. digest_opt_out_at is
+    // null for opt-outs that predate migration 0031 — they sort last.
+    c.env.DB.prepare(
+      `SELECT name, email, digest_opt_out_at
+       FROM organizations WHERE digest_opt_out = 1
+       ORDER BY digest_opt_out_at IS NULL, digest_opt_out_at DESC LIMIT 20`,
+    ).all<{ name: string; email: string | null; digest_opt_out_at: string | null }>(),
+    c.env.DB.prepare(
+      "SELECT COUNT(*) as n FROM organizations WHERE digest_opt_out = 1",
+    ).first<{ n: number }>(),
   ]);
   return c.json({
     days,
     by_type: byType.results ?? [],
     recent: recent.results ?? [],
+    unsubscribed_orgs: unsubCount?.n ?? 0,
+    recent_unsubscribes: unsub.results ?? [],
   });
 });
 

--- a/packages/db/migrations/0031_email_unsubscribes.sql
+++ b/packages/db/migrations/0031_email_unsubscribes.sql
@@ -1,0 +1,7 @@
+-- Unsubscribe observability (engram: admin email section).
+-- organizations.digest_opt_out already gates lifecycle sends; this adds
+-- WHEN it happened, and stamps the email that likely triggered it (the
+-- most recent send to that org at click time) so the admin dashboard can
+-- show per-type unsubscribe counts next to open rates.
+ALTER TABLE email_log ADD COLUMN unsubscribed_at TEXT;
+ALTER TABLE organizations ADD COLUMN digest_opt_out_at TEXT;


### PR DESCRIPTION
Unsubscribe existed (signed link sets digest_opt_out) but was invisible:
no timestamp, no tie to the email that caused it. Migration 0031 adds
email_log.unsubscribed_at + organizations.digest_opt_out_at. The
unsubscribe route now stamps the org's opt-out time and attributes the
click to the most recent email sent to that org (no link changes needed).
GET /admin/email-log gains per-type unsubscribed counts, a total, and the
20 most recent unsubscribers.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
