### PR TITLE
feat(cli): engram whoami + web-password creation from the CLI

### DIFF
--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -1,6 +1,6 @@
 import { createInterface } from "node:readline";
 import { saveConfig, loadConfig, getBaseUrl } from "../config.js";
-import { green, red, dim } from "../output.js";
+import { green, red, dim, bold } from "../output.js";
 import { Engram } from "@getengram/sdk";
 import { autoEnableCapture } from "../daemon/commands.js";
 
@@ -144,7 +144,88 @@ export async function link(args: string[] = [], flags: Record<string, string> = 
   }
 
   console.log(green(`✓ Account linked to ${email.trim()}`));
-  console.log(`  You can now sign in at getengram.app/login`);
+
+  // Offer a web password so getengram.app/login works with more than the
+  // API key. --password makes it non-interactive for agents.
+  let password = flags.password || "";
+  if (!password && process.stdin.isTTY) {
+    const answer = await prompt("Create a password for web login? [y/N] ");
+    if (/^y(es)?$/i.test(answer.trim())) {
+      password = await prompt("Password (min 8 chars): ", true);
+    }
+  }
+  if (password) {
+    await setWebPassword(apiKey, password);
+  } else {
+    console.log(`  You can sign in at getengram.app/login with your API key`);
+  }
+}
+
+/** POST /signup/set-password — create the Supabase login for this org. */
+async function setWebPassword(apiKey: string, password: string): Promise<void> {
+  const res = await fetch(`${API_URL}/signup/set-password`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ password }),
+  });
+  const j = (await res.json().catch(() => ({}))) as {
+    error?: string;
+    message?: string;
+    confirmation_required?: boolean;
+    email?: string;
+  };
+  if (!res.ok) {
+    console.error(red(j.message || `Failed to set password (${res.status})`));
+    return; // non-fatal: the link itself succeeded
+  }
+  console.log(green("✓ Password set"));
+  if (j.confirmation_required) {
+    console.log(`  Check ${j.email} for a confirmation link, then sign in at getengram.app/login`);
+  } else {
+    console.log(`  Sign in at getengram.app/login`);
+  }
+}
+
+/**
+ * `engram whoami` — which account is this machine using?
+ * Shows the org, email (or anonymous), and tier for the active API key.
+ */
+export async function whoami(): Promise<void> {
+  const config = await loadConfig();
+  const apiKey = process.env.ENGRAM_API_KEY ?? config.apiKey;
+  if (!apiKey) {
+    console.log("Not authenticated.");
+    console.log("\nRun: engram login   (or engram auth login <api-key>)");
+    process.exit(1);
+  }
+
+  const res = await fetch(`${API_URL}/api/account`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) {
+    console.error(red(`Could not fetch account (${res.status}). Check your API key.`));
+    process.exit(1);
+  }
+  const acct = (await res.json()) as {
+    org_id: string;
+    email: string | null;
+    name: string | null;
+    tier: string;
+  };
+  const source = process.env.ENGRAM_API_KEY ? "ENGRAM_API_KEY env var" : "~/.engram/config.json";
+
+  console.log(`${bold(acct.name ?? acct.org_id)} ${dim(`(${acct.tier})`)}`);
+  if (acct.email) {
+    console.log(`  Email: ${acct.email}`);
+  } else {
+    console.log(`  Email: ${dim("none — anonymous account")}`);
+    console.log(dim("  Add one (enables web login + billing): engram link <email>"));
+  }
+  console.log(`  Org:   ${acct.org_id}`);
+  console.log(`  Key:   ${apiKey.slice(0, 20)}... ${dim(`(${source})`)}`);
 }
 
 /**

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,7 +3,7 @@
 import { Engram } from "@getengram/sdk";
 import { loadConfig, getBaseUrl } from "./config.js";
 import { authLogin, authLogout, authStatus } from "./commands/auth.js";
-import { signup, login, link } from "./commands/login.js";
+import { signup, login, link, whoami } from "./commands/login.js";
 import {
   listConversations,
   createConversation,
@@ -26,7 +26,7 @@ const VERSION = "0.3.4";
 const TOP_COMMANDS = new Set([
   "help", "version", "store", "append", "search", "find", "convs",
   "start", "stop", "status", "install", "uninstall", "log",
-  "signup", "login", "link", "upgrade", "import",
+  "signup", "login", "link", "whoami", "upgrade", "import",
 ]);
 // Commands that take 2 words (group + subcommand)
 const GROUP_COMMANDS = new Set(["auth", "conversations", "conv", "daemon", "vault"]);
@@ -123,6 +123,7 @@ ${bold("COMMANDS")}
   ${bold("signup")}                   Create a free account instantly
   ${bold("login")}                    Sign in with email + password
   ${bold("link")}                     Link email to your account for dashboard access
+  ${bold("whoami")}                   Show which account this machine is using
 
   All auth commands accept ${dim("--email")} and ${dim("--password")} flags for non-interactive (agent) usage.
 
@@ -222,6 +223,11 @@ async function main(): Promise<void> {
 
       case "link":
         await link(args, flags);
+        break;
+
+      case "whoami":
+      case "auth whoami":
+        await whoami();
         break;
 
       case "auth login":

--- a/apps/mcp-server/src/routes/signup.ts
+++ b/apps/mcp-server/src/routes/signup.ts
@@ -209,6 +209,103 @@ signup.post("/link", async (c) => {
   return c.json({ linked: true, organization_id: keyRow.organization_id, email });
 });
 
+// POST /signup/set-password — give a CLI-born account a web login.
+// Auth: Engram API key Bearer. Body: { password }. Requires the org to
+// already have an email (engram link). Creates the Supabase user through
+// the same public signup endpoint the web form uses, so the email-based
+// org lookup in /signup logs the browser session into THIS org. If
+// Supabase requires email confirmation, the password works after the
+// user clicks the verification link.
+signup.post("/set-password", async (c) => {
+  const authHeader = c.req.header("authorization") ?? "";
+  const token = authHeader.replace(/^Bearer\s+/i, "");
+  if (!token || !token.startsWith("engram_sk_live_")) {
+    return c.json({ error: "unauthorized", message: "Missing or invalid API key" }, 401);
+  }
+  const { hashApiKey } = await import("@getengram/shared");
+  const keyHash = await hashApiKey(token);
+  const keyRow = await c.env.DB.prepare(
+    "SELECT k.organization_id FROM api_keys k WHERE k.key_hash = ?",
+  )
+    .bind(keyHash)
+    .first<{ organization_id: string }>();
+  if (!keyRow) {
+    return c.json({ error: "unauthorized", message: "Invalid API key" }, 401);
+  }
+
+  const org = await c.env.DB.prepare(
+    "SELECT email FROM organizations WHERE id = ?",
+  )
+    .bind(keyRow.organization_id)
+    .first<{ email: string | null }>();
+  if (!org?.email) {
+    return c.json(
+      { error: "no_email", message: "Link an email first: engram link <email>" },
+      400,
+    );
+  }
+
+  const body = await c.req
+    .json<{ password?: string }>()
+    .catch(() => ({}) as { password?: string });
+  const password = body.password ?? "";
+  if (password.length < 8) {
+    return c.json(
+      { error: "weak_password", message: "Password must be at least 8 characters" },
+      400,
+    );
+  }
+
+  const supabaseUrl = c.env.SUPABASE_URL;
+  const supabaseAnonKey = c.env.SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return c.json(
+      { error: "server_misconfigured", message: "Supabase is not configured" },
+      500,
+    );
+  }
+
+  const res = await fetch(`${supabaseUrl}/auth/v1/signup`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", apikey: supabaseAnonKey },
+    body: JSON.stringify({ email: org.email, password }),
+  });
+  const j = (await res.json().catch(() => ({}))) as {
+    msg?: string;
+    error_description?: string;
+    session?: unknown;
+    user?: { identities?: unknown[] };
+  };
+  if (!res.ok) {
+    const msg = j.msg || j.error_description || "";
+    if (/already registered/i.test(msg)) {
+      return c.json(
+        {
+          error: "password_exists",
+          message:
+            "This email already has a web login. Sign in at getengram.app/login (or use password reset there).",
+        },
+        409,
+      );
+    }
+    return c.json({ error: "auth_failed", message: msg || `Supabase error ${res.status}` }, 400);
+  }
+  // Supabase obfuscates existing users when confirmations are on: 200 with
+  // an identity-less user instead of an error.
+  if (j.user && Array.isArray(j.user.identities) && j.user.identities.length === 0) {
+    return c.json(
+      {
+        error: "password_exists",
+        message:
+          "This email already has a web login. Sign in at getengram.app/login (or use password reset there).",
+      },
+      409,
+    );
+  }
+
+  return c.json({ ok: true, confirmation_required: !j.session, email: org.email });
+});
+
 // POST /signup/login — authenticate with email + password, return API key.
 // Handles Supabase auth server-side so the CLI doesn't need credentials.
 signup.post("/login", async (c) => {


### PR DESCRIPTION
whoami shows which account this machine uses (name, tier, email or
'none — anonymous account', org id, key prefix + source) via the
existing GET /api/account. engram link now offers to create a web
password after attaching the email: new POST /signup/set-password
creates the Supabase user through the same public signup endpoint the
web form uses, so email-based org lookup logs the browser into the same
org. Handles already-registered (409, including Supabase's obfuscated
identity-less 200) and confirmation-required flows. --password flag
keeps it non-interactive for agents.

CLI-born accounts can now self-serve the full ladder: anonymous key →
linked email → web password → dashboard/billing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
