### PR TITLE
content-sizing: also measure chunks_fts_data (the FTS index bulk)

### DIFF
--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -701,8 +701,22 @@ admin.get("/content-sizing", async (c) => {
   const summaryAvg = blend(sHead, sTail);
   const GB = 1024 * 1024 * 1024;
 
+  // FTS5 index bulk lives in the chunks_fts_data shadow table (segment blobs).
+  // This is the redundant third copy of the text + the inverted index.
+  let ftsDataBytes = 0;
+  try {
+    const f = await c.env.DB.prepare(
+      "SELECT SUM(LENGTH(CAST(block AS BLOB))) AS bytes FROM chunks_fts_data",
+    ).first<{ bytes: number | null }>();
+    ftsDataBytes = f?.bytes ?? 0;
+  } catch (e) {
+    ftsDataBytes = -1;
+  }
+  const GB2 = 1024 * 1024 * 1024;
+
   return c.json({
     sample_size_per_end: SAMPLE,
+    chunks_fts_est_gb: ftsDataBytes < 0 ? "error" : +(ftsDataBytes / GB2).toFixed(2),
     messages: {
       count: msgCount,
       content_avg_bytes_head: Math.round(cHead.avg),


### PR DESCRIPTION
The standalone FTS5 table stores a full copy of chunk_text plus the inverted
index in the chunks_fts_data shadow table. SUM(LENGTH(block)) there is the
FTS footprint — the redundant third copy of the conversation text. Completes
the Phase 0 D1 size breakdown.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
