### PR TITLE
fix(docs): correct accuracy issues across docs + launch drafts

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Engram exposes 11 tools via the Model Context Protocol (MCP). All tools are accessed through the `/mcp` endpoint using Streamable HTTP transport.
+Engram exposes 7 core memory tools via the Model Context Protocol (MCP), plus vault and subscription tools on API-key surfaces. All tools are accessed through the `/mcp` endpoint using Streamable HTTP transport.
 
 All requests require an `Authorization: Bearer engram_sk_live_...` header.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -11,7 +11,7 @@ How Engram differs from other agent memory solutions.
 | Data loss | None — full transcript preserved | Details lost in extraction | Details lost in summarization | Context lost in extraction |
 | Protocol | MCP (native) | REST API | REST API | REST API |
 | Search | Semantic (vector) | Semantic | Semantic + graph | Semantic |
-| Self-hostable | Yes (Cloudflare) | Yes | Yes | Yes |
+| Self-hostable | Yes — source-available (BSL 1.1) | Yes | Yes | Yes |
 | Infrastructure | Cloudflare (D1 + Vectorize + Workers AI) | Postgres + Qdrant + OpenAI | Postgres + embeddings | Various |
 | Embedding cost | Free (Workers AI) | OpenAI API cost | Varies | Varies |
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,7 +4,7 @@
 
 ### What is Engram?
 
-Engram is a memory service for AI agents. It stores complete, uncompressed conversation transcripts and makes them searchable via semantic search. It's accessible through the Model Context Protocol (MCP).
+Engram is a memory service for AI agents. It stores complete, verbatim conversation transcripts and makes them searchable via semantic search. It's accessible through the Model Context Protocol (MCP).
 
 ### How is Engram different from Mem0, Zep, or Supermemory?
 
@@ -76,7 +76,7 @@ The MCP transport uses Streamable HTTP, which supports server-sent events. Howev
 
 ### Can I use Engram without MCP?
 
-Not yet. The current MVP only exposes MCP tools. A REST API is planned for Phase 2.
+Yes. Every memory operation is also available as a plain REST API under `/api/v1` — same behavior, same API key — on every plan. Use it from backends, scripts, and anywhere an MCP client isn't practical. See the [API reference](./api-reference.md#rest-api).
 
 ### How do I protect secrets and credentials in my conversations?
 

--- a/docs/launch/blog-post.md
+++ b/docs/launch/blog-post.md
@@ -152,4 +152,4 @@ If you're building with AI agents and tired of re-explaining your codebase every
 
 ---
 
-*Engram is open source under the MIT license. Contributions welcome.*
+*Engram is source-available: server & CLI under BSL 1.1 (self-host for your own use; converts to Apache 2.0 in 2030), SDK under MPL-2.0. Contributions welcome.*

--- a/docs/launch/chatgpt-app/README.md
+++ b/docs/launch/chatgpt-app/README.md
@@ -14,7 +14,7 @@ Copy-paste-ready launch posts for **Engram now being live in the ChatGPT App Dir
 
 ## Accuracy checklist
 
-- Product/repo license is **BSL-1.1**; the SDK + CLI are **MIT**.
+- Server & CLI are **BSL-1.1**; the SDK is **MPL-2.0**.
 - Free tier = **10,000 messages of memory, never expires**. Pro = **$9/mo** (1,000,000 messages of memory).
 - You **can** now say "available in the ChatGPT App Directory" (it's live).
 - Don't claim a Homebrew tap until `engram` is actually on homebrew-core (#36).

--- a/docs/launch/chatgpt-app/show-hn.md
+++ b/docs/launch/chatgpt-app/show-hn.md
@@ -25,7 +25,7 @@ Under the hood it's stored verbatim (no lossy summarization), chunked, and embed
 
 Connect in ChatGPT: Plugin directory → install Engram (OAuth, no key to paste). Free tier is 10,000 messages of memory — never expires; Pro is $9/mo.
 
-Source is BSL-1.1; the SDK + CLI are MIT: https://github.com/get-engram/engram
+Source is BSL-1.1 (server & CLI); the SDK is MPL-2.0: https://github.com/get-engram/engram
 Site: https://getengram.app
 
 I'd love feedback — especially: what context do you find yourself re-explaining to your AI tools the most? And would "one memory across all of them" actually change how you work, or is per-tool memory enough?
@@ -33,6 +33,6 @@ I'd love feedback — especially: what context do you find yourself re-explainin
 ---
 
 ## Accuracy notes
-- BSL-1.1 (product) / MIT (SDK+CLI). Free tier 1,000 msgs/mo. $9 Pro.
+- BSL-1.1 (server & CLI) / MPL-2.0 (SDK). Free tier 10,000 messages, no monthly cap. $9 Pro.
 - Do NOT claim ChatGPT auto-records everything — it's save-on-request + import.
 - OK to say "ChatGPT app" now that it's live in the directory.

--- a/docs/launch/chatgpt-app/x-thread.md
+++ b/docs/launch/chatgpt-app/x-thread.md
@@ -44,7 +44,7 @@ Runs entirely on Cloudflare. Fast, private, per-account isolated.
 ## Tweet 6 (CTA)
 Add Engram in ChatGPT: Settings → Apps & Connectors → Engram.
 
-Free tier (1,000 msgs/mo). Open source.
+Free tier (10,000 messages, no monthly cap). Source-available (BSL 1.1).
 
 → https://getengram.app
 

--- a/docs/launch/context-window-paper.md
+++ b/docs/launch/context-window-paper.md
@@ -234,7 +234,7 @@ The context window problem is not a model limitation that will be solved by bigg
 
 Store everything. Search when you need it. Let the conversation be the knowledge base.
 
-Engram is open source under the MIT license: [github.com/get-engram/engram](https://github.com/get-engram/engram)
+Engram is source-available: server & CLI under BSL 1.1 (self-host for your own use; converts to Apache 2.0 in 2030), SDK under MPL-2.0: [github.com/get-engram/engram](https://github.com/get-engram/engram)
 
 ---
 

--- a/docs/launch/one-memory-everywhere.md
+++ b/docs/launch/one-memory-everywhere.md
@@ -56,4 +56,4 @@ Then just work. Save something in one place, recall it in another. One memory, e
 
 ---
 
-*Engram is open source (MIT) and available hosted at [getengram.app](https://getengram.app) or self-hosted. Persistent, verbatim, searchable memory for every AI you use.*
+*Engram is source-available: server & CLI under BSL 1.1 (self-host for your own use; converts to Apache 2.0 in 2030), SDK under MPL-2.0. Available hosted at [getengram.app](https://getengram.app) or self-hosted. Persistent, verbatim, searchable memory for every AI you use.*

--- a/docs/launch/product-hunt.md
+++ b/docs/launch/product-hunt.md
@@ -10,7 +10,7 @@ Engram gives your AI agents persistent memory. Every conversation you have with 
 
 Install the CLI via Homebrew or npm, start the background daemon, and it auto-captures your Claude Code transcripts with zero friction. Engram runs as an MCP server on Cloudflare Workers, so your agent can store and recall context natively — no copy-pasting, no manual notes.
 
-Engram is open source (MIT), GDPR compliant, and has a free tier to get started. Self-host it or use the hosted version at getengram.app.
+Engram is source-available: server & CLI under BSL 1.1 (self-host for your own use; converts to Apache 2.0 in 2030), SDK under MPL-2.0. GDPR compliant, with a free tier to get started. Use the hosted version at getengram.app, or self-host your own instance.
 
 ## Maker Comment
 
@@ -20,7 +20,7 @@ I tried keeping notes, pasting things into docs, even saving transcripts manuall
 
 So Engram captures your full conversations automatically and makes them searchable via semantic search. Your agent can query its own history through MCP. The first time Claude Code pulled up a decision we'd made three sessions ago without me prompting it, it felt like a genuine step change in how useful these tools are.
 
-It's MIT licensed and open source. Would love your feedback — especially if you're using Claude Code or Cursor heavily and have felt this same pain.
+It's source-available: server & CLI under BSL 1.1 (self-host for your own use; converts to Apache 2.0 in 2030), SDK under MPL-2.0. Would love your feedback — especially if you're using Claude Code or Cursor heavily and have felt this same pain.
 
 ## Topics/Tags
 

--- a/docs/launch/reddit-claude-ai.md
+++ b/docs/launch/reddit-claude-ai.md
@@ -42,7 +42,7 @@ CLAUDE.md is great for static instructions. But it's a flat file -- no semantic 
 - MCP-native -- works with Claude Code, Claude Desktop, Cursor, Windsurf, Zed
 - Verbatim storage -- no summarization, no lossy extraction
 - Semantic search powered by vector embeddings
-- Free tier available, the SDK and CLI are MIT licensed
+- Free tier available; the SDK is MPL-2.0, CLI is BSL-1.1
 - Self-hostable on Cloudflare (free tier covers it)
 
 Website: https://getengram.app

--- a/docs/launch/reddit-local-llama.md
+++ b/docs/launch/reddit-local-llama.md
@@ -1,6 +1,6 @@
 # Reddit r/LocalLLaMA Draft
 
-**Title:** Engram: self-hostable memory service for AI agents -- MCP-native, runs on Cloudflare free tier, SDK/CLI are MIT
+**Title:** Engram: self-hostable memory service for AI agents -- MCP-native, runs on Cloudflare free tier, SDK is MPL-2.0 / CLI is BSL-1.1
 
 ---
 
@@ -8,7 +8,7 @@ I've been building a memory layer for AI agents called Engram. The core idea: st
 
 **Why I'm posting here:**
 
-The SDK and CLI are MIT licensed, the server is self-hostable on Cloudflare's free tier, and it uses the Model Context Protocol (MCP) which means it works with any MCP-compatible client. If you're running local models through an MCP-compatible interface, this gives them persistent memory.
+The SDK is MPL-2.0 and the CLI is BSL-1.1, the server is self-hostable on Cloudflare's free tier, and it uses the Model Context Protocol (MCP) which means it works with any MCP-compatible client. If you're running local models through an MCP-compatible interface, this gives them persistent memory.
 
 **Self-hosting:**
 

--- a/docs/launch/social-posts.md
+++ b/docs/launch/social-posts.md
@@ -98,7 +98,7 @@ Protocol-wise, it's standard MCP over HTTP with SSE transport. Any agent or clie
 
 **CLI:** `npm i -g @getengram/cli` (includes a daemon for auto-capturing Claude Code sessions)
 
-If you don't want to self-host, there's a managed version at https://getengram.app with a free tier (1,000 msgs/mo).
+If you don't want to self-host, there's a managed version at https://getengram.app with a free tier (10,000 messages, no monthly cap).
 
 Happy to answer questions about the architecture or MCP integration. PRs welcome.
 

--- a/docs/launch/twitter-thread.md
+++ b/docs/launch/twitter-thread.md
@@ -71,6 +71,6 @@ Entire stack runs on Cloudflare. Zero servers.
 Engram is live now. Free tier to get started.
 
 Try it: https://getengram.app
-SDK + CLI are MIT licensed: https://github.com/get-engram/engram
+SDK is MPL-2.0, CLI is BSL-1.1: https://github.com/get-engram/engram
 
 Your agents should remember. Now they can.

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -104,4 +104,13 @@ Each `append_messages` call is 1 Worker request. Each `search` is 1 request. At 
 
 ## Rate Limiting
 
-Rate limiting is not yet implemented in the Engram MVP. It is planned for Phase 2. For self-hosted instances, Cloudflare's platform limits serve as a natural rate limit.
+Requests are rate limited per organization with a token bucket. Limits scale by plan:
+
+| Plan | Requests per minute |
+|------|--------------------|
+| Free | 30 |
+| Pro | 120 |
+| Team | 300 |
+| Enterprise | 600 |
+
+Every response includes an `X-RateLimit-Limit` header. When you exceed the limit, the request returns `429 Too Many Requests` with a `retry_after` of 60 seconds. Billing endpoints are exempt. For self-hosted instances, Cloudflare's platform limits also apply.


### PR DESCRIPTION
Companion to the engram-web marketing-accuracy fixes:
- docs/faq.md: REST API is live (was 'planned Phase 2'); 'uncompressed' →
  'verbatim'.
- docs/limits.md: rate limiting IS implemented (per-org token bucket) —
  removed 'not yet implemented'.
- docs/api-reference.md + comparison.md: tool count / self-hostable row
  aligned to reality.
- docs/launch/*: draft launch copy (Product Hunt, Reddit, Twitter, HN)
  corrected — 'open source (MIT)' → source-available BSL-1.1/MPL-2.0;
  free tier '1,000/mo' → 10,000, no monthly cap. Fixed before these ship.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52
