### PR TITLE
feat: nightly off-Cloudflare D1 backup + physical db size gauge

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,38 @@
+# Nightly off-Cloudflare backup of the production D1 database.
+#
+# D1's built-in Time Travel gives 30-day point-in-time restore, but it
+# lives inside the same Cloudflare account — this export is the copy that
+# survives an account-level problem. Runs at 04:00 UTC (after the 03:00
+# purge cron) and keeps 14 days of compressed dumps as workflow artifacts.
+name: Nightly D1 backup
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: apps/mcp-server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Export D1 to SQL dump
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler d1 export engram-db --remote --output=backup.sql
+          gzip -9 backup.sql
+          ls -lh backup.sql.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: engram-db-${{ github.run_id }}
+          path: apps/mcp-server/backup.sql.gz
+          retention-days: 14
+          if-no-files-found: error

--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -196,6 +196,14 @@ admin.get("/metrics", async (c) => {
       messages: totals?.messages ?? 0,
       chunks: dbSize?.chunks ?? 0,
       api_keys: dbSize?.api_keys ?? 0,
+      // Physical D1 size vs the 10 GB per-database cap — watch this as
+      // messages grow. null if the platform rejects the pragma.
+      db_bytes: await c.env.DB.prepare(
+        "SELECT page_count * page_size AS bytes FROM pragma_page_count(), pragma_page_size()",
+      )
+        .first<{ bytes: number }>()
+        .then((r) => r?.bytes ?? null)
+        .catch(() => null),
     },
     today_signups: todaySignups?.results ?? [],
   });


### PR DESCRIPTION
D1's Time Travel (30-day PITR) covers oops-queries but lives in the same
Cloudflare account. A scheduled workflow now exports the full database
nightly (04:00 UTC, after the purge cron) and keeps 14 days of gzipped
dumps as artifacts using the existing CI credentials. /admin/metrics
storage gains db_bytes (pragma page math, null if unsupported) so we can
watch growth against D1's 10 GB per-database cap — the messages table
just crossed 3.2M rows.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
