### PR TITLE
fix: daily report died at 3.2M messages — index created_at, isolate cron failures

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -276,11 +276,21 @@ export default {
     //   03:00 UTC — GDPR purge of soft-deleted orgs
     //   13:00 UTC — daily ops report, emailed via engram-web
     if (event.cron === "0 13 * * *") {
-      await sendDailyReport(env);
+      // Isolated so a report failure can't swallow the Monday digests —
+      // and vice versa. Failures land in the worker logs with context.
+      try {
+        await sendDailyReport(env);
+      } catch (err) {
+        console.error(`[cron] daily report FAILED: ${err instanceof Error ? err.message : err}`);
+      }
       // Weekly memory digest (engram#256) — Mondays only.
       if (new Date(event.scheduledTime).getUTCDay() === 1) {
-        const digests = await sendWeeklyDigests(env);
-        if (digests > 0) console.log(`[cron] Sent ${digests} weekly digest(s)`);
+        try {
+          const digests = await sendWeeklyDigests(env);
+          if (digests > 0) console.log(`[cron] Sent ${digests} weekly digest(s)`);
+        } catch (err) {
+          console.error(`[cron] weekly digests FAILED: ${err instanceof Error ? err.message : err}`);
+        }
       }
       return;
     }

--- a/packages/db/migrations/0032_messages_created_at_idx.sql
+++ b/packages/db/migrations/0032_messages_created_at_idx.sql
@@ -1,0 +1,5 @@
+-- The daily ops report filters messages by created_at four ways (24h
+-- counts, active orgs, 7-day top-org join). With no index those are full
+-- scans — fine at thousands of rows, fatal at 3.2M: D1 kills the worker
+-- mid-report and the 13:00 cron dies silently (first observed 2026-07-31).
+CREATE INDEX IF NOT EXISTS idx_messages_created ON messages(created_at);


### PR DESCRIPTION
The report's four created_at-filtered queries were full scans; past ~3M
messages D1 kills the worker mid-build, so the 13:00 cron died silently
and no report went out (first miss 2026-07-31). Migration 0032 adds
idx_messages_created. The 13:00 handler now isolates the report and the
Monday digests in separate try/catch so one failure can't swallow the
other, and failures log with context instead of vanishing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
