### PR TITLE
Search: don't dedupe-per-conversation when scoped to one conversation

### DIFF
--- a/apps/mcp-server/src/services/search.ts
+++ b/apps/mcp-server/src/services/search.ts
@@ -267,8 +267,13 @@ export async function searchConversations(
     });
   }
 
-  // Deduplicate: keep only the highest-scoring chunk per conversation
-  if (dedupe) {
+  // Deduplicate: keep only the highest-scoring chunk per conversation — this
+  // gives cross-conversation searches diversity (one hit per conversation).
+  // But when the search is SCOPED to a single conversation, dedupe-by-
+  // conversation can only ever return one chunk, starving the caller (an AI
+  // drilling into one memory) of the rest of the relevant thread. Skip it when
+  // a conversation_id filter is active so scoped search returns the top-k.
+  if (dedupe && !conversationId) {
     const seen = new Set<string>();
     results = results.filter((r) => {
       if (seen.has(r.conversation_id)) return false;


### PR DESCRIPTION
`searchConversations` dedupes to the highest-scoring chunk **per conversation** (cross-conversation diversity). When a `conversation_id` filter is active, that collapses the result set to **one chunk** — an AI drilling into a single memory gets one ~870-char chunk instead of the top-k.

Found via a LoCoMo retrieval benchmark: every conversation-scoped search returned exactly 1 result regardless of `limit`, capping retrieval recall.

Fix: skip dedupe when `conversationId` is set. Cross-conversation search unchanged. `pnpm test` 199/199, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)