### PR TITLE
drain: use a reliable small batch (120) and allow parallel chains

### DIFF
--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -974,6 +974,7 @@ admin.post("/backfill-content-to-r2", async (c) => {
 admin.post("/backfill-drain", async (c) => {
   const after = parseInt(c.req.query("after") ?? "0", 10);
   const hops = parseInt(c.req.query("hops") ?? "20000", 10);
+  const batch = Math.min(200, Math.max(20, parseInt(c.req.query("batch") ?? "120", 10)));
   const origin = new URL(c.req.url).origin;
   const auth = c.req.header("Authorization") ?? "";
   const hdr = { Authorization: auth, "User-Agent": "engram-drain/1.0" };
@@ -983,7 +984,7 @@ admin.post("/backfill-drain", async (c) => {
   let stop = false;
   try {
     const r = await fetch(
-      `${origin}/admin/backfill-content-to-r2?after=${after}&batch=400`,
+      `${origin}/admin/backfill-content-to-r2?after=${after}&batch=${batch}`,
       { method: "POST", headers: hdr },
     );
     j = (await r.json()) as Record<string, unknown>;
@@ -997,7 +998,7 @@ admin.post("/backfill-drain", async (c) => {
   const more = !stop && hops > 1;
   if (more) {
     c.executionCtx.waitUntil(
-      fetch(`${origin}/admin/backfill-drain?after=${nextAfter}&hops=${hops - 1}`, {
+      fetch(`${origin}/admin/backfill-drain?after=${nextAfter}&hops=${hops - 1}&batch=${batch}`, {
         method: "POST",
         headers: hdr,
       }),


### PR DESCRIPTION
Big batches time out (Cloudflare caps concurrent subrequests); batch=120
completes in ~6s. Batch is now a param so multiple drain chains can run at
different cursors to finish the ~3.4M-row drain in hours instead of ~2 days.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
