### PR TITLE
chore(admin): surface canceled_at + cancellation_details in the Stripe peek

### DIFF
--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -611,6 +611,8 @@ admin.get("/stripe-customer/:customerId", async (c) => {
       trial_start: s.trial_start,
       trial_end: s.trial_end,
       pause_collection: s.pause_collection ?? null,
+      canceled_at: s.canceled_at ?? null,
+      cancellation_details: s.cancellation_details ?? null,
       current_period_end: s.current_period_end,
       items: ((s.items as { data?: Array<{ price?: { unit_amount?: number; recurring?: { interval?: string } } }> })?.data ?? []).map(
         (i) => ({ unit_amount: i.price?.unit_amount, interval: i.price?.recurring?.interval }),


### PR DESCRIPTION
The peek omitted when a cancellation was requested and why, so a scheduled
cancel (will.isaiah, effective Sep 3) couldn't be dated. Adds both fields,
read-only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
