### PR TITLE
Raise /admin/users cap to 5k; stop churning on past_due

### DIFF
--- a/apps/mcp-server/src/__tests__/billing.test.ts
+++ b/apps/mcp-server/src/__tests__/billing.test.ts
@@ -490,7 +490,12 @@ describe("webhook: customer.subscription.updated", () => {
     expect(res.status).toBe(200);
   });
 
-  it("downgrades to free when subscription is past_due", async () => {
+  // past_due means a renewal charge failed and Stripe is still retrying —
+  // the customer intends to pay, so the plan is NOT revoked mid-dunning.
+  // Stripe escalates to unpaid/canceled when retries are exhausted; those
+  // churn (see the tests below). The mock D1 doesn't apply UPDATEs, so this
+  // asserts the handler accepts the event without erroring.
+  it("accepts past_due without churning (dunning, not cancellation)", async () => {
     const db = createMockD1();
     const env = createBillingEnv(db);
     await insertOrganizationWithEmail(db, "org_pastdue", "PastDue Org", "pastdue@example.com");

--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -283,7 +283,12 @@ admin.get("/timeseries", async (c) => {
 admin.get("/users", async (c) => {
   const sort = c.req.query("sort") || "created_at";
   const order = c.req.query("order") === "asc" ? "ASC" : "DESC";
-  const limit = Math.min(Number(c.req.query("limit") || "100"), 500);
+  // 500 was too low to pull the whole base in one call once signups passed it,
+  // which silently truncated ad-hoc analysis (segment percentages computed on
+  // the newest 500 skew heavily toward not-yet-activated accounts). 5,000 is
+  // comfortably above current scale while still bounding the response; page
+  // with `offset` beyond that.
+  const limit = Math.min(Number(c.req.query("limit") || "100"), 5000);
   const offset = Number(c.req.query("offset") || "0");
 
   const allowedSort: Record<string, string> = {
@@ -333,11 +338,16 @@ admin.get("/users", async (c) => {
     "SELECT COUNT(*) as count FROM organizations WHERE deleted_at IS NULL"
   ).first<{ count: number }>();
 
+  const returned = (result.results ?? []).length;
+  const totalCount = total?.count ?? 0;
   return c.json({
     users: result.results,
-    total: total?.count ?? 0,
+    total: totalCount,
     limit,
     offset,
+    // Explicit so a truncated page can't be mistaken for the whole base —
+    // that silently skewed segment analysis when the cap was 500.
+    has_more: offset + returned < totalCount,
   });
 });
 

--- a/apps/mcp-server/src/routes/billing.ts
+++ b/apps/mcp-server/src/routes/billing.ts
@@ -378,11 +378,18 @@ billingWebhook.post("/", async (c) => {
       } else if (
         status === "canceled" ||
         status === "incomplete_expired" ||
-        status === "unpaid" ||
-        status === "past_due"
+        status === "unpaid"
       ) {
         // Only downgrade if this event is for the org's current sub (guards
         // against out-of-order events from a superseded subscription).
+        //
+        // NOTE: `past_due` is deliberately NOT in this list. It means a
+        // renewal charge failed and Stripe is still retrying (dunning runs for
+        // weeks and usually recovers) — the customer intends to pay and
+        // yanking their plan mid-retry is both wrong and a good way to lose
+        // them. Stripe escalates to `unpaid` or `canceled` when dunning is
+        // exhausted, and those DO churn here. Observed: a paying customer's
+        // card bounced and they were instantly downgraded to free.
         await churnIfCurrentSub(c.env.DB, orgId, subscriptionId);
       }
       break;


### PR DESCRIPTION
**API:** single-response cap 500 → 5,000 with explicit `has_more` (the 500 cap silently truncated whole-base analysis).

**Billing:** `past_due` no longer downgrades — it's a failed charge mid-dunning, not a cancellation. Stripe escalates to `unpaid`/`canceled` when retries are exhausted; those still churn. Hit live: a paying customer's card bounced and they were instantly downgraded.