### PR TITLE
ci: create R2 content bucket on deploy (idempotent)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,16 @@ jobs:
       - name: Build workspace packages
         run: pnpm -F @getengram/shared -F @getengram/db build
 
+      # Verbatim message content lives in R2 (D1 stays metadata + index only).
+      # Idempotent: create-if-absent so the binding in wrangler.toml always
+      # resolves. Safe to run every deploy.
+      - name: Ensure R2 content bucket exists
+        working-directory: apps/mcp-server
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler r2 bucket create engram-content || echo "bucket already exists — continuing"
+
       - name: Run D1 migrations
         working-directory: apps/mcp-server
         env:


### PR DESCRIPTION
First step of moving verbatim message content out of D1 (which keeps hitting
the 10GB cap) into R2. This deploy only ensures the bucket exists; the binding
+ code land next. D1 becomes metadata + search index only.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
