### PR TITLE
fix(billing): cancel_at false-positive flagged an active customer as cancelling

### DIFF
--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -459,7 +459,7 @@ admin.post("/users/:id/sync-stripe", async (c) => {
 
   // Both of Stripe's scheduled-cancel mechanisms count (see billing.ts
   // webhook note): the bool AND the cancel_at timestamp.
-  const cancelling = Boolean(activeSub.cancel_at_period_end) || activeSub.cancel_at != null;
+  const cancelling = Boolean(activeSub.cancel_at_period_end) || (typeof activeSub.cancel_at === "number" && activeSub.cancel_at > 0);
   await c.env.DB.prepare(
     "UPDATE organizations SET tier = ?, stripe_subscription_id = ?, seat_limit = ?, cancel_at_period_end = ?, churned_at = CASE WHEN ? = 0 THEN NULL ELSE churned_at END WHERE id = ?"
   ).bind(

--- a/apps/mcp-server/src/routes/billing.ts
+++ b/apps/mcp-server/src/routes/billing.ts
@@ -336,7 +336,7 @@ billingWebhook.post("/", async (c) => {
         // Reading only the bool missed real cancellations (anar3nata,
         // 2026-08 — dashboard showed "Cancels Aug 15", admin showed
         // healthy).
-        const cancelling = Boolean(obj.cancel_at_period_end) || obj.cancel_at != null;
+        const cancelling = Boolean(obj.cancel_at_period_end) || (typeof obj.cancel_at === "number" && obj.cancel_at > 0);
         await c.env.DB.prepare(
           "UPDATE organizations SET cancel_at_period_end = ?, churned_at = CASE WHEN ? = 0 THEN NULL ELSE churned_at END WHERE id = ?",
         )


### PR DESCRIPTION
PR #335 used 'cancel_at != null' to detect scheduled cancels, but Stripe
returns cancel_at as 0 (not null) on healthy subscriptions in some
payloads — so the next sync flagged an active team customer
(will.isaiah, 170k messages, no cancellation in Stripe) as cancelling.
Now requires a positive timestamp: cancel_at is number && > 0. anar3nata's
real cancel_at (a future epoch) still counts; healthy subs no longer do.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
