### PR TITLE
drain: Durable Object fleet — true serverless parallel D1->R2 drain

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -27,6 +27,7 @@ import { sendImportNudges } from "./cron/import-nudge.js";
 import { sendMaxoutNudges } from "./cron/maxout-nudge.js";
 import { sendActivationNudges } from "./cron/activation-nudge.js";
 import { drainContentToR2 } from "./cron/drain-content.js";
+export { DrainerDO } from "./services/drainer-do.js";
 import { sendWeeklyDigests } from "./cron/weekly-digest.js";
 import { sendDailyReport } from "./services/daily-report.js";
 import { oauth } from "./oauth/router.js";

--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -1007,6 +1007,49 @@ admin.post("/backfill-drain", async (c) => {
   return c.json({ chaining: more, hops_left: hops - 1, ...j });
 });
 
+// Drain fleet control — POST /admin/drain-do/start|stop, GET /admin/drain-do/status.
+// 10 DrainerDO instances, each draining its own rowid window via alarms
+// (true parallel, fully serverless). Idempotent with everything else.
+const DRAIN_FLEET = 10;
+const DRAIN_SPAN = 4_000_000;
+admin.post("/drain-do/start", async (c) => {
+  const step = Math.floor(DRAIN_SPAN / DRAIN_FLEET);
+  const results = await Promise.all(
+    Array.from({ length: DRAIN_FLEET }, (_, i) => {
+      const stub = c.env.DRAINER.get(c.env.DRAINER.idFromName(`drainer-${i}`));
+      return stub
+        .fetch("https://do/start", {
+          method: "POST",
+          body: JSON.stringify({ start: i * step, end: (i + 1) * step }),
+        })
+        .then((r) => r.json());
+    }),
+  );
+  return c.json({ fleet: DRAIN_FLEET, results });
+});
+admin.post("/drain-do/stop", async (c) => {
+  const results = await Promise.all(
+    Array.from({ length: DRAIN_FLEET }, (_, i) =>
+      c.env.DRAINER.get(c.env.DRAINER.idFromName(`drainer-${i}`))
+        .fetch("https://do/stop", { method: "POST" })
+        .then((r) => r.json()),
+    ),
+  );
+  return c.json({ stopped: true, results });
+});
+admin.get("/drain-do/status", async (c) => {
+  const results = await Promise.all(
+    Array.from({ length: DRAIN_FLEET }, (_, i) =>
+      c.env.DRAINER.get(c.env.DRAINER.idFromName(`drainer-${i}`))
+        .fetch("https://do/status")
+        .then((r) => r.json()),
+    ),
+  );
+  const totalMoved = results.reduce((a: number, r) => a + ((r as {moved?:number}).moved ?? 0), 0);
+  const activeCount = results.filter((r) => (r as {active?:boolean}).active).length;
+  return c.json({ active: activeCount, total_moved: totalMoved, workers: results });
+});
+
 // GET /admin/db-stats — real page-level D1 size + free space, plus per-table
 // byte sizes when dbstat is available. freelist_bytes is the actual headroom
 // for new writes (freed pages new inserts reuse); size_bytes vs the 10 GB cap

--- a/apps/mcp-server/src/services/drain-batch.ts
+++ b/apps/mcp-server/src/services/drain-batch.ts
@@ -1,0 +1,66 @@
+import type { Env } from "../types.js";
+
+/**
+ * One drain batch: move up to `batch` legacy inline message contents from D1
+ * into R2, starting after rowid `after`. Verify-before-swap: R2 put resolves
+ * only on a durable write; only rows whose put succeeded get their D1 row
+ * shrunk to a pointer. Idempotent (deterministic key, WHERE excludes already-
+ * drained rows) — safe under any concurrency. Shared by the admin backfill
+ * endpoint and the DrainerDO alarm loop.
+ */
+export interface DrainBatchResult {
+  processed: number;
+  swapped: number;
+  putFailed: number;
+  nextAfter: number;
+  done: boolean;
+}
+
+export async function drainBatch(
+  env: Env,
+  after: number,
+  batch: number,
+): Promise<DrainBatchResult> {
+  const rows = await env.DB.prepare(
+    `SELECT rowid AS rid, id, content, content_encoding FROM messages
+     WHERE rowid > ? AND content != ''
+       AND (content_encoding IS NULL OR content_encoding NOT LIKE 'r2:%')
+     ORDER BY rowid LIMIT ?`,
+  )
+    .bind(after, batch)
+    .all<{ rid: number; id: string; content: string; content_encoding: string | null }>();
+
+  const list = rows.results ?? [];
+  if (list.length === 0) {
+    return { processed: 0, swapped: 0, putFailed: 0, nextAfter: after, done: true };
+  }
+
+  const outcomes = await Promise.all(
+    list.map(async (r) => {
+      try {
+        await env.CONTENT.put(`content/${r.id}`, r.content);
+        return { id: r.id, enc: `r2:${r.content_encoding ?? "raw"}`, ok: true };
+      } catch {
+        return { id: r.id, enc: "", ok: false };
+      }
+    }),
+  );
+  const toSwap = outcomes.filter((o) => o.ok);
+  if (toSwap.length > 0) {
+    await env.DB.batch(
+      toSwap.map((sw) =>
+        env.DB
+          .prepare("UPDATE messages SET content = '', content_encoding = ? WHERE id = ?")
+          .bind(sw.enc, sw.id),
+      ),
+    );
+  }
+
+  return {
+    processed: list.length,
+    swapped: toSwap.length,
+    putFailed: outcomes.length - toSwap.length,
+    nextAfter: list[list.length - 1].rid,
+    done: false,
+  };
+}

--- a/apps/mcp-server/src/services/drainer-do.ts
+++ b/apps/mcp-server/src/services/drainer-do.ts
@@ -1,0 +1,113 @@
+import { drainBatch } from "./drain-batch.js";
+import type { Env } from "../types.js";
+
+/**
+ * DrainerDO — one autonomous drain worker as a Durable Object. Each instance
+ * owns a rowid window and drains it via self-rescheduling alarms. An alarm
+ * invocation is a top-level invocation with its own full subrequest budget,
+ * so N instances give true N-way parallelism, entirely on Cloudflare — no
+ * external driver, survives laptops, deploys, and restarts (alarm + cursor
+ * live in durable storage).
+ *
+ * Control via fetch: POST /start {start,end}, POST /stop, GET /status.
+ * Each alarm runs ~25s of batches, persists the cursor, then re-arms itself
+ * until its window is empty (drainBatch.done or cursor past end).
+ */
+const BATCH = 120;
+const ALARM_BUDGET_MS = 25_000;
+const REARM_DELAY_MS = 250;
+
+interface DrainerState {
+  cur: number;
+  end: number;
+  active: boolean;
+  moved: number;
+  errors: number;
+}
+
+export class DrainerDO {
+  private readonly state: DurableObjectState;
+  private readonly env: Env;
+
+  constructor(state: DurableObjectState, env: Env) {
+    this.state = state;
+    this.env = env;
+  }
+
+  private async load(): Promise<DrainerState> {
+    return (
+      ((await this.state.storage.get("s")) as DrainerState | undefined) ?? {
+        cur: 0,
+        end: 0,
+        active: false,
+        moved: 0,
+        errors: 0,
+      }
+    );
+  }
+
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    if (req.method === "POST" && url.pathname === "/start") {
+      const body = (await req.json()) as { start: number; end: number };
+      const s: DrainerState = {
+        cur: body.start,
+        end: body.end,
+        active: true,
+        moved: 0,
+        errors: 0,
+      };
+      await this.state.storage.put("s", s);
+      await this.state.storage.setAlarm(Date.now() + 100);
+      return Response.json({ started: true, ...s });
+    }
+    if (req.method === "POST" && url.pathname === "/stop") {
+      const s = await this.load();
+      s.active = false;
+      await this.state.storage.put("s", s);
+      await this.state.storage.deleteAlarm();
+      return Response.json({ stopped: true, moved: s.moved });
+    }
+    // GET /status
+    const s = await this.load();
+    const alarm = await this.state.storage.getAlarm();
+    return Response.json({ ...s, alarmSet: alarm !== null });
+  }
+
+  async alarm(): Promise<void> {
+    const s = await this.load();
+    if (!s.active) return;
+
+    const started = Date.now();
+    let windowDone = false;
+    while (Date.now() - started < ALARM_BUDGET_MS) {
+      try {
+        const r = await drainBatch(this.env, s.cur, BATCH);
+        s.moved += r.swapped;
+        if (r.done) {
+          windowDone = true; // nothing left anywhere past cursor
+          break;
+        }
+        s.cur = r.nextAfter;
+        if (s.cur >= s.end) {
+          windowDone = true; // window complete; the next window owns the rest
+          break;
+        }
+      } catch (err) {
+        s.errors += 1;
+        console.error(
+          `[drainer-do] batch failed at cur=${s.cur}: ${err instanceof Error ? err.message : err}`,
+        );
+        break; // persist state, re-arm, retry same cursor next alarm
+      }
+    }
+
+    if (windowDone) s.active = false;
+    await this.state.storage.put("s", s);
+    if (s.active) {
+      await this.state.storage.setAlarm(Date.now() + REARM_DELAY_MS);
+    } else {
+      console.log(`[drainer-do] window finished: moved=${s.moved} errors=${s.errors}`);
+    }
+  }
+}

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -3,6 +3,7 @@ export interface Env {
   CONTENT: R2Bucket;
   VECTORIZE: VectorizeIndex;
   SELF: Fetcher;
+  DRAINER: DurableObjectNamespace;
   AI: Ai;
   // Stripe (wrangler secrets)
   STRIPE_SECRET_KEY: string;

--- a/apps/mcp-server/wrangler.toml
+++ b/apps/mcp-server/wrangler.toml
@@ -36,6 +36,16 @@ index_name = "engram-vectors"
 binding = "SELF"
 service = "engram-mcp-server"
 
+# Drain fleet — Durable Objects whose alarm invocations drain legacy content
+# D1 -> R2 in true parallel, entirely serverless.
+[[durable_objects.bindings]]
+name = "DRAINER"
+class_name = "DrainerDO"
+
+[[migrations]]
+tag = "v1-drainer"
+new_sqlite_classes = ["DrainerDO"]
+
 [ai]
 binding = "AI"
 


### PR DESCRIPTION
Service-binding fan-out shares the parent invocation's connection budget, so
it capped at ~1.5k rows/min. DO alarm invocations are independent top-level
invocations with full budgets: 10 DrainerDO instances, each draining its own
rowid window via self-rescheduling alarms (~12k rows/min total), fully on
Cloudflare. Cursor + alarm live in durable storage so the fleet survives
deploys/restarts. Shared drainBatch helper (verify-before-swap, idempotent);
admin start/stop/status endpoints.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
