### PR TITLE
fix(backup): export per-table — D1 refuses whole-db export with fts5

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -22,12 +22,21 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Export D1 to SQL dump
+      - name: Export D1 to SQL dump (per table — fts5 blocks whole-db export)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          npx wrangler d1 export engram-db --remote --output=backup.sql
+          # chunks_fts* (the FTS5 virtual table + its shadow tables) is
+          # excluded: D1 refuses to export virtual tables, and it's fully
+          # derived — restore = apply these dumps, then re-run migration
+          # 0006_add_fts5_search.sql to rebuild the search index.
+          TABLES=$(npx wrangler d1 execute engram-db --remote --json --command             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'chunks_fts%' AND name NOT LIKE 'd1_%' AND name NOT LIKE '_cf_%'"             | jq -r '.[0].results[].name')
+          echo "exporting: $TABLES"
+          for t in $TABLES; do
+            npx wrangler d1 export engram-db --remote --table="$t" --output="dump_$t.sql"
+          done
+          cat dump_*.sql > backup.sql
           gzip -9 backup.sql
           ls -lh backup.sql.gz
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
'cannot export databases with Virtual Tables (fts5)': chunks_fts blocks
the single-shot export. Enumerate real tables from sqlite_master and
export each; chunks_fts is derived, so restore is dumps + rerunning
migration 0006 to rebuild the index.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
