### PR TITLE
feat(cli): any authenticated CLI use ensures capture is running

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -8,6 +8,9 @@ const CONFIG_FILE = join(CONFIG_DIR, "config.json");
 interface Config {
   apiKey?: string;
   baseUrl?: string;
+  /** "off" = the user explicitly stopped capture; the CLI must not
+   *  resurrect the daemon until they run start/install again. */
+  autocapture?: "on" | "off";
 }
 
 export async function loadConfig(): Promise<Config> {

--- a/apps/cli/src/daemon/commands.ts
+++ b/apps/cli/src/daemon/commands.ts
@@ -10,6 +10,7 @@ import {
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { bold, dim, red } from "../output.js";
+import { loadConfig, saveConfig } from "../config.js";
 import { DaemonDb } from "./db.js";
 import { readStatus, type SyncStatus } from "./status.js";
 import { ALL_ADAPTERS } from "./adapters.js";
@@ -88,6 +89,7 @@ export async function daemonStart(
   _args: string[],
   flags: Record<string, string>,
 ): Promise<void> {
+  await recordCaptureIntent("on");
   const existing = readPid();
   if (existing) {
     console.log(`Daemon already running (pid ${existing})`);
@@ -137,7 +139,18 @@ export async function daemonStart(
   }
 }
 
+async function recordCaptureIntent(v: "on" | "off"): Promise<void> {
+  try {
+    const config = await loadConfig();
+    config.autocapture = v;
+    await saveConfig(config);
+  } catch {
+    // config write failures never block daemon management
+  }
+}
+
 export async function daemonStop(): Promise<void> {
+  await recordCaptureIntent("off");
   const pid = readPid();
   if (!pid) {
     console.log("Daemon is not running.");
@@ -305,6 +318,7 @@ function uninstallLaunchd(): void {
 }
 
 export async function daemonInstall(): Promise<void> {
+  await recordCaptureIntent("on");
   installLaunchd();
 }
 
@@ -320,6 +334,9 @@ export async function autoEnableCapture(): Promise<void> {
   if (!process.stdin.isTTY) return;
   if (process.platform !== "darwin" && process.platform !== "linux") return;
   try {
+    const config = await loadConfig();
+    if (config.autocapture === "off") return; // user said stop; respect it
+    if (!(process.env.ENGRAM_API_KEY ?? config.apiKey)) return; // nothing to capture into
     if (!readPid()) {
       mkdirSync(ENGRAM_DIR, { recursive: true });
       const logFd = openSync(LOG_FILE, "a");
@@ -344,5 +361,6 @@ export async function autoEnableCapture(): Promise<void> {
 }
 
 export async function daemonUninstall(): Promise<void> {
+  await recordCaptureIntent("off");
   uninstallLaunchd();
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -15,6 +15,7 @@ import { search } from "./commands/search.js";
 import { log as showLog } from "./commands/log.js";
 import { importHistory } from "./commands/import.js";
 import { daemonStart, daemonStop, daemonStatus, daemonInstall, daemonUninstall } from "./daemon/index.js";
+import { autoEnableCapture } from "./daemon/commands.js";
 import { upgrade } from "./commands/upgrade.js";
 import { usage as showUsage } from "./commands/usage.js";
 import { vaultKeygen, vaultStatus, loadVaultKey, vaultSet, vaultGet, vaultList, vaultDelete } from "./commands/vault.js";
@@ -203,6 +204,17 @@ async function main(): Promise<void> {
   const { command, args, flags } = parseArgs(raw);
   const cmd = command.join(" ");
 
+  // Capture is the product default: any authenticated interactive use of
+  // the CLI ensures the daemon is running (unless the user explicitly ran
+  // stop/uninstall — autoEnableCapture respects config.autocapture="off").
+  // Runs after the command so its output never interleaves; skipped for
+  // daemon-management and auth commands, which handle capture themselves.
+  const CAPTURE_EXEMPT = new Set([
+    "help", "version", "start", "stop", "restart", "install", "uninstall",
+    "status", "log", "signup", "login", "link", "auth login", "auth logout",
+  ]);
+  const ensureCaptureAfter = !CAPTURE_EXEMPT.has(cmd);
+
   try {
     switch (cmd) {
       case "help":
@@ -363,6 +375,10 @@ async function main(): Promise<void> {
       console.error("An unexpected error occurred");
     }
     process.exit(1);
+  }
+
+  if (ensureCaptureAfter) {
+    await autoEnableCapture();
   }
 }
 


### PR DESCRIPTION
Login-time auto-start (0.4.1) missed everyone already logged in — the
owner's own machine sat with the daemon stopped until a manual 'engram
start'. Now every authenticated interactive command ends by ensuring the
daemon is up and launchd-installed. Explicit intent is respected:
stop/uninstall record autocapture=off in config and the CLI never
resurrects the daemon until start/install flips it back.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
