### PR TITLE
cron: serverless parallel drain via self service-binding (10x fan-out)

### DIFF
--- a/apps/mcp-server/src/cron/drain-content.ts
+++ b/apps/mcp-server/src/cron/drain-content.ts
@@ -1,66 +1,82 @@
 import type { Env } from "../types.js";
 
 /**
- * Background drain: move legacy inline message content from D1 into R2
- * (Step 2 of the content->R2 migration). Runs every minute via cron until
- * the table is fully drained, then becomes a cheap no-op.
+ * Serverless parallel drain: move legacy inline message content from D1 into
+ * R2 (Step 2 of the content->R2 migration), entirely on Cloudflare — no
+ * external driver. Runs every minute via cron until drained, then no-ops.
  *
- * Each tick: loop small batches for up to ~45s. Per row: PUT the stored
- * bytes to R2 (put resolves only on a durable write), then — only for rows
- * whose put succeeded — shrink the D1 row to a pointer
- * (content='', content_encoding='r2:<original encoding>'). Content is never
- * deleted before its R2 copy is confirmed; a crash mid-batch just re-drains
- * the same rows next tick (same deterministic key -> idempotent overwrite).
+ * A single invocation is capped at ~20-30 R2 writes/sec (per-invocation
+ * connection budget), so one tick fans out through the SELF service binding:
+ * WINDOWS parallel sub-invocations of /admin/backfill-content-to-r2, each
+ * draining its own rowid window with its own budget. The endpoint itself is
+ * verify-before-swap (content is durably in R2 before the D1 row is cleared)
+ * and idempotent, so overlapping ticks, retries, or an external driver
+ * running at the same time are all safe.
  *
- * The cursor restarts from 0 each tick — already-drained rows are excluded
- * by the WHERE clause, so scanning forward always lands on the first
- * un-drained row. No cursor state to persist or corrupt.
+ * Error handling: a window whose sub-request fails just retries the same
+ * cursor next round; a window that reports no rows (processed=0) or crosses
+ * into the next window is finished for this tick. When the whole table is
+ * drained every window reports no rows immediately and the tick is a no-op.
  */
-const BATCH = 100; // completes well inside limits (~20 R2 writes/s/invocation)
-const TICK_BUDGET_MS = 45_000;
+const WINDOWS = 10;
+const BATCH = 120;
+const TICK_BUDGET_MS = 50_000;
+const SPAN = 4_000_000; // > max messages rowid; empty windows finish instantly
+
+interface BackfillResp {
+  processed?: number;
+  verified_and_swapped?: number;
+  next_after?: number;
+  done?: boolean;
+  error?: string;
+}
 
 export async function drainContentToR2(env: Env): Promise<number> {
+  const secret = (env as Env & { ADMIN_SECRET?: string }).ADMIN_SECRET;
+  if (!secret) return 0;
+
   const started = Date.now();
+  const step = Math.floor(SPAN / WINDOWS);
+  const cursors = Array.from({ length: WINDOWS }, (_, i) => i * step);
+  const finished = new Array<boolean>(WINDOWS).fill(false);
   let moved = 0;
-  let after = 0;
 
-  while (Date.now() - started < TICK_BUDGET_MS) {
-    const rows = await env.DB.prepare(
-      `SELECT rowid AS rid, id, content, content_encoding FROM messages
-       WHERE rowid > ? AND content != ''
-         AND (content_encoding IS NULL OR content_encoding NOT LIKE 'r2:%')
-       ORDER BY rowid LIMIT ?`,
-    )
-      .bind(after, BATCH)
-      .all<{ rid: number; id: string; content: string; content_encoding: string | null }>();
-
-    const list = rows.results ?? [];
-    if (list.length === 0) break; // fully drained — future ticks are no-ops
-
-    const outcomes = await Promise.all(
-      list.map(async (r) => {
+  while (Date.now() - started < TICK_BUDGET_MS && finished.some((f) => !f)) {
+    const results = await Promise.all(
+      cursors.map(async (cur, i): Promise<BackfillResp | null> => {
+        if (finished[i]) return null;
         try {
-          await env.CONTENT.put(`content/${r.id}`, r.content);
-          return { id: r.id, enc: `r2:${r.content_encoding ?? "raw"}`, ok: true };
+          const res = await env.SELF.fetch(
+            `https://self.internal/admin/backfill-content-to-r2?after=${cur}&batch=${BATCH}`,
+            {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${secret}`,
+                "User-Agent": "engram-drain-cron/1.0",
+              },
+            },
+          );
+          return (await res.json()) as BackfillResp;
         } catch {
-          return { id: r.id, enc: "", ok: false };
+          return null; // transient — retry same cursor next round
         }
       }),
     );
-    const swap = outcomes.filter((o) => o.ok);
-    if (swap.length > 0) {
-      await env.DB.batch(
-        swap.map((sw) =>
-          env.DB
-            .prepare("UPDATE messages SET content = '', content_encoding = ? WHERE id = ?")
-            .bind(sw.enc, sw.id),
-        ),
-      );
-      moved += swap.length;
-    }
-    // Advance past this batch even if some puts failed — failed rows stay
-    // inline and are retried next tick when the scan restarts from 0.
-    after = list[list.length - 1].rid;
+
+    results.forEach((r, i) => {
+      if (finished[i] || r === null) return;
+      if (r.error !== undefined || typeof r.next_after !== "number") return; // retry
+      moved += r.verified_and_swapped ?? 0;
+      if (r.done || (r.processed ?? 0) === 0) {
+        finished[i] = true; // nothing left past this cursor
+        return;
+      }
+      if (r.next_after <= cursors[i] || r.next_after >= (i + 1) * step) {
+        finished[i] = true; // window complete (next window owns the rest)
+        return;
+      }
+      cursors[i] = r.next_after;
+    });
   }
 
   return moved;

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -2,6 +2,7 @@ export interface Env {
   DB: D1Database;
   CONTENT: R2Bucket;
   VECTORIZE: VectorizeIndex;
+  SELF: Fetcher;
   AI: Ai;
   // Stripe (wrangler secrets)
   STRIPE_SECRET_KEY: string;

--- a/apps/mcp-server/wrangler.toml
+++ b/apps/mcp-server/wrangler.toml
@@ -29,6 +29,13 @@ bucket_name = "engram-content"
 binding = "VECTORIZE"
 index_name = "engram-vectors"
 
+# Self service-binding — lets the drain cron fan out to parallel sub-invocations
+# of this same worker (each with its own subrequest/connection budget) without
+# going over the public internet.
+[[services]]
+binding = "SELF"
+service = "engram-mcp-server"
+
 [ai]
 binding = "AI"
 


### PR DESCRIPTION
A single invocation caps at ~25 R2 writes/s, so the every-minute drain tick
now fans out through a SELF service binding: 10 parallel sub-invocations of
the idempotent backfill endpoint, each draining its own rowid window with its
own budget (~9-10k rows/min, fully on Cloudflare — no external driver).
Windows retry transient errors at the same cursor, finish on processed=0 or
window-end, and the tick no-ops once the table is drained.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
