### PR TITLE
Release @getengram/cli 0.5.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getengram/cli",
-  "version": "0.5.0",
-  "description": "CLI for Engram \u2014 persistent memory for AI agents",
+  "version": "0.5.1",
+  "description": "CLI for Engram — persistent memory for AI agents",
   "type": "module",
   "bin": {
     "engram": "./dist/index.js"


### PR DESCRIPTION
Version bump for the published 0.5.1 (daemon batch/timeout fix, PR #367). Already live on npm.