### PR TITLE
fix(billing): scheduled cancellations via cancel_at were invisible

### DIFF
--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -422,6 +422,7 @@ admin.post("/users/:id/sync-stripe", async (c) => {
       id: string; status: string;
       items: { data: Array<{ price: { id: string }; quantity: number }> };
       cancel_at_period_end: boolean;
+      cancel_at: number | null;
       canceled_at: number | null;
     }>;
   };
@@ -456,14 +457,17 @@ admin.post("/users/:id/sync-stripe", async (c) => {
   if (priceId === c.env.STRIPE_PRICE_ID_TEAM) tier = "team";
   const seatLimit = tier === "team" ? quantity : 1;
 
+  // Both of Stripe's scheduled-cancel mechanisms count (see billing.ts
+  // webhook note): the bool AND the cancel_at timestamp.
+  const cancelling = Boolean(activeSub.cancel_at_period_end) || activeSub.cancel_at != null;
   await c.env.DB.prepare(
     "UPDATE organizations SET tier = ?, stripe_subscription_id = ?, seat_limit = ?, cancel_at_period_end = ?, churned_at = CASE WHEN ? = 0 THEN NULL ELSE churned_at END WHERE id = ?"
   ).bind(
     tier,
     activeSub.id,
     seatLimit,
-    activeSub.cancel_at_period_end ? 1 : 0,
-    activeSub.cancel_at_period_end ? 1 : 0,
+    cancelling ? 1 : 0,
+    cancelling ? 1 : 0,
     id,
   ).run();
 
@@ -472,7 +476,8 @@ admin.post("/users/:id/sync-stripe", async (c) => {
     tier,
     subscription_id: activeSub.id,
     status: activeSub.status,
-    cancel_at_period_end: activeSub.cancel_at_period_end,
+    cancel_at_period_end: cancelling,
+    cancel_at: activeSub.cancel_at ? new Date(activeSub.cancel_at * 1000).toISOString() : null,
     seat_limit: seatLimit,
   });
 });

--- a/apps/mcp-server/src/routes/billing.ts
+++ b/apps/mcp-server/src/routes/billing.ts
@@ -331,10 +331,16 @@ billingWebhook.post("/", async (c) => {
         await setOrganizationTier(c.env.DB, orgId, newTier, subscriptionId, seatLimit);
         // Track scheduled cancellation ("pro but cancelling" in admin). An
         // active sub also clears any past churn stamp — they came back.
+        // Stripe records a scheduled cancel two ways: cancel_at_period_end
+        // (bool) or cancel_at (timestamp, e.g. portal "cancel on <date>").
+        // Reading only the bool missed real cancellations (anar3nata,
+        // 2026-08 — dashboard showed "Cancels Aug 15", admin showed
+        // healthy).
+        const cancelling = Boolean(obj.cancel_at_period_end) || obj.cancel_at != null;
         await c.env.DB.prepare(
           "UPDATE organizations SET cancel_at_period_end = ?, churned_at = CASE WHEN ? = 0 THEN NULL ELSE churned_at END WHERE id = ?",
         )
-          .bind(obj.cancel_at_period_end ? 1 : 0, obj.cancel_at_period_end ? 1 : 0, orgId)
+          .bind(cancelling ? 1 : 0, cancelling ? 1 : 0, orgId)
           .run();
       } else if (
         status === "canceled" ||


### PR DESCRIPTION
Stripe records a scheduled cancel two ways — cancel_at_period_end (bool)
or cancel_at (timestamp, e.g. billing-portal 'cancel on <date>'). Both
the subscription.updated webhook and admin sync-stripe read only the
bool, so customers cancelling via the timestamp path (anar3nata:
dashboard showed 'Cancels Aug 15', admin showed healthy) never got the
orange cancelling badge and looked fine until they vanished. Both
readers now treat either mechanism as cancelling; sync-stripe also
returns the cancel_at date.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
