### PR TITLE
Fix admin dashboard: stop false-cancelled + make Stripe state live

### DIFF
--- a/apps/mcp-server/src/cron/reconcile-stripe.ts
+++ b/apps/mcp-server/src/cron/reconcile-stripe.ts
@@ -1,0 +1,49 @@
+import type { Env } from "../types.js";
+import { syncOrganizationFromStripe } from "../services/stripe-sync.js";
+
+// ---------------------------------------------------------------------------
+// Reconcile every org's D1 tier/cancel state against live Stripe.
+//
+// D1 is a webhook-only projection: a missed/late/mis-signed Stripe delivery
+// leaves the admin dashboard permanently stale until someone clicks "Sync".
+// This backstop polls Stripe for every org that has a customer id and repairs
+// D1 with the shared, evidence-only sync logic — so a dropped
+// `customer.subscription.created` (today's upgrade not showing) or a missed
+// `subscription.deleted` self-heals within one cron tick.
+//
+// Safe by construction: syncOrganizationFromStripe never downgrades on an
+// empty Stripe result, so this can run fleet-wide without nuking live payers.
+// Only orgs with a stripe_customer_id are touched (a handful today), so the
+// Stripe API volume is trivial; batch/paginate if that grows.
+// ---------------------------------------------------------------------------
+
+export async function reconcileStripeToD1(
+  env: Env,
+): Promise<{ checked: number; changed: number; errors: number }> {
+  // Enterprise is manually managed (comped / negotiated, often with no live
+  // Stripe sub) — never auto-sync it from Stripe (the helper also guards this).
+  // grace_ends_at lets the helper skip active admin grants/comps.
+  const rows = await env.DB.prepare(
+    "SELECT id, tier, stripe_customer_id, grace_ends_at FROM organizations WHERE stripe_customer_id IS NOT NULL AND deleted_at IS NULL AND tier != 'enterprise'",
+  ).all<{ id: string; tier: string; stripe_customer_id: string | null; grace_ends_at: string | null }>();
+
+  let checked = 0;
+  let changed = 0;
+  let errors = 0;
+
+  for (const org of rows.results ?? []) {
+    try {
+      const before = org.tier;
+      const result = await syncOrganizationFromStripe(env, org);
+      checked++;
+      if (result.synced && result.tier !== before) changed++;
+    } catch (err) {
+      errors++;
+      console.error(
+        `[reconcile] org ${org.id} FAILED: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return { checked, changed, errors };
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -27,6 +27,7 @@ import { sendImportNudges } from "./cron/import-nudge.js";
 import { sendMaxoutNudges } from "./cron/maxout-nudge.js";
 import { sendActivationNudges } from "./cron/activation-nudge.js";
 import { drainContentToR2 } from "./cron/drain-content.js";
+import { reconcileStripeToD1 } from "./cron/reconcile-stripe.js";
 export { DrainerDO } from "./services/drainer-do.js";
 import { sendWeeklyDigests } from "./cron/weekly-digest.js";
 import { sendDailyReport } from "./services/daily-report.js";
@@ -282,6 +283,19 @@ export default {
     if (event.cron === "* * * * *") {
       // MUST return here — falling through would run the daily purge/nudge
       // branch every minute.
+      // Every 10th minute: reconcile D1 tier/cancel state against live Stripe
+      // so a missed/late webhook (e.g. today's upgrade not showing, or a
+      // cancellation the webhook dropped) self-heals. Safe fleet-wide — the
+      // shared sync logic never downgrades on an empty Stripe result.
+      if (new Date(event.scheduledTime).getUTCMinutes() % 10 === 0) {
+        try {
+          const { checked, changed, errors } = await reconcileStripeToD1(env);
+          if (changed > 0 || errors > 0)
+            console.log(`[reconcile] ${changed}/${checked} tier(s) updated, ${errors} error(s)`);
+        } catch (err) {
+          console.error(`[reconcile] FAILED: ${err instanceof Error ? err.message : err}`);
+        }
+      }
       try {
         const moved = await drainContentToR2(env);
         if (moved > 0) console.log(`[drain] moved ${moved} message(s) to R2`);

--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -3,6 +3,7 @@ import { getAuditLogs } from "@getengram/db";
 import { compressContent, ENCODING_GZIP } from "../utils/compress.js";
 import type { Env } from "../types.js";
 import { sendDailyReport } from "../services/daily-report.js";
+import { syncOrganizationFromStripe } from "../services/stripe-sync.js";
 
 type AdminEnv = { Bindings: Env };
 
@@ -406,80 +407,24 @@ admin.get("/users/:id/stripe", async (c) => {
 admin.post("/users/:id/sync-stripe", async (c) => {
   const id = c.req.param("id");
   const org = await c.env.DB.prepare(
-    "SELECT id, tier, stripe_customer_id FROM organizations WHERE id = ?"
-  ).bind(id).first<{ id: string; tier: string; stripe_customer_id: string | null }>();
+    "SELECT id, tier, stripe_customer_id, grace_ends_at FROM organizations WHERE id = ?"
+  ).bind(id).first<{ id: string; tier: string; stripe_customer_id: string | null; grace_ends_at: string | null }>();
   if (!org) return c.json({ error: "not_found" }, 404);
-  if (!org.stripe_customer_id) return c.json({ error: "no_stripe_customer" }, 400);
 
-  const subsRes = await fetch(
-    `https://api.stripe.com/v1/subscriptions?customer=${org.stripe_customer_id}&status=all&limit=10`,
-    { headers: { Authorization: `Bearer ${c.env.STRIPE_SECRET_KEY}` } },
-  );
-  if (!subsRes.ok) return c.json({ error: "stripe_api_error" }, 502);
-
-  const subs = await subsRes.json() as {
-    data: Array<{
-      id: string; status: string;
-      items: { data: Array<{ price: { id: string }; quantity: number }> };
-      cancel_at_period_end: boolean;
-      cancel_at: number | null;
-      canceled_at: number | null;
-    }>;
-  };
-
-  const activeSub = subs.data.find((s) => s.status === "active" || s.status === "trialing");
-  if (!activeSub) {
-    // No live subscription. A canceled sub in the history (status=all) or a
-    // currently-paid tier means this org churned — stamp churned_at (with
-    // Stripe's canceled_at when available, keeping any earlier stamp) so the
-    // admin shows "cancelled" instead of plain free. Backfills cancellations
-    // the webhook never saw, including orgs already downgraded to free.
-    const canceled = subs.data
-      .filter((s) => s.canceled_at)
-      .sort((a, b) => (b.canceled_at ?? 0) - (a.canceled_at ?? 0))[0];
-    const churnedAt = canceled?.canceled_at
-      ? new Date(canceled.canceled_at * 1000).toISOString().slice(0, 19).replace("T", " ")
-      : null;
-    const isChurn = Boolean(churnedAt) || org.tier !== "free";
-    await c.env.DB.prepare(
-      `UPDATE organizations SET
-         churned_at = CASE WHEN ? THEN COALESCE(churned_at, COALESCE(?, datetime('now'))) ELSE churned_at END,
-         cancel_at_period_end = 0,
-         tier = 'free', stripe_subscription_id = NULL, seat_limit = 1
-       WHERE id = ?`
-    ).bind(isChurn ? 1 : 0, churnedAt, id).run();
-    return c.json({ synced: true, tier: "free", subscription: null, churned_at: isChurn ? (churnedAt ?? "now") : null });
+  // Shared, evidence-only reconcile logic (also used by the reconcile cron).
+  // Never downgrades on an empty Stripe result, in dunning, on a comp/grace, or
+  // for enterprise — see syncOrganizationFromStripe for the guardrails.
+  const result = await syncOrganizationFromStripe(c.env, org);
+  if (!result.synced) {
+    // manual_tier / in_dunning are deliberate no-ops, not errors → 200.
+    const code =
+      result.reason === "no_stripe_customer" ? 400 :
+      result.reason === "stripe_api_error" ? 502 :
+      result.reason === "no_subscriptions_returned" ? 409 :
+      200;
+    return c.json(result, code);
   }
-
-  const priceId = activeSub.items?.data?.[0]?.price?.id;
-  const quantity = activeSub.items?.data?.[0]?.quantity ?? 1;
-  let tier: string = "pro";
-  if (priceId === c.env.STRIPE_PRICE_ID_TEAM) tier = "team";
-  const seatLimit = tier === "team" ? quantity : 1;
-
-  // Both of Stripe's scheduled-cancel mechanisms count (see billing.ts
-  // webhook note): the bool AND the cancel_at timestamp.
-  const cancelling = Boolean(activeSub.cancel_at_period_end) || (typeof activeSub.cancel_at === "number" && activeSub.cancel_at > 0);
-  await c.env.DB.prepare(
-    "UPDATE organizations SET tier = ?, stripe_subscription_id = ?, seat_limit = ?, cancel_at_period_end = ?, churned_at = CASE WHEN ? = 0 THEN NULL ELSE churned_at END WHERE id = ?"
-  ).bind(
-    tier,
-    activeSub.id,
-    seatLimit,
-    cancelling ? 1 : 0,
-    cancelling ? 1 : 0,
-    id,
-  ).run();
-
-  return c.json({
-    synced: true,
-    tier,
-    subscription_id: activeSub.id,
-    status: activeSub.status,
-    cancel_at_period_end: cancelling,
-    cancel_at: activeSub.cancel_at ? new Date(activeSub.cancel_at * 1000).toISOString() : null,
-    seat_limit: seatLimit,
-  });
+  return c.json(result);
 });
 
 // POST /admin/daily-report/send — manually trigger the daily ops email

--- a/apps/mcp-server/src/routes/billing.ts
+++ b/apps/mcp-server/src/routes/billing.ts
@@ -29,6 +29,39 @@ async function markChurned(db: Env["DB"], orgId: string): Promise<void> {
     .run();
 }
 
+/**
+ * Churn + downgrade an org to free, but ONLY when the terminating Stripe event
+ * is about the org's CURRENT subscription. Stripe does not guarantee event
+ * ordering: a superseded old sub's late `canceled`/`deleted` can arrive after
+ * the new sub's `active` and would otherwise nuke a live payer to "cancelled".
+ * Returns false (no-op) when the event is for a stale/foreign subscription.
+ */
+async function churnIfCurrentSub(
+  db: Env["DB"],
+  orgId: string,
+  eventSubscriptionId: string | null | undefined,
+): Promise<boolean> {
+  const org = await db
+    .prepare("SELECT stripe_subscription_id, grace_ends_at FROM organizations WHERE id = ?")
+    .bind(orgId)
+    .first<{ stripe_subscription_id: string | null; grace_ends_at: string | null }>();
+  const current = org?.stripe_subscription_id;
+  if (current && eventSubscriptionId && current !== eventSubscriptionId) {
+    // Terminating event is for an old/superseded sub — the org already moved
+    // on to a different live subscription. Ignore.
+    return false;
+  }
+  // An admin grant-pro / comp still inside its grace window is operator-managed
+  // — a stray Stripe terminal event must not revert it.
+  const grace = org?.grace_ends_at;
+  if (grace && Date.parse(grace.replace(" ", "T") + "Z") > Date.now()) {
+    return false;
+  }
+  await markChurned(db, orgId);
+  await setOrganizationTier(db, orgId, "free", null, 1);
+  return true;
+}
+
 const billing = new Hono<HonoEnv>();
 
 // POST /api/billing/checkout
@@ -348,8 +381,9 @@ billingWebhook.post("/", async (c) => {
         status === "unpaid" ||
         status === "past_due"
       ) {
-        await markChurned(c.env.DB, orgId);
-        await setOrganizationTier(c.env.DB, orgId, "free", null, 1);
+        // Only downgrade if this event is for the org's current sub (guards
+        // against out-of-order events from a superseded subscription).
+        await churnIfCurrentSub(c.env.DB, orgId, subscriptionId);
       }
       break;
     }
@@ -357,8 +391,7 @@ billingWebhook.post("/", async (c) => {
     case "customer.subscription.deleted": {
       const orgId = await resolveOrgIdFromEvent(c.env, obj);
       if (orgId) {
-        await markChurned(c.env.DB, orgId);
-        await setOrganizationTier(c.env.DB, orgId, "free", null, 1);
+        await churnIfCurrentSub(c.env.DB, orgId, obj.id as string);
       }
       break;
     }

--- a/apps/mcp-server/src/services/stripe-sync.ts
+++ b/apps/mcp-server/src/services/stripe-sync.ts
@@ -1,0 +1,165 @@
+import type { Env } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Reconcile one org's D1 tier/cancel state from its live Stripe subscriptions.
+//
+// This is the single source of the "what does Stripe actually say" logic,
+// shared by the admin Sync button (routes/admin.ts) and the reconciliation
+// cron (cron/reconcile-stripe.ts) so they can never drift.
+//
+// Guardrails (each one guards a way an ACTIVE/valid payer could be wrongly
+// downgraded — the whole point of this fix):
+//   - enterprise tier is negotiated above the Stripe price tiers → never sync.
+//   - an active admin grant/comp (grace_ends_at in the future) → never churn.
+//   - an EMPTY Stripe result is a stale customer id, NOT a cancellation → skip.
+//   - a recoverable sub (past_due dunning / paused / incomplete) → don't
+//     downgrade; the customer may still pay. Only churn on genuinely terminal
+//     subs (canceled / incomplete_expired / unpaid).
+// ---------------------------------------------------------------------------
+
+export interface OrgSyncInput {
+  id: string;
+  tier: string;
+  stripe_customer_id: string | null;
+  grace_ends_at?: string | null;
+}
+
+export type StripeSyncResult =
+  | {
+      synced: false;
+      reason:
+        | "no_stripe_customer"
+        | "stripe_api_error"
+        | "no_subscriptions_returned"
+        | "manual_tier"
+        | "in_dunning";
+      tier: string;
+    }
+  | {
+      synced: true;
+      tier: string;
+      subscription_id: string | null;
+      status?: string;
+      cancel_at_period_end?: boolean;
+      cancel_at?: string | null;
+      seat_limit?: number;
+      churned_at?: string | null;
+    };
+
+interface StripeSub {
+  id: string;
+  status: string;
+  items: { data: Array<{ price: { id: string }; quantity: number }> };
+  cancel_at_period_end: boolean;
+  cancel_at: number | null;
+  canceled_at: number | null;
+}
+
+// D1 datetimes are stored UTC-naive ("YYYY-MM-DD HH:MM:SS"); parse as UTC.
+function isFuture(d1Datetime: string | null | undefined): boolean {
+  if (!d1Datetime) return false;
+  const t = Date.parse(d1Datetime.replace(" ", "T") + "Z");
+  return Number.isFinite(t) && t > Date.now();
+}
+
+export async function syncOrganizationFromStripe(
+  env: Env,
+  org: OrgSyncInput,
+): Promise<StripeSyncResult> {
+  // Enterprise is manually negotiated above the Stripe price tiers — syncing
+  // from Stripe would wrongly rewrite it. Leave it entirely to the operator.
+  if (org.tier === "enterprise") {
+    return { synced: false, reason: "manual_tier", tier: org.tier };
+  }
+  if (!org.stripe_customer_id) {
+    return { synced: false, reason: "no_stripe_customer", tier: org.tier };
+  }
+
+  // limit=100 (Stripe max): status=all is ordered created-desc, so a live sub
+  // must never be paginated out behind old churned subs — that would read as a
+  // false cancellation, and the cron would apply it fleet-wide.
+  const subsRes = await fetch(
+    `https://api.stripe.com/v1/subscriptions?customer=${org.stripe_customer_id}&status=all&limit=100`,
+    { headers: { Authorization: `Bearer ${env.STRIPE_SECRET_KEY}` } },
+  );
+  if (!subsRes.ok) {
+    return { synced: false, reason: "stripe_api_error", tier: org.tier };
+  }
+
+  const subs = (await subsRes.json()) as { data: StripeSub[] };
+
+  const activeSub = subs.data.find(
+    (s) => s.status === "active" || s.status === "trialing",
+  );
+
+  if (activeSub) {
+    // Live subscription — set the tier from its price, clear any stale churn.
+    const priceId = activeSub.items?.data?.[0]?.price?.id;
+    const quantity = activeSub.items?.data?.[0]?.quantity ?? 1;
+    let tier = "pro";
+    if (priceId === env.STRIPE_PRICE_ID_TEAM) tier = "team";
+    const seatLimit = tier === "team" ? quantity : 1;
+
+    // Both of Stripe's scheduled-cancel mechanisms count: the bool AND the
+    // cancel_at timestamp (portal "cancel on <date>").
+    const cancelling =
+      Boolean(activeSub.cancel_at_period_end) ||
+      (typeof activeSub.cancel_at === "number" && activeSub.cancel_at > 0);
+
+    await env.DB.prepare(
+      "UPDATE organizations SET tier = ?, stripe_subscription_id = ?, seat_limit = ?, cancel_at_period_end = ?, churned_at = CASE WHEN ? = 0 THEN NULL ELSE churned_at END WHERE id = ?",
+    )
+      .bind(tier, activeSub.id, seatLimit, cancelling ? 1 : 0, cancelling ? 1 : 0, org.id)
+      .run();
+
+    return {
+      synced: true,
+      tier,
+      subscription_id: activeSub.id,
+      status: activeSub.status,
+      cancel_at_period_end: cancelling,
+      cancel_at: activeSub.cancel_at ? new Date(activeSub.cancel_at * 1000).toISOString() : null,
+      seat_limit: seatLimit,
+    };
+  }
+
+  // No live subscription. Decide carefully before downgrading — several
+  // non-cancellation states land here.
+  if (subs.data.length === 0) {
+    // Empty result = stale/duplicate customer id, NOT a cancellation.
+    return { synced: false, reason: "no_subscriptions_returned", tier: org.tier };
+  }
+  if (isFuture(org.grace_ends_at)) {
+    // Admin grant-pro / comp still within its grace window — operator-managed,
+    // don't revert it just because Stripe has no live sub.
+    return { synced: false, reason: "manual_tier", tier: org.tier };
+  }
+  const recoverable = subs.data.find(
+    (s) => s.status === "past_due" || s.status === "paused" || s.status === "incomplete",
+  );
+  if (recoverable) {
+    // In dunning / paused / incomplete — the customer may still pay. Keep
+    // their tier; a real cancellation will surface as a terminal sub later.
+    return { synced: false, reason: "in_dunning", tier: org.tier };
+  }
+
+  // Genuine churn: every sub is terminal (canceled / incomplete_expired /
+  // unpaid). Stamp churned_at from Stripe's canceled_at (keeping any earlier
+  // stamp) and downgrade. Churn is derived from Stripe evidence only.
+  const canceled = subs.data
+    .filter((s) => s.canceled_at)
+    .sort((a, b) => (b.canceled_at ?? 0) - (a.canceled_at ?? 0))[0];
+  const churnedAt = canceled?.canceled_at
+    ? new Date(canceled.canceled_at * 1000).toISOString().slice(0, 19).replace("T", " ")
+    : null;
+  await env.DB.prepare(
+    `UPDATE organizations SET
+       churned_at = COALESCE(churned_at, COALESCE(?, datetime('now'))),
+       cancel_at_period_end = 0,
+       tier = 'free', stripe_subscription_id = NULL, seat_limit = 1
+     WHERE id = ?`,
+  )
+    .bind(churnedAt, org.id)
+    .run();
+  return { synced: true, tier: "free", subscription_id: null, churned_at: churnedAt ?? "now" };
+}


### PR DESCRIPTION
## Problem
- Active paying subscribers were shown as **cancelled/cancelling** in the admin dashboard.
- The dashboard showed **stale** Stripe data (a payment made today didn't appear; tier didn't flip after upgrade).

## Root causes → fixes
1. **`sync-stripe` nuked active payers** to free when Stripe returned an empty result set (a stale/duplicate `stripe_customer_id`). New shared `syncOrganizationFromStripe` helper never downgrades without Stripe evidence, and guards **enterprise**, **active comps/grace grants**, and **in-dunning** (`past_due`/`paused`/`incomplete`) subs.
2. **Out-of-order webhooks** could downgrade a live sub. `churnIfCurrentSub` now only churns when the terminating event matches the org's **current** subscription id (and not during an active grace window).
3. **No reconciliation** — D1 was a webhook-only projection. Added a **10-min `reconcile-stripe` cron** that self-heals missed/late webhooks fleet-wide using the evidence-only helper.

## Verification
- `pnpm typecheck` clean; `pnpm test` 199/199 pass; `wrangler deploy --dry-run` bundles cleanly.
- Adversarial review performed; hardened enterprise/comp/dunning guards and pagination (limit=100).

## Notes
- The paired admin-UI "live refresh" change ships in engram-web.
- The webhook's existing `past_due → churn` policy is intentionally left unchanged (the reconcile cron no longer amplifies it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)