### PR TITLE
cron: every-minute background drain of legacy content D1 -> R2

### DIFF
--- a/apps/mcp-server/src/cron/drain-content.ts
+++ b/apps/mcp-server/src/cron/drain-content.ts
@@ -1,0 +1,67 @@
+import type { Env } from "../types.js";
+
+/**
+ * Background drain: move legacy inline message content from D1 into R2
+ * (Step 2 of the content->R2 migration). Runs every minute via cron until
+ * the table is fully drained, then becomes a cheap no-op.
+ *
+ * Each tick: loop small batches for up to ~45s. Per row: PUT the stored
+ * bytes to R2 (put resolves only on a durable write), then — only for rows
+ * whose put succeeded — shrink the D1 row to a pointer
+ * (content='', content_encoding='r2:<original encoding>'). Content is never
+ * deleted before its R2 copy is confirmed; a crash mid-batch just re-drains
+ * the same rows next tick (same deterministic key -> idempotent overwrite).
+ *
+ * The cursor restarts from 0 each tick — already-drained rows are excluded
+ * by the WHERE clause, so scanning forward always lands on the first
+ * un-drained row. No cursor state to persist or corrupt.
+ */
+const BATCH = 100; // completes well inside limits (~20 R2 writes/s/invocation)
+const TICK_BUDGET_MS = 45_000;
+
+export async function drainContentToR2(env: Env): Promise<number> {
+  const started = Date.now();
+  let moved = 0;
+  let after = 0;
+
+  while (Date.now() - started < TICK_BUDGET_MS) {
+    const rows = await env.DB.prepare(
+      `SELECT rowid AS rid, id, content, content_encoding FROM messages
+       WHERE rowid > ? AND content != ''
+         AND (content_encoding IS NULL OR content_encoding NOT LIKE 'r2:%')
+       ORDER BY rowid LIMIT ?`,
+    )
+      .bind(after, BATCH)
+      .all<{ rid: number; id: string; content: string; content_encoding: string | null }>();
+
+    const list = rows.results ?? [];
+    if (list.length === 0) break; // fully drained — future ticks are no-ops
+
+    const outcomes = await Promise.all(
+      list.map(async (r) => {
+        try {
+          await env.CONTENT.put(`content/${r.id}`, r.content);
+          return { id: r.id, enc: `r2:${r.content_encoding ?? "raw"}`, ok: true };
+        } catch {
+          return { id: r.id, enc: "", ok: false };
+        }
+      }),
+    );
+    const swap = outcomes.filter((o) => o.ok);
+    if (swap.length > 0) {
+      await env.DB.batch(
+        swap.map((sw) =>
+          env.DB
+            .prepare("UPDATE messages SET content = '', content_encoding = ? WHERE id = ?")
+            .bind(sw.enc, sw.id),
+        ),
+      );
+      moved += swap.length;
+    }
+    // Advance past this batch even if some puts failed — failed rows stay
+    // inline and are retried next tick when the scan restarts from 0.
+    after = list[list.length - 1].rid;
+  }
+
+  return moved;
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -26,6 +26,7 @@ import { enforceRetentionPolicies } from "./cron/retention-policy.js";
 import { sendImportNudges } from "./cron/import-nudge.js";
 import { sendMaxoutNudges } from "./cron/maxout-nudge.js";
 import { sendActivationNudges } from "./cron/activation-nudge.js";
+import { drainContentToR2 } from "./cron/drain-content.js";
 import { sendWeeklyDigests } from "./cron/weekly-digest.js";
 import { sendDailyReport } from "./services/daily-report.js";
 import { oauth } from "./oauth/router.js";
@@ -273,9 +274,21 @@ app.route("/api/v1", v1);
 export default {
   fetch: app.fetch,
   async scheduled(event: ScheduledEvent, env: Env, _ctx: ExecutionContext) {
-    // Two daily crons (see wrangler.toml [triggers]):
+    // Crons (see wrangler.toml [triggers]):
+    //   * * * * *  — drain legacy inline content D1 -> R2 (no-op once done)
     //   03:00 UTC — GDPR purge of soft-deleted orgs
     //   13:00 UTC — daily ops report, emailed via engram-web
+    if (event.cron === "* * * * *") {
+      // MUST return here — falling through would run the daily purge/nudge
+      // branch every minute.
+      try {
+        const moved = await drainContentToR2(env);
+        if (moved > 0) console.log(`[drain] moved ${moved} message(s) to R2`);
+      } catch (err) {
+        console.error(`[drain] FAILED: ${err instanceof Error ? err.message : err}`);
+      }
+      return;
+    }
     if (event.cron === "0 13 * * *") {
       // Isolated so a report failure can't swallow the Monday digests —
       // and vice versa. Failures land in the worker logs with context.

--- a/apps/mcp-server/wrangler.toml
+++ b/apps/mcp-server/wrangler.toml
@@ -37,7 +37,8 @@ binding = "AI"
 pattern = "mcp.getengram.app/*"
 zone_name = "getengram.app"
 
-# Daily crons — 03:00 GDPR purge of soft-deleted orgs; 13:00 daily ops
-# report (built here, emailed by engram-web /api/reports/daily).
+# Crons — every-minute content drain (D1 -> R2, no-op once drained);
+# 03:00 GDPR purge of soft-deleted orgs; 13:00 daily ops report (built
+# here, emailed by engram-web /api/reports/daily).
 [triggers]
-crons = ["0 3 * * *", "0 13 * * *"]
+crons = ["* * * * *", "0 3 * * *", "0 13 * * *"]


### PR DESCRIPTION
Shell/self-chaining drivers proved unreliable. A cron tick runs ~45s of
batches: parallel R2 puts (put resolves only on durable write), then swap
only successful rows to pointers. Scan restarts at rowid 0 each tick so
failed rows retry naturally; when the table is drained the query returns
nothing and the cron becomes a no-op. Explicit early return so the
every-minute cron can't fall through into the daily purge/nudge branch.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
