### PR TITLE
fix: daily report timed out again — replace COUNT(*) over messages with the maintained counter

### DIFF
--- a/apps/mcp-server/src/services/daily-report.ts
+++ b/apps/mcp-server/src/services/daily-report.ts
@@ -59,7 +59,13 @@ export async function buildDailyReport(env: Env): Promise<DailyReport> {
         "SELECT COUNT(*) AS n FROM organizations WHERE deleted_at IS NULL AND stripe_subscription_id IS NOT NULL",
       )
       .first<{ n: number }>(),
-    db.prepare("SELECT COUNT(*) AS n FROM messages").first<{ n: number }>(),
+    // Total messages via the maintained per-conversation counter (3.1k rows),
+    // NOT COUNT(*) over the 3.2M-row messages table — that full scan grows
+    // every day and was timing the worker out (the report stopped sending
+    // around Aug 4). This mirrors how /admin/metrics stays fast.
+    db
+      .prepare("SELECT COALESCE(SUM(message_count), 0) AS n FROM conversations")
+      .first<{ n: number }>(),
     db.prepare("SELECT COUNT(*) AS n FROM conversations").first<{ n: number }>(),
     db
       .prepare(


### PR DESCRIPTION
The Jul 31 index fixed the date-filtered queries, but the report still ran
'SELECT COUNT(*) FROM messages' — a full scan of 3.2M rows that grows daily
and pushed the worker past its 60s limit (report stopped sending ~Aug 4;
manual trigger died at exactly 60.2s). Switched the lifetime total to
SUM(message_count) over conversations (~3.1k rows), the same fast method
/admin/metrics uses (2s). The remaining messages queries are all
date-bounded and index-backed, so they stay cheap.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
