### PR TITLE
feat(api): PATCH /api/v1/conversations/:id/messages/:messageId — update a message in place

### DIFF
--- a/apps/mcp-server/src/__tests__/v1-rest.test.ts
+++ b/apps/mcp-server/src/__tests__/v1-rest.test.ts
@@ -216,3 +216,100 @@ describe("meterApiRequest middleware", () => {
     expect(waited.length).toBe(0);
   });
 });
+
+describe("REST v1 — update message (PATCH)", () => {
+  it("requires the write scope", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    const app = createApp("org_upd", ["read"]);
+    const res = await app.request(
+      "/api/v1/conversations/conv_x/messages/msg_x",
+      { method: "PATCH", body: JSON.stringify({ content: "hi" }), headers: { "Content-Type": "application/json" } },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("404s for a missing conversation", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    await insertOrganization(db, "org_upd2", "Upd Org");
+    const app = createApp("org_upd2");
+    const res = await app.request(
+      "/api/v1/conversations/conv_missing/messages/msg_x",
+      { method: "PATCH", body: JSON.stringify({ content: "hi" }), headers: { "Content-Type": "application/json" } },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("edits a message in place and returns the redacted content", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    await insertOrganization(db, "org_upd3", "Upd Org 3");
+    // Enterprise tier skips the atomic storage gate — the mock D1 doesn't
+    // emulate UPDATE…RETURNING, and this test targets the edit path, not
+    // the storage gate (covered in tier tests).
+    const app = new Hono<HonoEnv>();
+    app.use("*", async (c, next) => {
+      c.set("auth", {
+        organizationId: "org_upd3",
+        apiKeyId: "key_test",
+        scopes: ["read", "write", "search", "delete"] as Scope[],
+        tier: "enterprise" as const,
+      });
+      await next();
+    });
+    app.route("/api/v1", v1);
+
+    const create = await app.request(
+      "/api/v1/conversations",
+      { method: "POST", body: JSON.stringify({ title: "Edit me" }), headers: { "Content-Type": "application/json" } },
+      env,
+    );
+    const { conversation_id: convId } = (await create.json()) as {
+      conversation_id: string;
+    };
+
+    const append = await app.request(
+      "/api/v1/messages",
+      {
+        method: "POST",
+        body: JSON.stringify({ conversation_id: convId, messages: [{ role: "user", content: "the old wording" }] }),
+        headers: { "Content-Type": "application/json" },
+      },
+      env,
+    );
+    expect(append.status).toBe(200);
+    const { message_ids } = (await append.json()) as { message_ids: string[] };
+
+    const patch = await app.request(
+      `/api/v1/conversations/${convId}/messages/${message_ids[0]}`,
+      { method: "PATCH", body: JSON.stringify({ content: "the corrected wording" }), headers: { "Content-Type": "application/json" } },
+      env,
+    );
+    expect(patch.status).toBe(200);
+    const body = (await patch.json()) as { updated: boolean; message: { content: string; id: string } };
+    expect(body.updated).toBe(true);
+    expect(body.message.id).toBe(message_ids[0]);
+    expect(body.message.content).toBe("the corrected wording");
+
+    // No read-back here: the hand-rolled mock D1 doesn't emulate the
+    // ORDER BY/LIMIT SELECT that message listing uses. The PATCH response
+    // above is produced after the real redact→compress→UPDATE pipeline
+    // ran, which is the behavior under test.
+  });
+
+  it("rejects an empty content body", async () => {
+    const db = createMockD1();
+    const env = createMockEnv(db);
+    await insertOrganization(db, "org_upd4", "Upd Org 4");
+    const app = createApp("org_upd4");
+    const res = await app.request(
+      "/api/v1/conversations/conv_x/messages/msg_x",
+      { method: "PATCH", body: JSON.stringify({ content: "" }), headers: { "Content-Type": "application/json" } },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/mcp-server/src/routes/v1.ts
+++ b/apps/mcp-server/src/routes/v1.ts
@@ -9,6 +9,7 @@ import {
   getConversation,
   deleteConversation,
   appendMessages,
+  updateMessage,
   getOrCreateDefaultConversation,
 } from "../services/conversation.js";
 import {
@@ -346,6 +347,63 @@ v1.post("/messages", async (c) => {
     message_ids: messages.map((m) => m.id),
     ...(meter ? { usage: meter } : {}),
     ...(storageMeter ? { storage: storageMeter } : {}),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/conversations/:id/messages/:messageId — update a message
+// in place (REST-first, no MCP mirror yet — requested by the community
+// Obsidian plugin). Same redaction pipeline as append; the affected
+// search-index window is rebuilt so recall matches what's stored.
+// ---------------------------------------------------------------------------
+
+const updateMessageSchema = z.object({
+  content: z.string().min(1).max(1_000_000),
+});
+
+v1.patch("/conversations/:id/messages/:messageId", async (c) => {
+  const auth = c.get("auth");
+  if (!hasScope(auth, "write")) return scopeError(c, "write");
+
+  const conversationId = c.req.param("id");
+  const messageId = c.req.param("messageId");
+  const parsed = updateMessageSchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return c.json(
+      { error: "invalid_request", message: "content (non-empty string) is required" },
+      400,
+    );
+  }
+
+  const updated = await updateMessage(
+    c.env,
+    auth.organizationId,
+    conversationId,
+    messageId,
+    parsed.data.content,
+    auth,
+  );
+  if (!updated) {
+    return c.json({ error: "not_found", message: "Conversation or message not found" }, 404);
+  }
+
+  await audit(c.env.DB, auth.organizationId, auth.apiKeyId, "message.update", "message", messageId, {
+    conversation_id: conversationId,
+  });
+  fireWebhooks(c.env.DB, auth.organizationId, "message.updated", {
+    conversation_id: conversationId,
+    message_id: messageId,
+  });
+
+  return c.json({
+    updated: true,
+    message: {
+      id: updated.id,
+      conversation_id: updated.conversation_id,
+      role: updated.role,
+      content: updated.content,
+      sequence: updated.sequence,
+    },
   });
 });
 

--- a/apps/mcp-server/src/services/audit.ts
+++ b/apps/mcp-server/src/services/audit.ts
@@ -9,6 +9,7 @@ export type AuditAction =
   | "conversation.delete"
   | "conversation.retention_purge"
   | "messages.append"
+  | "message.update"
   | "account.update_email"
   | "account.delete"
   | "account.restore"

--- a/apps/mcp-server/src/services/conversation.ts
+++ b/apps/mcp-server/src/services/conversation.ts
@@ -22,6 +22,11 @@ import {
   insertChunks,
   getVectorizeIdsByConversation,
   insertVaultEntries,
+  getMessageById,
+  updateMessageContent,
+  getMessagesBySequenceRange,
+  getChunksOverlappingSequence,
+  deleteChunksByIds,
 } from "@getengram/db";
 import { generateEmbeddings } from "./embedding.js";
 import { releaseStorage } from "./tier.js";
@@ -313,6 +318,174 @@ export async function getConversation(
   ) as Message[];
 
   return { conversation, messages };
+}
+
+/**
+ * Update one message's content in place (engram: update API — requested by
+ * the community Obsidian plugin). The edit goes through the same redaction
+ * + compression pipeline as append, then the search index is rebuilt for
+ * exactly the chunk window the message participates in: overlapping chunks
+ * are deleted (D1 + FTS + Vectorize) and re-chunked from the fresh message
+ * contents, so recall stays consistent with what's stored. Reindexing is
+ * best-effort like append — on failure the edit is saved and search
+ * catches up on the next successful index.
+ *
+ * Returns the updated message, or null if the conversation/message doesn't
+ * exist (or the viewer can't access a private conversation).
+ */
+export async function updateMessage(
+  env: Env,
+  organizationId: string,
+  conversationId: string,
+  messageId: string,
+  newContent: string,
+  viewer?: AuthContext
+): Promise<Message | null> {
+  const conv = await getConversationById(env.DB, conversationId, organizationId);
+  if (!conv) return null;
+  if (
+    viewer &&
+    !canAccessConversation(
+      viewer,
+      conv as { visibility?: string | null; seat_id?: string | null }
+    )
+  ) {
+    return null;
+  }
+
+  const existing = (await getMessageById(env.DB, messageId, organizationId)) as
+    | (Record<string, unknown> & { conversation_id: string; sequence: number })
+    | null;
+  if (!existing || existing.conversation_id !== conversationId) return null;
+
+  // Same hygiene as append: redact, then compress for storage.
+  const candidate: Message = {
+    id: existing.id as string,
+    conversation_id: conversationId,
+    organization_id: organizationId,
+    role: existing.role as Message["role"],
+    content: newContent,
+    tool_call_id: (existing.tool_call_id as string | null) ?? null,
+    tool_name: (existing.tool_name as string | null) ?? null,
+    sequence: existing.sequence,
+    metadata: JSON.parse((existing.metadata as string) || "{}"),
+    created_at: existing.created_at as string,
+  };
+  const { messages: redacted, totalRedactions } = redactMessages([candidate]);
+  if (totalRedactions > 0) {
+    console.log(
+      `[redact] Scrubbed ${totalRedactions} sensitive pattern(s) from edit of ${messageId}`
+    );
+  }
+  const updated = redacted[0];
+  const compressed = await compressContent(updated.content);
+  await updateMessageContent(
+    env.DB,
+    messageId,
+    organizationId,
+    compressed.content,
+    compressed.encoding
+  );
+
+  // Rebuild the affected slice of the search index. Chunk boundaries are
+  // per-append-batch, so re-chunking just the window spanned by the
+  // invalidated chunks can't shift neighbours.
+  try {
+    const overlapping = await getChunksOverlappingSequence(
+      env.DB,
+      conversationId,
+      organizationId,
+      existing.sequence
+    );
+    const old = overlapping.results ?? [];
+    const startSeq = old.length
+      ? Math.min(...old.map((c) => c.start_sequence))
+      : existing.sequence;
+    const endSeq = old.length
+      ? Math.max(...old.map((c) => c.end_sequence))
+      : existing.sequence;
+
+    const windowResult = await getMessagesBySequenceRange(
+      env.DB,
+      conversationId,
+      organizationId,
+      startSeq,
+      endSeq
+    );
+    const windowMessages = (await Promise.all(
+      (windowResult.results as Array<Record<string, unknown>>).map(
+        async (m) => ({
+          ...m,
+          content: await decompressContent(
+            m.content as string,
+            m.content_encoding as string | null
+          ),
+          metadata: JSON.parse((m.metadata as string) || "{}"),
+        })
+      )
+    )) as Message[];
+
+    const chunks = chunkMessages(windowMessages);
+    const texts = chunks.map((c) => c.text);
+    const embeddings = texts.length
+      ? await generateEmbeddings(env.AI, texts)
+      : [];
+
+    if (old.length > 0) {
+      await env.VECTORIZE.deleteByIds(old.map((c) => c.vectorize_id));
+      await deleteChunksByIds(
+        env.DB,
+        old.map((c) => c.id),
+        organizationId
+      );
+    }
+
+    if (chunks.length > 0) {
+      const chunkRecords = chunks.map((chunk, i) => ({
+        id: generateId("chk"),
+        conversationId,
+        organizationId,
+        chunkText: chunk.text,
+        chunkSummary: summarizeChunk(chunk.text),
+        startSequence: chunk.startSequence,
+        endSequence: chunk.endSequence,
+        vectorizeId: generateId("chk"),
+        embedding: embeddings[i],
+      }));
+      await insertChunks(
+        env.DB,
+        chunkRecords.map((c) => ({
+          id: c.id,
+          conversationId: c.conversationId,
+          organizationId: c.organizationId,
+          chunkText: c.chunkText,
+          chunkSummary: c.chunkSummary,
+          startSequence: c.startSequence,
+          endSequence: c.endSequence,
+          vectorizeId: c.vectorizeId,
+        }))
+      );
+      await env.VECTORIZE.upsert(
+        chunkRecords.map((c) => ({
+          id: c.vectorizeId,
+          values: c.embedding,
+          metadata: {
+            organization_id: organizationId,
+            conversation_id: conversationId,
+            start_sequence: c.startSequence,
+            end_sequence: c.endSequence,
+          },
+        }))
+      );
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[index] Failed to reindex after edit of ${messageId}: ${msg}`
+    );
+  }
+
+  return updated;
 }
 
 export async function deleteConversation(

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -439,6 +439,7 @@ All requests require the same `Authorization: Bearer engram_sk_live_...` header.
 | `GET /api/v1/conversations/:id` | `get_conversation` | Fetch a conversation with messages. Query: `message_limit`, `message_offset` |
 | `DELETE /api/v1/conversations/:id` | `delete_conversation` | Delete a conversation, its messages, and embeddings |
 | `POST /api/v1/messages` | `append_messages` | Store messages. Body: `{ conversation_id?, messages: [{ role, content, ... }] }` — omit `conversation_id` to use the default memory |
+| `PATCH /api/v1/conversations/:id/messages/:messageId` | — (REST only) | Update a message's content in place. Body: `{ content }` → `200 { updated, message }`. The edit runs the same redaction pipeline as append, and the affected slice of the search index is rebuilt so recall matches the stored text. Requires the `write` scope. |
 | `GET /api/v1/search` | `search` | Hybrid search. Query: `q` (required), `limit`, `conversation_id`, `tags`, `project` |
 
 ### Example

--- a/packages/db/src/queries/chunks.ts
+++ b/packages/db/src/queries/chunks.ts
@@ -115,3 +115,38 @@ export function getVectorizeIdsByConversation(
     .bind(conversationId, organizationId)
     .all<{ vectorize_id: string }>();
 }
+
+/** Chunks whose [start,end] sequence window covers the given message
+ *  sequence — the ones invalidated when that message's content changes. */
+export function getChunksOverlappingSequence(
+  db: D1Database,
+  conversationId: string,
+  organizationId: string,
+  sequence: number
+) {
+  return db
+    .prepare(
+      "SELECT id, vectorize_id, start_sequence, end_sequence FROM conversation_chunks WHERE conversation_id = ? AND organization_id = ? AND start_sequence <= ? AND end_sequence >= ?"
+    )
+    .bind(conversationId, organizationId, sequence, sequence)
+    .all<{ id: string; vectorize_id: string; start_sequence: number; end_sequence: number }>();
+}
+
+export function deleteChunksByIds(
+  db: D1Database,
+  ids: string[],
+  organizationId: string
+) {
+  if (ids.length === 0) return Promise.resolve();
+  const ph = ids.map(() => "?").join(",");
+  return db.batch([
+    db
+      .prepare(`DELETE FROM chunks_fts WHERE chunk_id IN (${ph})`)
+      .bind(...ids),
+    db
+      .prepare(
+        `DELETE FROM conversation_chunks WHERE id IN (${ph}) AND organization_id = ?`
+      )
+      .bind(...ids, organizationId),
+  ]);
+}

--- a/packages/db/src/queries/messages.ts
+++ b/packages/db/src/queries/messages.ts
@@ -70,3 +70,29 @@ export function getMessagesBySequenceRange(
     .bind(conversationId, organizationId, startSeq, endSeq)
     .all();
 }
+
+export function getMessageById(
+  db: D1Database,
+  messageId: string,
+  organizationId: string
+) {
+  return db
+    .prepare("SELECT * FROM messages WHERE id = ? AND organization_id = ?")
+    .bind(messageId, organizationId)
+    .first();
+}
+
+export function updateMessageContent(
+  db: D1Database,
+  messageId: string,
+  organizationId: string,
+  content: string,
+  contentEncoding: string | null
+) {
+  return db
+    .prepare(
+      "UPDATE messages SET content = ?, content_encoding = ? WHERE id = ? AND organization_id = ?"
+    )
+    .bind(content, contentEncoding, messageId, organizationId)
+    .run();
+}


### PR DESCRIPTION
The REST API had append and delete but no update — the gap the community
Obsidian plugin (obsidian-engram-vault) hit trying to push note edits
back. Edits run the same redaction + compression pipeline as append, then
the search index is rebuilt for exactly the chunk window the message
participates in: overlapping chunks are deleted (D1 + FTS5 + Vectorize)
and re-chunked from fresh contents, so recall stays consistent with
what's stored. Chunk boundaries are per-append-batch, so the windowed
rebuild can't shift neighbours. Reindex is best-effort like append.

Write scope required; audited as message.update; fires a message.updated
webhook. REST-only for now (no MCP mirror). Four endpoint tests added;
docs updated.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
