### PR TITLE
Add D1 latency probe: daily-report metric + 10-min early-warning log

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -294,6 +294,18 @@ export default {
       // load that contributed to "D1 overloaded" (7429) incidents. Removed;
       // /admin/backfill-content-to-r2 and the DrainerDO remain for on-demand
       // use if inline content ever reappears.
+      // D1 latency early-warning: time one indexed point-read. Sustained
+      // multi-second latency preceded the Aug 2026 "D1 overloaded" (7429)
+      // incident by hours — this makes it visible in the worker logs while
+      // it is still just "slow". (Trend also lands in the daily report.)
+      try {
+        const t0 = Date.now();
+        await env.DB.prepare("SELECT id FROM organizations LIMIT 1").first();
+        const ms = Date.now() - t0;
+        if (ms > 3000) console.error(`[d1-latency] WARNING: probe took ${ms}ms (>3s) — D1 under pressure`);
+      } catch (err) {
+        console.error(`[d1-latency] probe FAILED: ${err instanceof Error ? err.message : err}`);
+      }
       try {
         const { checked, changed, errors } = await reconcileStripeToD1(env);
         if (changed > 0 || errors > 0)

--- a/apps/mcp-server/src/services/daily-report.ts
+++ b/apps/mcp-server/src/services/daily-report.ts
@@ -25,6 +25,10 @@ export interface DailyReport {
     }>;
   };
   referrals_all_time: Record<string, number>;
+  /** Milliseconds for a simple indexed D1 point-read at report time. Normal is
+   *  <500ms; sustained values in the seconds mean D1 is under pressure (see
+   *  the Aug 2026 "D1 overloaded" incident) and is the early-warning signal. */
+  d1_latency_ms?: number;
   /** Emails of team/enterprise orgs — engram-web flags support-inbox mail
    *  from these as PRIORITY (only paid team tiers get priority support). */
   priority_support_emails: string[];
@@ -38,6 +42,13 @@ export interface DailyReport {
 
 export async function buildDailyReport(env: Env): Promise<DailyReport> {
   const db = env.DB;
+
+  // D1 health probe: time one simple indexed point-read BEFORE the heavy
+  // batch below, so the number reflects baseline latency, not contention
+  // with our own report queries.
+  const probeStart = Date.now();
+  await db.prepare("SELECT id FROM organizations LIMIT 1").first();
+  const d1LatencyMs = Date.now() - probeStart;
 
   const [
     tiers,
@@ -139,6 +150,7 @@ export async function buildDailyReport(env: Env): Promise<DailyReport> {
       new_signups: newSignups.results ?? [],
     },
     referrals_all_time: refs,
+    d1_latency_ms: d1LatencyMs,
     priority_support_emails: (teamEmails.results ?? []).map((r) => r.email.toLowerCase()),
     top_orgs_7d: topOrgs.results ?? [],
   };


### PR DESCRIPTION
Sustained multi-second D1 latency preceded the 'D1 overloaded' (7429) incident by hours, invisibly (`/health` doesn't touch D1). Adds a timed indexed point-read to the daily report (`d1_latency_ms`) and a `[d1-latency]` WARNING log in the 10-min cron when the probe exceeds 3s. 201/201 tests.