### PR TITLE
fix(cli): tell the user when memory is full instead of failing silently

### DIFF
--- a/apps/cli/src/__tests__/storage-full.test.ts
+++ b/apps/cli/src/__tests__/storage-full.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { classifyError, syncErrorSummary } from "../daemon/status.js";
+import { parseStorageFullError } from "../storage-error.js";
+
+/**
+ * A full memory used to be indistinguishable from any other 402 inside the
+ * daemon: classified as "billing", logged once to daemon.log, then retried
+ * on a backoff forever. Nothing reached the user, and captures kept piling
+ * into a local queue that could never drain.
+ */
+describe("storage_full classification", () => {
+  const body = JSON.stringify({
+    error: "storage_full",
+    message: "Engram's memory is full (10,000 messages).",
+    used: 10000,
+    limit: 10000,
+  });
+
+  it("classifies a storage_full body distinctly from other billing errors", () => {
+    expect(classifyError(body)).toBe("storage_full");
+  });
+
+  it("still classifies ordinary quota errors as billing", () => {
+    expect(classifyError('{"error":"limit_exceeded","message":"x"}')).toBe("billing");
+    expect(classifyError("Request failed with 402")).toBe("billing");
+  });
+
+  it("does not let the generic 402 branch shadow storage_full", () => {
+    // The real payload carries both markers; order of checks decides.
+    expect(classifyError(`402 ${body}`)).toBe("storage_full");
+  });
+
+  it("leaves other error classes alone", () => {
+    expect(classifyError("Authentication failed")).toBe("auth");
+    expect(classifyError("429 too many requests")).toBe("rate_limit");
+    expect(classifyError("503 service unavailable")).toBe("server");
+    expect(classifyError("fetch failed")).toBe("network");
+  });
+});
+
+describe("syncErrorSummary", () => {
+  it("names the actual numbers when they are known", () => {
+    const msg = syncErrorSummary("storage_full", { used: 10000, limit: 10000 });
+    expect(msg).toContain("10,000/10,000");
+    expect(msg).toContain("getengram.app/pricing");
+  });
+
+  it("says new captures will NOT be saved — the part users need", () => {
+    const msg = syncErrorSummary("storage_full", { used: 10000, limit: 10000 });
+    expect(msg).toMatch(/not be saved/i);
+  });
+
+  it("degrades without numbers rather than printing undefined", () => {
+    const msg = syncErrorSummary("storage_full", null);
+    expect(msg).not.toContain("undefined");
+    expect(msg).toContain("full");
+  });
+
+  it("distinguishes a full memory from a generic plan limit", () => {
+    const full = syncErrorSummary("storage_full", { used: 10000, limit: 10000 });
+    const billing = syncErrorSummary("billing", null);
+    expect(full).not.toBe(billing);
+    // Retrying clears a rate limit; it can never clear a full memory, so the
+    // copy must not imply waiting is a fix.
+    expect(full).not.toMatch(/retry|backoff/i);
+    expect(billing).toMatch(/retry/i);
+  });
+
+  it("covers every error type without falling through to undefined", () => {
+    for (const t of ["auth", "storage_full", "billing", "rate_limit", "network", "server"] as const) {
+      const msg = syncErrorSummary(t, null);
+      expect(msg.length).toBeGreaterThan(10);
+      expect(msg).not.toContain("undefined");
+    }
+  });
+});
+
+describe("parseStorageFullError (shared module)", () => {
+  it("round-trips the server payload", () => {
+    expect(
+      parseStorageFullError(
+        JSON.stringify({ error: "storage_full", message: "full", used: 10000, limit: 10000 }),
+      ),
+    ).toEqual({ message: "full", used: 10000, limit: 10000, upgrade_url: undefined });
+  });
+
+  it("returns null for other errors and for junk", () => {
+    expect(parseStorageFullError('{"error":"limit_exceeded"}')).toBeNull();
+    expect(parseStorageFullError("not json")).toBeNull();
+    expect(parseStorageFullError("")).toBeNull();
+  });
+});

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -4,6 +4,11 @@ import { Engram, type MessageInput } from "@getengram/sdk";
 import { loadConfig, getBaseUrl } from "../config.js";
 import { green, dim, bold } from "../output.js";
 
+import { parseStorageFullError } from "../storage-error.js";
+// Re-exported for backwards compatibility: this parser moved to a shared module
+// so the sync daemon can use it without importing this command.
+export { parseStorageFullError, type StorageFullError } from "../storage-error.js";
+
 /**
  * Import a ChatGPT or Claude data export into Engram. The format is
  * auto-detected from the file.
@@ -331,36 +336,6 @@ export function storageWarning(
   );
 }
 
-/**
- * Parse an SDK error message as the server's `storage_full` payload. The
- * MCP tool returns it as an isError JSON body, which the SDK surfaces
- * verbatim as the Error message. Returns null for anything else.
- */
-export function parseStorageFullError(raw: string): {
-  message: string;
-  used?: number;
-  limit?: number;
-  upgrade_url?: string;
-} | null {
-  try {
-    const parsed = JSON.parse(raw) as {
-      error?: string;
-      message?: string;
-      used?: number;
-      limit?: number;
-      upgrade_url?: string;
-    };
-    if (parsed?.error !== "storage_full") return null;
-    return {
-      message: parsed.message || "Engram's memory is full.",
-      used: parsed.used,
-      limit: parsed.limit,
-      upgrade_url: parsed.upgrade_url,
-    };
-  } catch {
-    return null;
-  }
-}
 
 /** Fetch lifetime storage usage; returns null on any failure (never blocks the import). */
 async function fetchStorageUsage(): Promise<StorageUsage | null> {

--- a/apps/cli/src/commands/usage.ts
+++ b/apps/cli/src/commands/usage.ts
@@ -1,5 +1,6 @@
 import { loadConfig, getBaseUrl } from "../config.js";
 import { bold, dim, red, json as printJson } from "../output.js";
+import { readStatus } from "../daemon/status.js";
 
 const API_URL = process.env.ENGRAM_BASE_URL ?? getBaseUrl();
 
@@ -79,8 +80,23 @@ export async function usage(
   if (data.storage && data.storage.limit > 0) {
     const pct = data.storage.used / data.storage.limit;
     if (pct >= 1) {
-      console.log(dim("  Memory is full — nothing expires, but new saves are paused."));
-      console.log(dim("  Free space by deleting conversations, or upgrade: engram upgrade\n"));
+      // Not dim: this is the one state where the product has silently
+      // stopped doing its job, and it needs to read that way.
+      console.log(red(bold("  Memory is full — new saves are paused.")));
+      console.log("  Nothing already saved expires or is lost.");
+
+      // Background captures keep queueing locally while capped. Left
+      // unsaid, auto-capture looks like it's still working.
+      const queued = readStatus().pending_messages;
+      if (queued > 0) {
+        console.log(
+          red(
+            `  ${fmt(queued)} captured message${queued === 1 ? "" : "s"} ` +
+              `waiting on this machine — they will not be saved until you free space.`,
+          ),
+        );
+      }
+      console.log("  Free space by deleting conversations, or upgrade: engram upgrade\n");
     } else if (pct >= 0.8) {
       console.log(dim("  Heads up: memory is over 80% full. More room: engram upgrade\n"));
     }

--- a/apps/cli/src/daemon/status.ts
+++ b/apps/cli/src/daemon/status.ts
@@ -6,14 +6,27 @@ const STATUS_FILE = join(homedir(), ".engram", "status.json");
 
 export type SyncHealth = "healthy" | "warning" | "error";
 
+export type SyncErrorType =
+  | "auth"
+  /** Lifetime memory is full. Distinct from `billing`: retrying will never
+   *  succeed on its own — it needs an upgrade or deleted conversations. */
+  | "storage_full"
+  | "billing"
+  | "rate_limit"
+  | "network"
+  | "server";
+
 export interface SyncStatus {
   health: SyncHealth;
   last_sync_at: string | null;
   last_error_at: string | null;
   last_error: string | null;
-  error_type: "auth" | "billing" | "rate_limit" | "network" | "server" | null;
+  error_type: SyncErrorType | null;
   pending_messages: number;
   consecutive_failures: number;
+  /** Populated on a storage_full error so the numbers can be shown without
+   *  a network round trip (the CLI may be offline when it surfaces them). */
+  storage: { used: number; limit: number } | null;
   updated_at: string;
 }
 
@@ -25,6 +38,7 @@ const DEFAULT_STATUS: SyncStatus = {
   error_type: null,
   pending_messages: 0,
   consecutive_failures: 0,
+  storage: null,
   updated_at: new Date().toISOString(),
 };
 
@@ -34,7 +48,13 @@ let lastNotifiedError: string | null = null;
 export function readStatus(): SyncStatus {
   try {
     if (existsSync(STATUS_FILE)) {
-      return JSON.parse(readFileSync(STATUS_FILE, "utf-8"));
+      // Merged over the defaults: a status.json written by an older CLI
+      // predates newer fields, and callers should get null rather than
+      // undefined for them.
+      return {
+        ...DEFAULT_STATUS,
+        ...(JSON.parse(readFileSync(STATUS_FILE, "utf-8")) as Partial<SyncStatus>),
+      };
     }
   } catch {
     // corrupt or missing
@@ -60,24 +80,38 @@ export function recordSuccess(pendingMessages: number): void {
   currentStatus.error_type = null;
   currentStatus.pending_messages = pendingMessages;
   currentStatus.consecutive_failures = 0;
+  currentStatus.storage = null;
   lastNotifiedError = null;
   writeStatus();
 }
 
-/** Record a sync failure. Sends a desktop notification on first occurrence. */
+/**
+ * Record a sync failure. Logs once per error type and, for the two states
+ * the user must act on (auth, storage_full), raises a desktop notification
+ * on first occurrence — the daemon is headless, so a line in daemon.log is
+ * not "telling" anyone.
+ */
 export function recordFailure(
   error: string,
   errorType: SyncStatus["error_type"],
   pendingMessages: number,
+  storage?: { used?: number; limit?: number } | null,
 ): void {
   currentStatus.consecutive_failures++;
   currentStatus.last_error = error;
   currentStatus.last_error_at = new Date().toISOString();
   currentStatus.error_type = errorType;
   currentStatus.pending_messages = pendingMessages;
+  if (
+    errorType === "storage_full" &&
+    typeof storage?.used === "number" &&
+    typeof storage?.limit === "number"
+  ) {
+    currentStatus.storage = { used: storage.used, limit: storage.limit };
+  }
 
   // Escalate health based on severity and consecutive failures
-  if (errorType === "auth" || errorType === "billing") {
+  if (errorType === "auth" || errorType === "billing" || errorType === "storage_full") {
     currentStatus.health = "error";
   } else if (currentStatus.consecutive_failures >= 5) {
     currentStatus.health = "error";
@@ -90,7 +124,10 @@ export function recordFailure(
   // Log once per error type (not per unique message) to avoid spam
   if (errorType !== lastNotifiedError) {
     lastNotifiedError = errorType;
-    logWarning(errorType);
+    logWarning(errorType, currentStatus.storage);
+    if (errorType === "auth" || errorType === "storage_full") {
+      notifyDesktop(errorType, currentStatus.storage);
+    }
   }
 }
 
@@ -103,6 +140,12 @@ export function updatePending(count: number): void {
 function classifyError(message: string): SyncStatus["error_type"] {
   if (message.includes("401") || message.includes("403") || message.includes("Authentication")) {
     return "auth";
+  }
+  // Must precede the generic billing check: a storage_full body also carries
+  // a 402, but it is a different situation — backing off and retrying can
+  // never clear it, so it gets its own state and its own copy.
+  if (message.includes("storage_full")) {
+    return "storage_full";
   }
   if (message.includes("402") || message.includes("limit_exceeded") || message.includes("billing")) {
     return "billing";
@@ -118,17 +161,83 @@ function classifyError(message: string): SyncStatus["error_type"] {
 
 export { classifyError };
 
-/** Log a warning to stderr (goes to daemon.log). One line per error type. */
-function logWarning(errorType: SyncStatus["error_type"]): void {
-  const warnings: Record<string, string> = {
-    auth: "Authentication failed — run 'engram auth login'",
-    billing: "Plan limit reached — upgrade at https://getengram.app/pricing. Messages are queued locally and will retry with backoff.",
-    rate_limit: "Rate limited — messages queued, will retry",
-    network: "Can't reach servers — messages queued locally",
-    server: "Server error — messages queued, will retry",
-  };
+const n = (x: number) => x.toLocaleString("en-US");
 
-  const msg = warnings[errorType ?? "network"] ?? "Unknown sync error";
-  console.error(`[engram] WARNING: ${msg}`);
+/**
+ * One-line summary of a sync error, in the second person. Shared by the
+ * daemon log, the desktop notification, and the banner the CLI prints on
+ * the next interactive command.
+ */
+export function syncErrorSummary(
+  errorType: SyncStatus["error_type"],
+  storage?: { used: number; limit: number } | null,
+): string {
+  switch (errorType) {
+    case "auth":
+      return "Authentication failed — run 'engram auth login'.";
+    case "storage_full": {
+      const size = storage ? `${n(storage.used)}/${n(storage.limit)} messages` : "its limit";
+      return (
+        `Engram's memory is full (${size}). Everything already saved is safe and ` +
+        `searchable — but new captures are queued locally and will NOT be saved ` +
+        `until you free space. Upgrade ($9/mo for 1,000,000 messages) or delete ` +
+        `old conversations: https://getengram.app/pricing`
+      );
+    }
+    case "billing":
+      return "Plan limit reached — upgrade at https://getengram.app/pricing. Messages are queued locally and will retry with backoff.";
+    case "rate_limit":
+      return "Rate limited — messages queued, will retry.";
+    case "server":
+      return "Server error — messages queued, will retry.";
+    default:
+      return "Can't reach servers — messages queued locally.";
+  }
+}
+
+/** Log a warning to stderr (goes to daemon.log). One line per error type. */
+function logWarning(
+  errorType: SyncStatus["error_type"],
+  storage?: { used: number; limit: number } | null,
+): void {
+  console.error(`[engram] WARNING: ${syncErrorSummary(errorType, storage)}`);
   console.error(`[engram] Run 'engram status' for details.`);
+}
+
+/**
+ * Best-effort desktop notification. The daemon runs headless under launchd,
+ * so stderr goes to daemon.log where nobody reads it — for states that need
+ * a human decision, this is the only channel that actually reaches them.
+ *
+ * Deliberately fire-and-forget and fully swallowed: notification tooling is
+ * absent on plenty of systems (headless Linux, minimal containers) and a
+ * failure to notify must never disturb syncing.
+ */
+function notifyDesktop(
+  errorType: SyncStatus["error_type"],
+  storage?: { used: number; limit: number } | null,
+): void {
+  const title = errorType === "storage_full" ? "Engram memory is full" : "Engram needs attention";
+  const body =
+    errorType === "storage_full" && storage
+      ? `${n(storage.used)}/${n(storage.limit)} messages used. New captures are paused.`
+      : syncErrorSummary(errorType, storage).slice(0, 180);
+  try {
+    // Lazy require: keeps the module import-light for the daemon bootstrap,
+    // which deliberately avoids pulling in anything heavy at startup.
+    const { execFile } = require("node:child_process") as typeof import("node:child_process");
+    const done = () => {};
+    if (process.platform === "darwin") {
+      const esc = (s: string) => s.replace(/["\\]/g, "\\$&");
+      execFile(
+        "osascript",
+        ["-e", `display notification "${esc(body)}" with title "${esc(title)}"`],
+        done,
+      );
+    } else if (process.platform === "linux") {
+      execFile("notify-send", [title, body], done);
+    }
+  } catch {
+    // no notification tooling — the log line and the CLI banner still stand
+  }
 }

--- a/apps/cli/src/daemon/syncer.ts
+++ b/apps/cli/src/daemon/syncer.ts
@@ -1,6 +1,7 @@
 import type { Engram } from "@getengram/sdk";
 import { DaemonDb } from "./db.js";
 import { recordSuccess, recordFailure, classifyError } from "./status.js";
+import { parseStorageFullError } from "../storage-error.js";
 import type { ParsedMessage, SessionMeta, PendingRow } from "./types.js";
 
 // Claude Code transcript messages can be enormous (tool output dumps), and
@@ -166,7 +167,7 @@ export class Syncer {
             return;
           }
           const errType = classifyError(msg);
-          if (errType === "billing") {
+          if (errType === "billing" || errType === "storage_full") {
             this.enterBillingBackoff(msg);
             return;
           }
@@ -222,7 +223,7 @@ export class Syncer {
 
         // Billing / limit errors — exponential backoff
         const errType = classifyError(msg);
-        if (errType === "billing") {
+        if (errType === "billing" || errType === "storage_full") {
           this.enterBillingBackoff(msg);
           return;
         }
@@ -245,7 +246,16 @@ export class Syncer {
     }
   }
 
-  /** Enter billing backoff — escalates each time: 5min → 15min → 1hr */
+  /**
+   * Enter billing backoff — escalates each time: 5min → 15min → 1hr.
+   *
+   * A full memory is separated out here. It arrives as a 402 like any other
+   * billing error, but retrying can never clear it on its own: it needs an
+   * upgrade or deleted conversations. It gets its own status state (so the
+   * CLI can say "memory is full" rather than "plan limit reached") and its
+   * used/limit numbers are carried through, so the banner can name them
+   * even when the machine is offline.
+   */
   private enterBillingBackoff(msg: string): void {
     const delay = BILLING_BACKOFF_MS[
       Math.min(this.billingBackoffStep, BILLING_BACKOFF_MS.length - 1)
@@ -253,7 +263,20 @@ export class Syncer {
     this.billingBackoffUntil = Date.now() + delay;
     this.billingBackoffStep++;
 
+    const storageFull = parseStorageFullError(msg);
     const mins = Math.round(delay / 60_000);
+    if (storageFull) {
+      console.error(
+        `[engram] memory full (${storageFull.used ?? "?"}/${storageFull.limit ?? "?"}), ` +
+          `pausing sync ${mins}m — new captures stay queued until space is freed`,
+      );
+      recordFailure(msg, "storage_full", this.db.getPendingCount(), {
+        used: storageFull.used,
+        limit: storageFull.limit,
+      });
+      return;
+    }
+
     console.error(
       `[engram] billing limit hit, backing off ${mins}m (attempt ${this.billingBackoffStep}): ${msg}`,
     );

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createRequire } from "node:module";
 import { Engram } from "@getengram/sdk";
 import { loadConfig, getBaseUrl } from "./config.js";
 import { authLogin, authLogout, authStatus } from "./commands/auth.js";
@@ -19,9 +20,23 @@ import { autoEnableCapture } from "./daemon/commands.js";
 import { upgrade } from "./commands/upgrade.js";
 import { usage as showUsage } from "./commands/usage.js";
 import { vaultKeygen, vaultStatus, loadVaultKey, vaultSet, vaultGet, vaultList, vaultDelete } from "./commands/vault.js";
-import { bold, dim } from "./output.js";
+import { bold, dim, red } from "./output.js";
+import { readStatus, syncErrorSummary } from "./daemon/status.js";
 
-const VERSION = "0.3.4";
+// Read from package.json rather than duplicated here. The previous hardcoded
+// constant had drifted to 0.3.4 while the package shipped 0.5.1, so
+// `engram version` — the first thing anyone reports in a bug — was wrong for
+// two releases. npm always includes package.json in the tarball, and dist/
+// sits directly under the package root, so this resolves both from the repo
+// and from a global install.
+const VERSION: string = (() => {
+  try {
+    const require = createRequire(import.meta.url);
+    return (require("../package.json") as { version?: string }).version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+})();
 
 // Commands that take 1 word
 const TOP_COMMANDS = new Set([
@@ -183,6 +198,31 @@ ${dim(`v${VERSION} — https://getengram.app`)}
 `);
 }
 
+/**
+ * Print a one-time banner if the background sync daemon is stuck in a state
+ * the user has to resolve. Goes to stderr, never stdout, so `--json` output
+ * stays machine-parseable.
+ *
+ * Only the two states a human must act on are surfaced. Transient trouble
+ * (network, rate limits, 5xx) resolves itself and would just be noise on
+ * every command.
+ */
+function printSyncBanner(): void {
+  try {
+    const s = readStatus();
+    if (s.error_type !== "storage_full" && s.error_type !== "auth") return;
+    const queued =
+      s.pending_messages > 0
+        ? ` ${s.pending_messages.toLocaleString("en-US")} message${s.pending_messages === 1 ? "" : "s"} waiting locally.`
+        : "";
+    console.error(red(bold("engram:")) + ` ${syncErrorSummary(s.error_type, s.storage)}${queued}`);
+    console.error(dim("  (run 'engram status' for details)"));
+    console.error("");
+  } catch {
+    // Never let a status-file problem block the command the user asked for.
+  }
+}
+
 async function main(): Promise<void> {
   const raw = process.argv.slice(2);
 
@@ -214,6 +254,14 @@ async function main(): Promise<void> {
     "status", "log", "signup", "login", "link", "auth login", "auth logout",
   ]);
   const ensureCaptureAfter = !CAPTURE_EXEMPT.has(cmd);
+
+  // The daemon is headless, so a full memory would otherwise only ever be
+  // visible in ~/.engram/daemon.log. Surface it on the next interactive
+  // command instead — this is the moment the user is actually looking.
+  // `status` and `usage` print their own detail, so skip the banner there.
+  if (cmd !== "status" && cmd !== "usage") {
+    printSyncBanner();
+  }
 
   try {
     switch (cmd) {

--- a/apps/cli/src/storage-error.ts
+++ b/apps/cli/src/storage-error.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared parsing for the server's `storage_full` response.
+ *
+ * Lives outside `commands/` because both the `import` command and the sync
+ * daemon need it, and the daemon's bootstrap is deliberately import-light —
+ * it must not pull the import command's dependency tree in just to read a
+ * four-field JSON body.
+ */
+
+export interface StorageFullError {
+  message: string;
+  used?: number;
+  limit?: number;
+  upgrade_url?: string;
+}
+
+/**
+ * Parse an SDK error message as the server's `storage_full` payload.
+ *
+ * The MCP tool returns it as an isError JSON body, which the SDK surfaces
+ * verbatim as the Error message (see EngramError in packages/sdk). Returns
+ * null for anything else, including other 402s such as `limit_exceeded`.
+ */
+export function parseStorageFullError(raw: string): StorageFullError | null {
+  try {
+    const parsed = JSON.parse(raw) as {
+      error?: string;
+      message?: string;
+      used?: number;
+      limit?: number;
+      upgrade_url?: string;
+    };
+    if (parsed?.error !== "storage_full") return null;
+    return {
+      message: parsed.message || "Engram's memory is full.",
+      used: parsed.used,
+      limit: parsed.limit,
+      upgrade_url: parsed.upgrade_url,
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What was happening

The server already does its part — it blocks saves at the cap and returns a warm `storage_full` body. **The CLI daemon threw it away.**

`classifyError()` lumped it in with every other 402 as `"billing"`, logged one line to `~/.engram/daemon.log`, and retried on a 5m → 15m → 1hr backoff forever. The daemon runs headless under launchd, so that log line reaches nobody.

**This is worse than a missed upsell.** Captures keep queueing into the local SQLite queue, which has no bound and no pruning — so a capped user goes on "capturing" indefinitely into a queue that can never drain, while auto-capture appears to be working normally.

Two production accounts sit at exactly `10,000/10,000` right now. One is CLI-sourced **with no email on file**, so in-CLI messaging is the only channel that can reach them at all.

## Changes

- **`storage_full` is its own status type**, checked *before* the generic 402 branch that used to shadow it. It isn't "billing" — retrying can never clear it, so the copy must not imply that waiting helps.
- **The numbers ride along** in `status.json`, so the message can say "10,000/10,000" even when the machine is offline.
- **Desktop notification** (`osascript` / `notify-send`) on first occurrence, for the two states needing a human decision. `recordFailure`'s docstring already claimed it did this — it never did. Best-effort and fully swallowed; missing notification tooling must never disturb syncing.
- **A stderr banner on the next interactive command** — the moment the user is actually looking. On stderr specifically, so `engram search --json | jq` stays parseable.
- **`engram usage`** promotes the full-memory notice out of `dim()` (this is the one state where the product has silently stopped working — it should read that way) and reports how many captures are stranded locally.
- `parseStorageFullError` moved to `src/storage-error.ts` so the daemon can use it without importing the import command's dependency tree. Re-exported from `commands/import.ts` for compatibility.

## Verified end-to-end

Against a simulated capped `status.json`:

```
$ engram version
engram: Engram's memory is full (10,000/10,000 messages). Everything already
saved is safe and searchable — but new captures are queued locally and will
NOT be saved until you free space. Upgrade ($9/mo for 1,000,000 messages) or
delete old conversations: https://getengram.app/pricing 3,412 messages waiting locally.
  (run 'engram status' for details)

engram 0.5.1

$ engram version 2>/dev/null      # stdout stays clean
engram 0.5.1
```

## Unrelated bug this surfaced

That smoke test showed `engram 0.3.4` — the hardcoded `VERSION` constant had drifted while the package shipped **0.5.1**. So `engram version`, the first thing anyone quotes in a bug report, had been wrong for two releases. Now derived from `package.json` so it can't drift again. (Same duplicate-constant failure mode as the pricing `highPrice: 49` fixed in engram-web#202.)

## Tests

11 new: classification precedence over the generic 402, copy that distinguishes a full memory from a retryable limit, no `undefined` leaking when numbers are unknown, and full coverage of the error-type switch so a new type can't silently fall through.

`pnpm test` 355 passing, `pnpm typecheck` and `pnpm build` clean.

## Not covered

The local queue is still unbounded — this makes the situation *visible* but a long-capped machine still accumulates rows forever. Worth a follow-up: cap the queue and drop oldest with a clear warning, rather than growing without limit.

The connector path (ChatGPT/Claude) is unchanged and already works: `append_messages` returns `storageFullMessage()` with OAuth-specific copy instructing the agent to relay it, plus an 80% early warning. Its weakness is different — it depends on the agent choosing to pass the message along — and isn't addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52