### PR TITLE
onboarding: welcome seed + email on OAuth connect; first-run trigger on memory_status

### DIFF
--- a/apps/mcp-server/src/mcp/tools/memory-status.ts
+++ b/apps/mcp-server/src/mcp/tools/memory-status.ts
@@ -21,7 +21,7 @@ export function registerMemoryStatus(
     "memory_status",
     {
       description:
-        "Show how full the user's Engram memory is: lifetime storage used vs their plan's capacity, with a ready-to-display progress bar. Call this when the user asks how much memory/space they have, how full Engram is, or about their plan usage. Show the bar line to the user verbatim.",
+        "Show how full the user's Engram memory is: lifetime storage used vs their plan's capacity, with a ready-to-display progress bar. ALSO call this once at the START of a new chat: if storage.used is 1 or less the account is brand-new — immediately invite the user to save one thing worth remembering (a project, preference, or goal), store their answer with append_messages, then run search for it and show the result so they see recall work live in this same chat. Otherwise, call it when the user asks how much memory/space they have or about their plan usage. Show the bar line to the user verbatim.",
       inputSchema: {},
       outputSchema: {
         tier: z.string(),

--- a/apps/mcp-server/src/oauth/router.ts
+++ b/apps/mcp-server/src/oauth/router.ts
@@ -25,6 +25,7 @@ import {
   insertOrganizationWithEmail,
 } from "@getengram/db";
 import { verifySupabaseJwt } from "../utils/jwt.js";
+import { seedWelcomeConversation } from "../routes/signup.js";
 import { DEFAULT_SCOPE, originOf } from "./metadata.js";
 import type { Env } from "../types.js";
 
@@ -273,6 +274,31 @@ oauth.post("/authorize/approve", async (c) => {
     // "Cursor", "Claude Desktop") — lowercase, fallback to "oauth".
     const ref = (client.client_name || "oauth").toLowerCase().replace(/\s+/g, "-");
     await insertOrganizationWithEmail(c.env.DB, orgId, email.split("@")[0], email, ref);
+    // Activation parity with /signup (engram#onboarding): connector-directory
+    // users never see the dashboard, so this is their only welcome. Seed the
+    // getting-started note (their first search hits something real) and fire
+    // the welcome email with the save->recall script. Both best-effort —
+    // OAuth must never fail because of onboarding extras.
+    try {
+      await seedWelcomeConversation(c.env.DB, orgId);
+    } catch (err) {
+      console.error(`[oauth] welcome seed failed for ${orgId}: ${err instanceof Error ? err.message : err}`);
+    }
+    const adminSecret = (c.env as Env & { ADMIN_SECRET?: string }).ADMIN_SECRET;
+    if (c.env.APP_URL && adminSecret) {
+      c.executionCtx.waitUntil(
+        fetch(`${c.env.APP_URL}/api/email/welcome`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${adminSecret}`,
+          },
+          body: JSON.stringify({ to: email, name: email.split("@")[0] }),
+        }).catch((err) =>
+          console.error(`[oauth] welcome email failed for ${orgId}: ${err instanceof Error ? err.message : err}`),
+        ),
+      );
+    }
   }
 
   const scope = body.scope || DEFAULT_SCOPE;

--- a/apps/mcp-server/src/routes/signup.ts
+++ b/apps/mcp-server/src/routes/signup.ts
@@ -31,7 +31,7 @@ That's it. Three steps. Your AI now has memory that persists across sessions, pr
 
 Try it now — have a conversation about something you're working on, then say "remember this." Tomorrow, ask about it and watch the magic happen.`;
 
-async function seedWelcomeConversation(db: D1Database, orgId: string): Promise<void> {
+export async function seedWelcomeConversation(db: D1Database, orgId: string): Promise<void> {
   const convId = generateId("conv");
   const msgId = generateId("msg");
   const now = new Date().toISOString();


### PR DESCRIPTION
77% of signups (connector-directory users) never save a memory. Root causes
fixed here: (1) OAuth-created orgs got no welcome note and no welcome email —
now seeded + fired (best-effort, never blocks the flow); (2) memory_status's
description told the model to only check on explicit request, suppressing the
first-run save+recall prompt — now it instructs a start-of-chat check that
walks brand-new accounts through save -> live recall.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
