### PR TITLE
fix(cli): self-heal better-sqlite3 ABI mismatch; keep native module off the CLI hot path (0.4.2)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getengram/cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "CLI for Engram \u2014 persistent memory for AI agents",
   "type": "module",
   "bin": {

--- a/apps/cli/src/daemon/commands.ts
+++ b/apps/cli/src/daemon/commands.ts
@@ -11,7 +11,6 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { bold, dim, red } from "../output.js";
 import { loadConfig, saveConfig } from "../config.js";
-import { DaemonDb } from "./db.js";
 import { readStatus, type SyncStatus } from "./status.js";
 import { ALL_ADAPTERS } from "./adapters.js";
 
@@ -168,6 +167,22 @@ export async function daemonStop(): Promise<void> {
   try { unlinkSync(PID_FILE); } catch { /* ignore */ }
 }
 
+/** Print local capture stats; never let a broken native module crash status. */
+async function printDbStats(): Promise<void> {
+  if (!existsSync(DB_FILE)) return;
+  try {
+    const { DaemonDb } = await import("./db.js");
+    const db = new DaemonDb(DB_FILE);
+    const stats = db.getStats();
+    db.close();
+    console.log(`${dim("Sessions captured:")} ${stats.sessionsMapped}`);
+    console.log(`${dim("Pending sync:")}      ${stats.pendingMessages} messages`);
+    console.log(`${dim("Files tracked:")}     ${stats.trackedFiles}`);
+  } catch {
+    console.log(dim("Local capture DB unreadable (native module mismatch?) — the daemon rebuilds it on start."));
+  }
+}
+
 export async function daemonStatus(): Promise<void> {
   const pid = readPid();
 
@@ -175,27 +190,13 @@ export async function daemonStatus(): Promise<void> {
     console.log(`${bold("Status:")} stopped`);
 
     // Still show DB stats if available
-    if (existsSync(DB_FILE)) {
-      const db = new DaemonDb(DB_FILE);
-      const stats = db.getStats();
-      db.close();
-      console.log(`${dim("Sessions captured:")} ${stats.sessionsMapped}`);
-      console.log(`${dim("Pending sync:")}      ${stats.pendingMessages} messages`);
-      console.log(`${dim("Files tracked:")}     ${stats.trackedFiles}`);
-    }
+    await printDbStats();
     return;
   }
 
   console.log(`${bold("Status:")} running (pid ${pid})`);
 
-  if (existsSync(DB_FILE)) {
-    const db = new DaemonDb(DB_FILE);
-    const stats = db.getStats();
-    db.close();
-    console.log(`${dim("Sessions captured:")} ${stats.sessionsMapped}`);
-    console.log(`${dim("Pending sync:")}      ${stats.pendingMessages} messages`);
-    console.log(`${dim("Files tracked:")}     ${stats.trackedFiles}`);
-  }
+  await printDbStats();
 
   printHostStatus();
 

--- a/apps/cli/src/daemon/preflight.ts
+++ b/apps/cli/src/daemon/preflight.ts
@@ -1,0 +1,67 @@
+import { createRequire } from "node:module";
+import { execSync } from "node:child_process";
+import { dirname } from "node:path";
+
+// IMPORTANT: this module must never import better-sqlite3 (or anything
+// that does) statically — its whole job is to run before the native
+// module loads and heal an ABI mismatch.
+
+const req = createRequire(import.meta.url);
+
+const ABI_MISMATCH =
+  /NODE_MODULE_VERSION|was compiled against a different Node\.js version|ERR_DLOPEN_FAILED|invalid ELF header|is not a valid Win32 application/i;
+
+/**
+ * Make sure better-sqlite3 can actually load on this Node.
+ *
+ * The daemon's native module is compiled at install time against whatever
+ * Node ran npm/brew. When the runtime Node changes (brew upgrades to a new
+ * major, or the user switches between brew's Node and nvm's), the addon
+ * throws an ABI-mismatch error and — before this preflight — the daemon
+ * died silently in its log while `engram` commands that touch the local DB
+ * crashed outright. Now that capture is on by default, that failure mode
+ * has to self-heal.
+ *
+ * Strategy: try to load; on an ABI mismatch, run `npm rebuild
+ * better-sqlite3` in the package that owns it (better-sqlite3 ships
+ * prebuilds for common ABIs, so this is usually a quick download, not a
+ * compile) and try once more. Returns true when the module loads; false
+ * after printing the exact manual fix when it can't.
+ */
+export function ensureNativeSqlite(
+  log: (msg: string) => void = (m) => console.error(m),
+): boolean {
+  try {
+    req("better-sqlite3");
+    return true;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!ABI_MISMATCH.test(msg)) {
+      throw err;
+    }
+    log(
+      `better-sqlite3 was built for a different Node (now running ${process.version}) — rebuilding...`,
+    );
+    let ownerDir = "";
+    try {
+      const pkgDir = dirname(req.resolve("better-sqlite3/package.json"));
+      // …/node_modules/better-sqlite3 → the package root that owns node_modules
+      ownerDir = dirname(dirname(pkgDir));
+      execSync("npm rebuild better-sqlite3", {
+        cwd: ownerDir,
+        stdio: "pipe",
+        timeout: 180_000,
+      });
+      req("better-sqlite3");
+      log("better-sqlite3 rebuilt for this Node — continuing.");
+      return true;
+    } catch {
+      log(
+        "Automatic rebuild failed. Fix manually with:\n" +
+          `  cd ${ownerDir || "<the directory containing node_modules/better-sqlite3>"} && npm rebuild better-sqlite3\n` +
+          "then run 'engram start' again.",
+      );
+      return false;
+    }
+  }
+}

--- a/apps/cli/src/daemon/worker-main.ts
+++ b/apps/cli/src/daemon/worker-main.ts
@@ -1,0 +1,112 @@
+/**
+ * Daemon worker body. Entry is worker.ts, which preflights the native
+ * sqlite module (and self-heals ABI mismatches) before importing this —
+ * keep any new native-module imports behind that boundary.
+ */
+
+import { writeFileSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { Engram } from "@getengram/sdk";
+import { loadConfig, getBaseUrl } from "../config.js";
+import { DaemonDb } from "./db.js";
+import { Watcher } from "./watcher.js";
+import { Syncer } from "./syncer.js";
+import { availableAdapters } from "./adapters.js";
+
+const ENGRAM_DIR = join(homedir(), ".engram");
+const PID_FILE = join(ENGRAM_DIR, "daemon.pid");
+const DB_FILE = join(ENGRAM_DIR, "daemon.db");
+const LOG_FILE = join(ENGRAM_DIR, "daemon.log");
+
+function log(msg: string): void {
+  const ts = new Date().toISOString();
+  const line = `[${ts}] ${msg}\n`;
+  process.stderr.write(line);
+}
+
+async function main(): Promise<void> {
+  // Write PID file
+  writeFileSync(PID_FILE, String(process.pid));
+
+  log(`daemon started (pid ${process.pid})`);
+  log(`database: ${DB_FILE}`);
+
+  // Load API key
+  const config = await loadConfig();
+  const apiKey = process.env.ENGRAM_API_KEY ?? config.apiKey;
+  if (!apiKey) {
+    log("ERROR: no API key. Run 'engram auth login' first.");
+    process.exit(1);
+  }
+
+  const client = new Engram({
+    apiKey,
+    baseUrl: process.env.ENGRAM_BASE_URL ?? config.baseUrl ?? getBaseUrl(),
+  });
+
+  const db = new DaemonDb(DB_FILE);
+
+  const syncer = new Syncer(db, client);
+
+  // Wrap syncer.onMessages to handle the async call
+  const onMessages: ConstructorParameters<typeof Watcher>[1] = (
+    sessionId,
+    meta,
+    messages,
+  ) => {
+    syncer.onMessages(sessionId, meta, messages).catch((err) => {
+      log(`sync error: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  };
+
+  // One watcher per installed host (engram#261). Hosts that aren't
+  // installed are skipped, so this is safe on any machine.
+  const adapters = availableAdapters();
+  if (adapters.length === 0) {
+    log("no supported hosts detected (Claude Code, Codex). Nothing to watch.");
+  }
+  const watchers = adapters.map((a) => {
+    log(`watching ${a.label}: ${a.watchDir}`);
+    return new Watcher(db, onMessages, a);
+  });
+
+  // Start
+  for (const w of watchers) w.start();
+  syncer.startFlushLoop();
+
+  log(`watching for transcripts across ${watchers.length} host(s)...`);
+
+  // Graceful shutdown
+  const shutdown = async () => {
+    log("shutting down...");
+    for (const w of watchers) w.stop();
+    syncer.stopFlushLoop();
+
+    // Final flush
+    try {
+      await syncer.flush();
+    } catch {
+      // best effort
+    }
+
+    db.close();
+
+    try {
+      unlinkSync(PID_FILE);
+    } catch {
+      // already gone
+    }
+
+    log("daemon stopped");
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+}
+
+main().catch((err) => {
+  log(`fatal: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/apps/cli/src/daemon/worker.ts
+++ b/apps/cli/src/daemon/worker.ts
@@ -1,113 +1,23 @@
 #!/usr/bin/env node
 
 /**
- * Daemon worker process. Spawned by `engram start` and runs detached.
- * Watches Claude Code transcripts and streams them to Engram.
+ * Daemon entry point. Spawned by `engram start` and runs detached.
+ *
+ * This file must stay import-light: it preflights better-sqlite3 (healing
+ * the ABI mismatch that occurs when the installing Node differs from the
+ * running Node) BEFORE the worker body — with its static sqlite imports —
+ * is loaded. A static import here would defeat the preflight.
  */
 
-import { writeFileSync, unlinkSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-import { Engram } from "@getengram/sdk";
-import { loadConfig, getBaseUrl } from "../config.js";
-import { DaemonDb } from "./db.js";
-import { Watcher } from "./watcher.js";
-import { Syncer } from "./syncer.js";
-import { availableAdapters } from "./adapters.js";
-
-const ENGRAM_DIR = join(homedir(), ".engram");
-const PID_FILE = join(ENGRAM_DIR, "daemon.pid");
-const DB_FILE = join(ENGRAM_DIR, "daemon.db");
-const LOG_FILE = join(ENGRAM_DIR, "daemon.log");
+import { ensureNativeSqlite } from "./preflight.js";
 
 function log(msg: string): void {
-  const ts = new Date().toISOString();
-  const line = `[${ts}] ${msg}\n`;
-  process.stderr.write(line);
+  process.stderr.write(`[${new Date().toISOString()}] ${msg}\n`);
 }
 
-async function main(): Promise<void> {
-  // Write PID file
-  writeFileSync(PID_FILE, String(process.pid));
-
-  log(`daemon started (pid ${process.pid})`);
-  log(`database: ${DB_FILE}`);
-
-  // Load API key
-  const config = await loadConfig();
-  const apiKey = process.env.ENGRAM_API_KEY ?? config.apiKey;
-  if (!apiKey) {
-    log("ERROR: no API key. Run 'engram auth login' first.");
-    process.exit(1);
-  }
-
-  const client = new Engram({
-    apiKey,
-    baseUrl: process.env.ENGRAM_BASE_URL ?? config.baseUrl ?? getBaseUrl(),
-  });
-
-  const db = new DaemonDb(DB_FILE);
-
-  const syncer = new Syncer(db, client);
-
-  // Wrap syncer.onMessages to handle the async call
-  const onMessages: ConstructorParameters<typeof Watcher>[1] = (
-    sessionId,
-    meta,
-    messages,
-  ) => {
-    syncer.onMessages(sessionId, meta, messages).catch((err) => {
-      log(`sync error: ${err instanceof Error ? err.message : String(err)}`);
-    });
-  };
-
-  // One watcher per installed host (engram#261). Hosts that aren't
-  // installed are skipped, so this is safe on any machine.
-  const adapters = availableAdapters();
-  if (adapters.length === 0) {
-    log("no supported hosts detected (Claude Code, Codex). Nothing to watch.");
-  }
-  const watchers = adapters.map((a) => {
-    log(`watching ${a.label}: ${a.watchDir}`);
-    return new Watcher(db, onMessages, a);
-  });
-
-  // Start
-  for (const w of watchers) w.start();
-  syncer.startFlushLoop();
-
-  log(`watching for transcripts across ${watchers.length} host(s)...`);
-
-  // Graceful shutdown
-  const shutdown = async () => {
-    log("shutting down...");
-    for (const w of watchers) w.stop();
-    syncer.stopFlushLoop();
-
-    // Final flush
-    try {
-      await syncer.flush();
-    } catch {
-      // best effort
-    }
-
-    db.close();
-
-    try {
-      unlinkSync(PID_FILE);
-    } catch {
-      // already gone
-    }
-
-    log("daemon stopped");
-    process.exit(0);
-  };
-
-  process.on("SIGTERM", shutdown);
-  process.on("SIGINT", shutdown);
-}
-
-main().catch((err) => {
-  log(`fatal: ${err instanceof Error ? err.message : String(err)}`);
+if (!ensureNativeSqlite(log)) {
+  log("daemon exiting: native sqlite unavailable");
   process.exit(1);
-});
+}
+
+await import("./worker-main.js");


### PR DESCRIPTION
The daemon's native sqlite module is compiled against whichever Node ran
the install; when the runtime Node differs (brew node 26 vs npm node 20,
observed on the owner's machine) the addon throws an ABI error. Worse,
commands.ts imported db.js statically, so EVERY engram command crashed,
and the spawned daemon died silently in its log. With capture now on by
default this had to self-heal.

- daemon/preflight.ts: try load → on ABI mismatch run 'npm rebuild
  better-sqlite3' in the owning package (prebuilds make this a download,
  not a compile) → retry once → clear manual fix if it still fails
- worker.ts is now an import-light bootstrap that preflights before
  importing the worker body (worker-main.ts) with its static imports
- daemon status loads the DB lazily and degrades gracefully

Verified: CLI startup no longer loads better-sqlite3 at all.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
