### PR TITLE
feat(cli): auto-capture on by default after login (0.4.1)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getengram/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI for Engram \u2014 persistent memory for AI agents",
   "type": "module",
   "bin": {

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -1,6 +1,7 @@
 import { saveConfig, loadConfig } from "../config.js";
 import { green, red } from "../output.js";
 import { Engram } from "@getengram/sdk";
+import { autoEnableCapture } from "../daemon/commands.js";
 
 export async function authLogin(args: string[]): Promise<void> {
   const key = args[0];
@@ -33,6 +34,7 @@ export async function authLogin(args: string[]): Promise<void> {
   console.log(green("✓ Authenticated successfully"));
   console.log(`  Key saved to ~/.engram/config.json`);
   console.log(`  Prefix: ${key.slice(0, 20)}...`);
+  await autoEnableCapture();
 }
 
 export async function authLogout(): Promise<void> {

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -2,6 +2,7 @@ import { createInterface } from "node:readline";
 import { saveConfig, loadConfig, getBaseUrl } from "../config.js";
 import { green, red, dim } from "../output.js";
 import { Engram } from "@getengram/sdk";
+import { autoEnableCapture } from "../daemon/commands.js";
 
 const API_URL = process.env.ENGRAM_BASE_URL ?? getBaseUrl();
 
@@ -88,9 +89,7 @@ export async function signup(): Promise<void> {
   console.log(green("✓ Account created"));
   console.log(`  Organization: ${data.organization_id}`);
   console.log(`  API key saved to ~/.engram/config.json`);
-  console.log(
-    dim("\n  Tip: run 'engram install' to auto-start on login"),
-  );
+  await autoEnableCapture();
   console.log(
     dim("  Tip: run 'engram link <email>' to claim your account for upgrades"),
   );
@@ -176,6 +175,7 @@ export async function login(args: string[] = [], flags: Record<string, string> =
     if (config.apiKey) {
       console.log(green(`✓ Signed in as ${email.trim()}`));
       console.log(`  Using existing API key from ~/.engram/config.json`);
+      await autoEnableCapture();
       return;
     }
     console.error(
@@ -202,4 +202,5 @@ export async function login(args: string[] = [], flags: Record<string, string> =
 
   console.log(green(`✓ Signed in as ${email.trim()}`));
   console.log(`  API key saved to ~/.engram/config.json`);
+  await autoEnableCapture();
 }

--- a/apps/cli/src/daemon/commands.ts
+++ b/apps/cli/src/daemon/commands.ts
@@ -308,6 +308,41 @@ export async function daemonInstall(): Promise<void> {
   installLaunchd();
 }
 
+/**
+ * Auto-capture is the product default: a successful interactive login
+ * turns the capture daemon on and enables start-at-login, loudly, with a
+ * one-line off switch. Never fatal — login must succeed even if the
+ * daemon can't start. Skipped for scripted logins (no TTY) and when
+ * ENGRAM_NO_AUTOCAPTURE is set.
+ */
+export async function autoEnableCapture(): Promise<void> {
+  if (process.env.ENGRAM_NO_AUTOCAPTURE) return;
+  if (!process.stdin.isTTY) return;
+  if (process.platform !== "darwin" && process.platform !== "linux") return;
+  try {
+    if (!readPid()) {
+      mkdirSync(ENGRAM_DIR, { recursive: true });
+      const logFd = openSync(LOG_FILE, "a");
+      const child = spawn(process.execPath, [getWorkerPath()], {
+        detached: true,
+        stdio: ["ignore", logFd, logFd],
+        env: { ...process.env },
+      });
+      child.unref();
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    if (process.platform === "darwin" && !isLaunchdInstalled()) {
+      installLaunchd();
+    }
+    console.log(
+      `${bold("Auto-capture is on")} — conversations from supported agents on this machine save to your Engram.`,
+    );
+    console.log(dim("  Turn off anytime: engram stop && engram uninstall"));
+  } catch {
+    // Non-fatal by design: capture is a convenience, login is the job.
+  }
+}
+
 export async function daemonUninstall(): Promise<void> {
   uninstallLaunchd();
 }


### PR DESCRIPTION
Every successful interactive login/signup now starts the capture daemon
and installs the launchd agent, announced loudly with a one-line off
switch (engram stop && engram uninstall). Previously the daemon required
an explicit 'engram start'/'engram install' that nobody discovered —
real accounts (e.g. the 6,600-message CLI user) ran for weeks with
capture off.

Skipped when stdin isn't a TTY (CI/scripts) or ENGRAM_NO_AUTOCAPTURE is
set; never fatal — login succeeds even if the daemon can't start.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
