### PR TITLE
index: deterministic chunk ids + idempotent insert (Step 1 of search-coverage fix)

### DIFF
--- a/apps/mcp-server/src/services/conversation.ts
+++ b/apps/mcp-server/src/services/conversation.ts
@@ -1,6 +1,7 @@
 import {
   generateId,
   chunkMessages,
+  chunkId,
   summarizeChunk,
   redactMessages,
   type MessageInput,
@@ -219,16 +220,23 @@ export async function appendMessages(
 
       // Prepare chunk records with vectorize IDs
       const chunkRecords = chunks.map((chunk, i) => {
-        const vectorizeId = generateId("chk");
+        // Deterministic id -> re-indexing the same window is a pure upsert,
+        // never a duplicate. Same value for the row id and the vector id.
+        const cid = chunkId(
+          conversationId,
+          chunk.startSequence,
+          chunk.endSequence,
+          chunk.index,
+        );
         return {
-          id: generateId("chk"),
+          id: cid,
           conversationId,
           organizationId,
           chunkText: chunk.text,
           chunkSummary: summarizeChunk(chunk.text),
           startSequence: chunk.startSequence,
           endSequence: chunk.endSequence,
-          vectorizeId,
+          vectorizeId: cid,
           embedding: embeddings[i],
         };
       });
@@ -441,17 +449,25 @@ export async function updateMessage(
     }
 
     if (chunks.length > 0) {
-      const chunkRecords = chunks.map((chunk, i) => ({
-        id: generateId("chk"),
-        conversationId,
-        organizationId,
-        chunkText: chunk.text,
-        chunkSummary: summarizeChunk(chunk.text),
-        startSequence: chunk.startSequence,
-        endSequence: chunk.endSequence,
-        vectorizeId: generateId("chk"),
-        embedding: embeddings[i],
-      }));
+      const chunkRecords = chunks.map((chunk, i) => {
+        const cid = chunkId(
+          conversationId,
+          chunk.startSequence,
+          chunk.endSequence,
+          chunk.index,
+        );
+        return {
+          id: cid,
+          conversationId,
+          organizationId,
+          chunkText: chunk.text,
+          chunkSummary: summarizeChunk(chunk.text),
+          startSequence: chunk.startSequence,
+          endSequence: chunk.endSequence,
+          vectorizeId: cid,
+          embedding: embeddings[i],
+        };
+      });
       await insertChunks(
         env.DB,
         chunkRecords.map((c) => ({

--- a/packages/db/src/queries/chunks.ts
+++ b/packages/db/src/queries/chunks.ts
@@ -11,28 +11,40 @@ export function insertChunks(
     vectorizeId: string;
   }>
 ) {
-  const stmts = chunks.flatMap((c) => [
-    db
-      .prepare(
-        "INSERT INTO conversation_chunks (id, conversation_id, organization_id, chunk_text, chunk_summary, start_sequence, end_sequence, vectorize_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
-      )
-      .bind(
-        c.id,
-        c.conversationId,
-        c.organizationId,
-        c.chunkText,
-        c.chunkSummary,
-        c.startSequence,
-        c.endSequence,
-        c.vectorizeId
-      ),
-    // Dual-write into FTS5 index for keyword search
-    db
-      .prepare(
-        "INSERT INTO chunks_fts(chunk_text, chunk_id, organization_id) VALUES (?, ?, ?)"
-      )
-      .bind(c.chunkText, c.id, c.organizationId),
-  ]);
+  if (chunks.length === 0) return Promise.resolve();
+  // Idempotent by chunk id: with deterministic ids (see chunkId()), re-indexing
+  // the same window must upsert, not duplicate or PK-conflict. chunks_fts has no
+  // unique key and chunk_id is UNINDEXED (a per-row delete would full-scan the
+  // whole FTS on every append), so we clear all prior FTS rows for this batch's
+  // ids in ONE delete up front, then INSERT OR REPLACE each chunk row and write
+  // its fresh FTS row. All in one D1 batch/transaction.
+  const ids = chunks.map((c) => c.id);
+  const ph = ids.map(() => "?").join(",");
+  const stmts = [
+    db.prepare(`DELETE FROM chunks_fts WHERE chunk_id IN (${ph})`).bind(...ids),
+    ...chunks.flatMap((c) => [
+      db
+        .prepare(
+          "INSERT OR REPLACE INTO conversation_chunks (id, conversation_id, organization_id, chunk_text, chunk_summary, start_sequence, end_sequence, vectorize_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        )
+        .bind(
+          c.id,
+          c.conversationId,
+          c.organizationId,
+          c.chunkText,
+          c.chunkSummary,
+          c.startSequence,
+          c.endSequence,
+          c.vectorizeId
+        ),
+      // Dual-write into FTS5 index for keyword search
+      db
+        .prepare(
+          "INSERT INTO chunks_fts(chunk_text, chunk_id, organization_id) VALUES (?, ?, ?)"
+        )
+        .bind(c.chunkText, c.id, c.organizationId),
+    ]),
+  ];
   return db.batch(stmts);
 }
 

--- a/packages/shared/src/__tests__/chunk.test.ts
+++ b/packages/shared/src/__tests__/chunk.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { chunkMessages, estimateTokens, summarizeChunk } from "../utils/chunk.js";
+import { chunkMessages, chunkId, estimateTokens, summarizeChunk } from "../utils/chunk.js";
 import type { Message } from "../types/index.js";
 
 const MAX_CHARS = 480 * 4; // mirrors MAX_TOKENS * CHARS_PER_TOKEN in chunk.ts
@@ -200,5 +200,52 @@ describe("chunkMessages", () => {
         "[assistant]: First sentence here. " + "x".repeat(300);
       expect(summarizeChunk(text)).toBe("First sentence here.");
     });
+  });
+});
+
+describe("deterministic chunk identity", () => {
+  it("assigns index 0 to ordinary (uniquely-ranged) windows", () => {
+    const messages = Array.from({ length: 8 }, (_, i) =>
+      makeMessage(i + 1, i % 2 ? "assistant" : "user", `msg ${i + 1}`)
+    );
+    const chunks = chunkMessages(messages);
+    // overlapping windows all have distinct [start,end] -> every index is 0
+    expect(chunks.every((c) => c.index === 0)).toBe(true);
+  });
+
+  it("disambiguates pieces of one oversized message with 0,1,2…", () => {
+    // A single message far over the embedding budget is hard-split into
+    // pieces that all share the same [start,end]=[1,1]; they must get
+    // distinct indices so their ids don't collide.
+    const huge = "x".repeat(MAX_CHARS * 3 + 10);
+    const chunks = chunkMessages([makeMessage(1, "user", huge)]);
+    expect(chunks.length).toBeGreaterThan(1);
+    const sameRange = chunks.filter(
+      (c) => c.startSequence === 1 && c.endSequence === 1
+    );
+    expect(sameRange.map((c) => c.index)).toEqual(
+      sameRange.map((_, i) => i)
+    );
+  });
+
+  it("chunkId is stable for the same inputs and unique across pieces", () => {
+    const a = chunkId("conv_abc", 1, 5, 0);
+    const b = chunkId("conv_abc", 1, 5, 0);
+    expect(a).toBe(b); // deterministic -> re-index is an upsert
+    expect(a).not.toBe(chunkId("conv_abc", 1, 5, 1)); // piece disambiguation
+    expect(a).not.toBe(chunkId("conv_abc", 4, 8, 0)); // different window
+    expect(a).not.toBe(chunkId("conv_xyz", 1, 5, 0)); // different conversation
+  });
+
+  it("produces one id per chunk with no collisions across a conversation", () => {
+    const messages = Array.from({ length: 40 }, (_, i) =>
+      makeMessage(i + 1, i % 2 ? "assistant" : "user", `message number ${i}`)
+    );
+    const chunks = chunkMessages(messages);
+    const ids = chunks.map((c) =>
+      chunkId("conv_test", c.startSequence, c.endSequence, c.index)
+    );
+    expect(new Set(ids).size).toBe(ids.length); // all unique
+    expect(ids.every((id) => id.length <= 64)).toBe(true); // Vectorize id limit
   });
 });

--- a/packages/shared/src/utils/chunk.ts
+++ b/packages/shared/src/utils/chunk.ts
@@ -15,6 +15,30 @@ export interface ChunkResult {
   text: string;
   startSequence: number;
   endSequence: number;
+  /**
+   * Disambiguator for chunks that share the same [startSequence, endSequence]
+   * (an oversized message hard-split into pieces). 0 for ordinary windows.
+   * Combined with the conversation id + sequence range it forms a STABLE,
+   * collision-free identity so re-indexing the same content upserts instead of
+   * duplicating. Assigned by chunkMessages(); see chunkId().
+   */
+  index: number;
+}
+
+/**
+ * Deterministic, collision-free id for a chunk. Same (conversation, sequence
+ * range, piece index) always yields the same id, so re-indexing is a pure
+ * upsert (no duplicate rows/vectors on retry or backfill). Used for BOTH the
+ * D1 chunk row id and the Vectorize vector id. Stays well under Vectorize's
+ * 64-byte id limit (conv ids are fixed-length; sequences are integers).
+ */
+export function chunkId(
+  conversationId: string,
+  startSequence: number,
+  endSequence: number,
+  index: number,
+): string {
+  return `chk_${conversationId}_${startSequence}_${endSequence}_${index}`;
 }
 
 export interface ChunkOptions {
@@ -80,6 +104,7 @@ function splitOversized(parts: Part[], warn: (m: string) => void): ChunkResult[]
       text: buf.map((p) => p.text).join("\n"),
       startSequence: buf[0].seq,
       endSequence: buf[buf.length - 1].seq,
+      index: 0, // corrected by the per-(start,end) pass in chunkMessages
     });
     buf = [];
     bufChars = 0;
@@ -98,6 +123,7 @@ function splitOversized(parts: Part[], warn: (m: string) => void): ChunkResult[]
           text: part.text.slice(j, j + MAX_CHARS),
           startSequence: part.seq,
           endSequence: part.seq,
+          index: 0, // corrected by the per-(start,end) pass in chunkMessages
         });
       }
       continue;
@@ -136,6 +162,7 @@ export function chunkMessages(
         text,
         startSequence: window[0].sequence,
         endSequence: window[window.length - 1].sequence,
+        index: 0, // corrected by the per-(start,end) pass below
       });
     } else {
       // Window overflows the embedding context — split it so nothing is
@@ -145,6 +172,18 @@ export function chunkMessages(
 
     // If window didn't fill, we've reached the end
     if (window.length < WINDOW_SIZE) break;
+  }
+
+  // Assign a stable disambiguator to chunks that share a [start,end] range
+  // (only happens when an oversized message is hard-split). Ordinary windows
+  // have unique ranges and keep index 0. This makes chunkId() collision-free
+  // and deterministic across re-indexing runs.
+  const seen = new Map<string, number>();
+  for (const ch of chunks) {
+    const key = `${ch.startSequence}:${ch.endSequence}`;
+    const idx = seen.get(key) ?? 0;
+    ch.index = idx;
+    seen.set(key, idx + 1);
   }
 
   return chunks;


### PR DESCRIPTION
Chunk ids were random (generateId('chk')), so any retry/reindex duplicated
chunks + vectors. Now id = chunkId(conv, startSeq, endSeq, index) — stable per
window — used for BOTH the D1 row id and the Vectorize id. insertChunks is now
idempotent: one batched FTS delete for the batch's ids, then INSERT OR REPLACE
each row + fresh FTS row, in one D1 transaction. A per-(start,end) index
disambiguates oversized-message hard-splits. This is the prerequisite that lets
the coming backfill re-index the unsearchable message backlog without
duplicating. Adversarially reviewed (verdict: ship).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
