### PR TITLE
feat: store verbatim message content in R2, D1 keeps only a pointer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,16 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler r2 bucket create engram-content || echo "bucket already exists — continuing"
+        run: |
+          set +e
+          OUT=$(npx wrangler r2 bucket create engram-content 2>&1)
+          CODE=$?
+          echo "$OUT"
+          # Tolerate "already exists"; fail loudly on any other error (e.g. R2 not enabled).
+          if [ $CODE -ne 0 ] && ! echo "$OUT" | grep -qiE "already (exists|owned)"; then
+            echo "::error::R2 bucket create failed — is R2 enabled and the API token scoped for R2?"
+            exit 1
+          fi
 
       - name: Run D1 migrations
         working-directory: apps/mcp-server

--- a/apps/mcp-server/src/__tests__/content-store.test.ts
+++ b/apps/mcp-server/src/__tests__/content-store.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { createMockD1, createMockEnv } from "./helpers.js";
+import { storeContent, loadContent } from "../services/content-store.js";
+import type { Env } from "../types.js";
+
+function env(): Env {
+  return createMockEnv(createMockD1()) as unknown as Env;
+}
+
+describe("content-store", () => {
+  it("stores content in R2 and round-trips it (D1 keeps only a pointer)", async () => {
+    const e = env();
+    const text = "hello world, this is a verbatim message";
+    const { content, encoding } = await storeContent(e, "msg_a", text);
+    // D1 row carries no content, just an r2 pointer
+    expect(content).toBe("");
+    expect(encoding).toMatch(/^r2:/);
+    // loading reconstructs the original text
+    const back = await loadContent(e, { id: "msg_a", content, content_encoding: encoding });
+    expect(back).toBe(text);
+  });
+
+  it("round-trips large (gzipped) content through R2", async () => {
+    const e = env();
+    const text = "verbatim ".repeat(500); // > compression threshold
+    const { content, encoding } = await storeContent(e, "msg_big", text);
+    expect(content).toBe("");
+    expect(encoding).toBe("r2:gzip+base64");
+    expect(await loadContent(e, { id: "msg_big", content, content_encoding: encoding })).toBe(text);
+  });
+
+  it("falls back to INLINE D1 storage (no data loss) when R2 write fails", async () => {
+    const e = env();
+    (e.CONTENT.put as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
+      throw new Error("R2 down");
+    });
+    const text = "content that must survive an R2 outage";
+    const { content, encoding } = await storeContent(e, "msg_fallback", text);
+    // Content is kept inline in D1 — NOT empty, not lost
+    expect(content).toBe(text); // short text stored raw
+    expect(encoding?.startsWith("r2:") ?? false).toBe(false); // inline, not an R2 pointer
+    // and reads still work off the inline value
+    expect(await loadContent(e, { id: "msg_fallback", content, content_encoding: encoding })).toBe(text);
+  });
+
+  it("reads legacy inline content unchanged", async () => {
+    const e = env();
+    expect(await loadContent(e, { id: "msg_legacy", content: "old inline text", content_encoding: null })).toBe(
+      "old inline text",
+    );
+  });
+
+  it("throws loudly (never returns empty) if an r2-marked object is missing", async () => {
+    const e = env();
+    await expect(
+      loadContent(e, { id: "msg_missing", content: "", content_encoding: "r2:raw" }),
+    ).rejects.toThrow(/missing/);
+  });
+});

--- a/apps/mcp-server/src/__tests__/conversation-service.test.ts
+++ b/apps/mcp-server/src/__tests__/conversation-service.test.ts
@@ -6,12 +6,15 @@ import {
   getOrCreateDefaultConversation,
 } from "../services/conversation.js";
 import { insertOrganization, insertConversation as dbInsertConversation } from "@getengram/db";
+import type { Env } from "../types.js";
 
 describe("Conversation service", () => {
   let db: D1Database;
+  let env: Env;
 
   beforeAll(async () => {
     db = createMockD1();
+    env = createMockEnv(db) as unknown as Env;
     await insertOrganization(db, "org_svc", "Svc Org");
   });
 
@@ -29,14 +32,14 @@ describe("Conversation service", () => {
 
   describe("getConversation", () => {
     it("returns null for non-existent conversation", async () => {
-      const result = await getConversation(db, "org_svc", "conv_fake", 100, 0);
+      const result = await getConversation(env, "org_svc", "conv_fake", 100, 0);
       expect(result).toBeNull();
     });
 
     it("returns conversation with messages", async () => {
       // Create via the service to populate the mock
       const convId = await createConversation(db, "org_svc", "Get Test");
-      const result = await getConversation(db, "org_svc", convId, 100, 0);
+      const result = await getConversation(env, "org_svc", convId, 100, 0);
       expect(result).not.toBeNull();
       expect(result!.conversation.id).toBe(convId);
     });

--- a/apps/mcp-server/src/__tests__/helpers.ts
+++ b/apps/mcp-server/src/__tests__/helpers.ts
@@ -196,8 +196,25 @@ export function createMockD1(): D1Database {
 }
 
 export function createMockEnv(db: D1Database) {
+  // In-memory R2 mock so content write-then-read round-trips in tests.
+  const r2store = new Map<string, string>();
   return {
     DB: db,
+    CONTENT: {
+      put: vi.fn(async (key: string, val: unknown) => {
+        r2store.set(key, typeof val === "string" ? val : String(val));
+        return {};
+      }),
+      get: vi.fn(async (key: string) => {
+        const v = r2store.get(key);
+        return v == null ? null : { text: async () => v };
+      }),
+      delete: vi.fn(async (key: string) => {
+        r2store.delete(key);
+      }),
+      head: vi.fn(async () => null),
+      list: vi.fn(async () => ({ objects: [] })),
+    } as unknown as R2Bucket,
     AI: {
       run: vi.fn(async () => ({
         data: [[0.1, 0.2, 0.3]], // minimal fake embedding

--- a/apps/mcp-server/src/mcp/tools/get-conversation.ts
+++ b/apps/mcp-server/src/mcp/tools/get-conversation.ts
@@ -73,7 +73,7 @@ export function registerGetConversation(
       await audit(env.DB, auth.organizationId, auth.apiKeyId, "conversation.read", "conversation", params.conversation_id);
 
       const result = await getConversation(
-        env.DB,
+        env,
         auth.organizationId,
         params.conversation_id,
         params.message_limit,

--- a/apps/mcp-server/src/routes/export.ts
+++ b/apps/mcp-server/src/routes/export.ts
@@ -4,7 +4,7 @@ import {
   listConversations,
   getMessagesByConversation,
 } from "@getengram/db";
-import { decompressContent } from "../utils/compress.js";
+import { loadContent } from "../services/content-store.js";
 import { audit } from "../services/audit.js";
 import type { Env, AuthContext } from "../types.js";
 
@@ -46,10 +46,11 @@ dataExport.get("/", async (c) => {
     const messages = await Promise.all(
       (msgResult.results as Array<Record<string, unknown>>).map(async (m) => ({
         role: m.role,
-        content: await decompressContent(
-          m.content as string,
-          m.content_encoding as string | null,
-        ),
+        content: await loadContent(c.env, {
+          id: m.id as string,
+          content: m.content as string,
+          content_encoding: m.content_encoding as string | null,
+        }),
         sequence: m.sequence,
         created_at: m.created_at,
         ...(m.tool_name ? { tool_name: m.tool_name } : {}),

--- a/apps/mcp-server/src/routes/v1.ts
+++ b/apps/mcp-server/src/routes/v1.ts
@@ -191,7 +191,7 @@ v1.get("/conversations/:id", async (c) => {
   });
 
   const result = await getConversation(
-    c.env.DB,
+    c.env,
     auth.organizationId,
     conversationId,
     messageLimit,

--- a/apps/mcp-server/src/services/content-store.ts
+++ b/apps/mcp-server/src/services/content-store.ts
@@ -1,0 +1,72 @@
+import { compressContent, decompressContent } from "../utils/compress.js";
+import type { Env } from "../types.js";
+
+/**
+ * Message content storage. Verbatim content lives in R2 (unbounded, cheap),
+ * keyed by message id; the D1 `messages` row keeps only a small pointer marker
+ * in `content_encoding` and an empty `content` column. This is what keeps D1
+ * off the 10 GB cap.
+ *
+ * content_encoding values:
+ *   null | "gzip+base64"      -> legacy inline content (still in the D1 column)
+ *   "r2:raw" | "r2:gzip+base64" -> content is the R2 object at content/<id>,
+ *                                  stored with the named compression
+ *
+ * SAFETY: writes NEVER lose content. If the R2 put fails, we fall back to
+ * storing the (compressed) content inline in D1 exactly as before — no space
+ * savings, but the words are never dropped. Reads throw loudly if an R2 object
+ * that should exist is missing, rather than silently returning empty text.
+ */
+
+const PREFIX = "content/";
+
+const r2Key = (messageId: string) => PREFIX + messageId;
+
+/**
+ * Compress `text` and store it in R2, returning the {content, encoding} to
+ * write into the D1 row. Falls back to inline D1 storage if R2 is unavailable.
+ * Deterministic key (message id) => retries/backfills are idempotent overwrites.
+ */
+export async function storeContent(
+  env: Env,
+  messageId: string,
+  text: string,
+): Promise<{ content: string; encoding: string | null }> {
+  const { content, encoding } = await compressContent(text);
+  try {
+    await env.CONTENT.put(r2Key(messageId), content);
+    return { content: "", encoding: `r2:${encoding ?? "raw"}` };
+  } catch (err) {
+    // R2 unavailable — keep the content inline in D1 so nothing is lost.
+    console.error(
+      `[content-store] R2 put failed for ${messageId}; storing inline in D1: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return { content, encoding };
+  }
+}
+
+/**
+ * Load a message's verbatim content, transparently handling both R2-backed
+ * (new) and inline (legacy) storage.
+ */
+export async function loadContent(
+  env: Env,
+  msg: { id: string; content: string; content_encoding: string | null },
+): Promise<string> {
+  const enc = msg.content_encoding;
+  if (enc && enc.startsWith("r2:")) {
+    const obj = await env.CONTENT.get(r2Key(msg.id));
+    if (!obj) {
+      // A row marked r2:* must have an object; surface the inconsistency
+      // loudly instead of returning empty content that looks like data loss.
+      throw new Error(`[content-store] R2 object missing for message ${msg.id}`);
+    }
+    const stored = await obj.text();
+    const realEnc = enc.slice(3); // strip "r2:"
+    return decompressContent(stored, realEnc === "raw" ? null : realEnc);
+  }
+  // Legacy inline content (or short raw content).
+  return decompressContent(msg.content, enc);
+}

--- a/apps/mcp-server/src/services/conversation.ts
+++ b/apps/mcp-server/src/services/conversation.ts
@@ -31,7 +31,7 @@ import {
 } from "@getengram/db";
 import { generateEmbeddings } from "./embedding.js";
 import { releaseStorage } from "./tier.js";
-import { compressContent, decompressContent } from "../utils/compress.js";
+import { storeContent, loadContent } from "./content-store.js";
 import type { Env, AuthContext } from "../types.js";
 import { canAccessConversation } from "./spaces.js";
 
@@ -160,12 +160,13 @@ export async function appendMessages(
     console.log(`[redact] Scrubbed ${totalRedactions} sensitive pattern(s) from ${conversationId}`);
   }
 
-  // Compress message content for storage
-  const compressed = await Promise.all(
-    redacted.map((m) => compressContent(m.content))
+  // Store verbatim content in R2 (D1 keeps only a pointer), falling back to
+  // inline D1 if R2 is unavailable so content is never lost.
+  const stored = await Promise.all(
+    redacted.map((m) => storeContent(env, m.id, m.content))
   );
 
-  // Insert messages with compressed content
+  // Insert message rows (content lives in R2; D1 row carries the pointer)
   await insertMessages(
     env.DB,
     redacted.map((m, i) => ({
@@ -173,8 +174,8 @@ export async function appendMessages(
       conversationId: m.conversation_id,
       organizationId: m.organization_id,
       role: m.role,
-      content: compressed[i].content,
-      contentEncoding: compressed[i].encoding,
+      content: stored[i].content,
+      contentEncoding: stored[i].encoding,
       toolCallId: m.tool_call_id,
       toolName: m.tool_name,
       sequence: m.sequence,
@@ -282,13 +283,13 @@ export async function appendMessages(
 }
 
 export async function getConversation(
-  db: D1Database,
+  env: Env,
   organizationId: string,
   conversationId: string,
   messageLimit: number,
   messageOffset: number
 ): Promise<{ conversation: Conversation; messages: Message[] } | null> {
-  const conv = await getConversationById(db, conversationId, organizationId);
+  const conv = await getConversationById(env.DB, conversationId, organizationId);
   if (!conv) return null;
 
   const raw = conv as Record<string, unknown>;
@@ -305,22 +306,23 @@ export async function getConversation(
   };
 
   const msgsResult = await getMessagesByConversation(
-    db,
+    env.DB,
     conversationId,
     organizationId,
     messageLimit,
     messageOffset
   );
 
-  // Decompress message content in parallel
+  // Load message content (from R2 or legacy inline) in parallel
   const rawMessages = msgsResult.results as Array<Record<string, unknown>>;
   const messages = await Promise.all(
     rawMessages.map(async (m) => ({
       ...m,
-      content: await decompressContent(
-        m.content as string,
-        m.content_encoding as string | null
-      ),
+      content: await loadContent(env, {
+        id: m.id as string,
+        content: m.content as string,
+        content_encoding: m.content_encoding as string | null,
+      }),
       metadata: JSON.parse((m.metadata as string) || "{}"),
     }))
   ) as Message[];
@@ -386,13 +388,14 @@ export async function updateMessage(
     );
   }
   const updated = redacted[0];
-  const compressed = await compressContent(updated.content);
+  // Overwrite the R2 object for this message (same key) — falls back to inline.
+  const stored = await storeContent(env, messageId, updated.content);
   await updateMessageContent(
     env.DB,
     messageId,
     organizationId,
-    compressed.content,
-    compressed.encoding
+    stored.content,
+    stored.encoding
   );
 
   // Rebuild the affected slice of the search index. Chunk boundaries are
@@ -424,10 +427,11 @@ export async function updateMessage(
       (windowResult.results as Array<Record<string, unknown>>).map(
         async (m) => ({
           ...m,
-          content: await decompressContent(
-            m.content as string,
-            m.content_encoding as string | null
-          ),
+          content: await loadContent(env, {
+            id: m.id as string,
+            content: m.content as string,
+            content_encoding: m.content_encoding as string | null,
+          }),
           metadata: JSON.parse((m.metadata as string) || "{}"),
         })
       )

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -1,5 +1,6 @@
 export interface Env {
   DB: D1Database;
+  CONTENT: R2Bucket;
   VECTORIZE: VectorizeIndex;
   AI: Ai;
   // Stripe (wrangler secrets)

--- a/apps/mcp-server/wrangler.toml
+++ b/apps/mcp-server/wrangler.toml
@@ -19,6 +19,12 @@ database_name = "engram-db"
 database_id = "fcf57f81-8d26-4288-aee5-11c42d6ca0d5"
 migrations_dir = "../../packages/db/migrations"
 
+# Verbatim message content lives here (unbounded), keyed by message id. D1
+# holds only metadata + a pointer, so it never hits the 10 GB cap again.
+[[r2_buckets]]
+binding = "CONTENT"
+bucket_name = "engram-content"
+
 [[vectorize]]
 binding = "VECTORIZE"
 index_name = "engram-vectors"


### PR DESCRIPTION
D1 kept hitting the 10GB cap because it held all verbatim content (~4GB and
growing). Now new message content goes to R2 (unbounded, keyed by message id)
and the D1 row carries only a small pointer in content_encoding ('r2:...').
D1 becomes metadata + search index only — the cap can't be hit by content.

Safety: storeContent falls back to inline D1 if the R2 put fails (content is
NEVER lost). loadContent transparently reads R2 or legacy inline content, and
throws loudly rather than returning empty if an r2-marked object is missing.
Backward compatible — existing inline rows read unchanged. getConversation now
takes env (for R2 access); callers + tests updated. Read paths covered:
get_conversation, REST conversation, edit re-chunk, export. The compress
backfill only touches content_encoding IS NULL rows, so it can't corrupt R2
pointers. Next: backfill the existing ~4GB out of D1 to free the space.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
