### PR TITLE
fix(oauth): stop signing users out on benign refresh-token races

### DIFF
--- a/apps/mcp-server/src/__tests__/oauth.test.ts
+++ b/apps/mcp-server/src/__tests__/oauth.test.ts
@@ -305,13 +305,77 @@ describe("Token endpoint — refresh_token grant", () => {
     const second = (await refreshed.json()) as { refresh_token: string };
     expect(second.refresh_token).not.toBe(first.refresh_token);
 
-    // Reuse the now-rotated token — reuse detection kicks in.
-    const reuse = await app.fetch(
+    // Immediate reuse is a RACE, not an attack: the client most likely never
+    // received the successor (dropped response, retry, second process on the
+    // same credential store). Inside the grace window it gets a usable pair
+    // instead of having its whole chain revoked.
+    const race = await app.fetch(
       form({ grant_type: "refresh_token", client_id: clientId, refresh_token: first.refresh_token }),
       env,
     );
-    expect(reuse.status).toBe(400);
-    expect(((await reuse.json()) as { error_description: string }).error_description).toMatch(/reuse/i);
+    expect(race.status).toBe(200);
+    const raced = (await race.json()) as { refresh_token: string; access_token: string };
+    expect(raced.refresh_token).not.toBe(first.refresh_token);
+    expect(raced.refresh_token).not.toBe(second.refresh_token);
+
+    // Critically, the successor issued to the OTHER caller still works —
+    // neither client is signed out. This is the regression that mattered:
+    // 80 chain revocations across 54 orgs came from failing this case.
+    const other = await app.fetch(
+      form({ grant_type: "refresh_token", client_id: clientId, refresh_token: second.refresh_token }),
+      env,
+    );
+    expect(other.status).toBe(200);
+  });
+
+  it("still revokes the chain when a rotated token is replayed after the grace window", async () => {
+    const db = createOAuthD1();
+    const env = createOAuthEnv(db);
+    const clientId = await registerClient(env);
+    const { verifier, challenge } = await pkcePair();
+    const code = await getAuthCode(env, clientId, challenge);
+
+    const first = (await (
+      await app.fetch(
+        form({
+          grant_type: "authorization_code",
+          client_id: clientId,
+          code,
+          redirect_uri: REDIRECT,
+          code_verifier: verifier,
+        }),
+        env,
+      )
+    ).json()) as { refresh_token: string };
+
+    const second = (await (
+      await app.fetch(
+        form({ grant_type: "refresh_token", client_id: clientId, refresh_token: first.refresh_token }),
+        env,
+      )
+    ).json()) as { refresh_token: string };
+
+    // Age the rotation past the grace window. Replay now looks like theft,
+    // not a dropped response, so the security behaviour must be unchanged.
+    const anHourAgo = new Date(Date.now() - 3_600_000).toISOString().slice(0, 19).replace("T", " ");
+    await db
+      .prepare("UPDATE oauth_refresh_tokens SET revoked_at = ? WHERE rotated_to IS NOT NULL")
+      .bind(anHourAgo)
+      .run();
+
+    const replay = await app.fetch(
+      form({ grant_type: "refresh_token", client_id: clientId, refresh_token: first.refresh_token }),
+      env,
+    );
+    expect(replay.status).toBe(400);
+    expect(((await replay.json()) as { error_description: string }).error_description).toMatch(/reuse/i);
+
+    // ...and the whole chain is dead, including the successor.
+    const afterRevoke = await app.fetch(
+      form({ grant_type: "refresh_token", client_id: clientId, refresh_token: second.refresh_token }),
+      env,
+    );
+    expect(afterRevoke.status).toBe(400);
   });
 });
 

--- a/apps/mcp-server/src/oauth/router.ts
+++ b/apps/mcp-server/src/oauth/router.ts
@@ -35,6 +35,31 @@ const ACCESS_TTL_SECONDS = 60 * 60; // 1 hour
 const REFRESH_TTL_SECONDS = 60 * 60 * 24 * 60; // 60 days
 const CODE_TTL_SECONDS = 60 * 10; // 10 minutes
 
+/**
+ * Window after a rotation in which re-presenting the OLD refresh token is
+ * treated as a benign race rather than a replay attack.
+ *
+ * Without this, the single most common failure is self-inflicted: the client
+ * sends a refresh, the server rotates and replies, and the response is lost
+ * in transit. The client never learns the successor, retries with the token
+ * it still holds, and strict reuse detection revokes the entire chain —
+ * silently signing the user out of a connector that was working seconds ago.
+ *
+ * Measured before this fix: 80 chain revocations across 54 organizations
+ * between 2026-07-13 and 2026-08-31, one user kicked 9 times.
+ *
+ * Kept short so a genuinely stolen token stays useless: rotation still
+ * happens on every refresh, and reuse outside this window is still treated
+ * as a compromised chain.
+ */
+const REFRESH_REUSE_GRACE_SECONDS = 60;
+
+/** Parse a SQLite `datetime('now')` string (UTC, no zone marker) to epoch ms. */
+function sqliteDateTimeToMs(value: string | null | undefined): number {
+  if (!value) return NaN;
+  return Date.parse(value.replace(" ", "T") + "Z");
+}
+
 const BROWSER_ORIGINS = [
   "https://getengram.app",
   "https://www.getengram.app",
@@ -451,11 +476,61 @@ async function handleRefreshTokenGrant(
   if (!row || row.client_id !== clientId) {
     return c.json({ error: "invalid_grant", error_description: "Unknown refresh token" }, 400);
   }
-  // Reuse detection: an already-rotated or revoked token means the chain is
-  // compromised — revoke everything for this client+org.
+  // Reuse detection. An already-rotated or revoked token is EITHER a replay
+  // attack OR a client that never received the successor (dropped response,
+  // retry, a second process sharing the same credential store). Those look
+  // identical here, so the rotation age is used to separate them.
   if (row.rotated_to || row.revoked_at) {
-    await revokeRefreshTokenChain(c.env.DB, row.client_id, row.organization_id);
-    return c.json({ error: "invalid_grant", error_description: "Refresh token reuse detected" }, 400);
+    const rotatedAgeMs = Date.now() - sqliteDateTimeToMs(row.revoked_at);
+    const withinGrace =
+      Boolean(row.rotated_to) &&
+      Number.isFinite(rotatedAgeMs) &&
+      rotatedAgeMs >= 0 &&
+      rotatedAgeMs < REFRESH_REUSE_GRACE_SECONDS * 1000;
+
+    if (!withinGrace) {
+      console.warn(
+        `[oauth] refresh reuse outside grace — revoking chain for org=${row.organization_id} ` +
+          `client=${clientId} rotated_age_ms=${Number.isFinite(rotatedAgeMs) ? rotatedAgeMs : "unknown"}`,
+      );
+      await revokeRefreshTokenChain(c.env.DB, row.client_id, row.organization_id);
+      return c.json({ error: "invalid_grant", error_description: "Refresh token reuse detected" }, 400);
+    }
+
+    // Benign race. Issue a fresh pair WITHOUT re-rotating this row: its
+    // existing `rotated_to` still points at the successor the other caller
+    // received, so both callers end up holding a usable token and neither is
+    // signed out. Deliberately not idempotent — only hashes are stored, so
+    // the original successor cannot be replayed.
+    console.info(
+      `[oauth] refresh reuse within ${REFRESH_REUSE_GRACE_SECONDS}s grace — treating as race, ` +
+        `org=${row.organization_id} client=${clientId} rotated_age_ms=${rotatedAgeMs}`,
+    );
+    const raceRefresh = generateRefreshToken();
+    const raceAccess = generateAccessToken();
+    await insertAccessToken(
+      c.env.DB,
+      await hashApiKey(raceAccess),
+      clientId,
+      row.organization_id,
+      row.scope,
+      expiryFromNow(ACCESS_TTL_SECONDS),
+    );
+    await insertRefreshToken(
+      c.env.DB,
+      await hashApiKey(raceRefresh),
+      clientId,
+      row.organization_id,
+      row.scope,
+      expiryFromNow(REFRESH_TTL_SECONDS),
+    );
+    return c.json({
+      access_token: raceAccess,
+      token_type: "Bearer",
+      expires_in: ACCESS_TTL_SECONDS,
+      refresh_token: raceRefresh,
+      scope: row.scope,
+    });
   }
   if (sqliteDateTime(new Date()) > row.expires_at) {
     return c.json({ error: "invalid_grant", error_description: "Refresh token expired" }, 400);


### PR DESCRIPTION
## What was happening

Strict reuse detection treated *every* re-presentation of a rotated refresh token as a compromised chain, and revoked **every token for that client+org**:

```js
if (row.rotated_to || row.revoked_at) {
  await revokeRefreshTokenChain(c.env.DB, row.client_id, row.organization_id);
  return c.json({ error: "invalid_grant", ... }, 400);
}
```

The commonest cause of that condition is not theft. The server rotates, the response is lost in transit, the client retries with the token it still holds — and gets its whole chain revoked, silently signing it out of a connector that was working a second earlier.

## This was live for seven weeks

Rows with `revoked_at IS NOT NULL AND rotated_to IS NULL` are tokens that were live and killed by chain revocation rather than by normal rotation:

```
80 chain revocations across 54 organizations
2026-07-13 → 2026-08-31
```

Repeat victims — real users, not test accounts:

| org | times signed out |
|---|---|
| minecrafmania | **9** |
| rdanielenrique | 5 |
| imthequeen0516 | 4 |
| ketchup_glitter_3y | 3 |

It left no trace beyond the revoked rows: no logging, no error surfaced anywhere an operator would look. The symptom users experience is "I have to keep re-authenticating."

## The fix

A 60-second grace window. Re-presenting a token rotated inside that window is treated as a race:

- a fresh access+refresh pair is issued **without re-rotating the row**, so the successor already handed to the other caller stays valid
- **neither client is signed out** — this is the property that was missing
- deliberately *not* idempotent: only hashes are stored, so the original successor cannot be replayed

Outside the window, behaviour is unchanged — chain revoked, `invalid_grant`. A stolen token remains useless: rotation still happens on every refresh, and a thief's usable window is bounded by the same 60s.

Both paths now log, so this stops being invisible.

`rotateRefreshToken` already stamps `revoked_at` at rotation time, so the rotation age was available with no migration.

## Tests

The existing `"rotates the refresh token and detects reuse"` case asserted **400 on immediate reuse** — that assertion encoded the bug, so it's updated rather than worked around. It now asserts the race path returns 200 *and* that the other caller's successor still works.

A new case ages the rotation past the window and proves the security path is intact: replay is rejected **and** the whole chain dies.

355 tests pass, typecheck and build clean.

## What this does not fix

Running many concurrent MCP clients that share one credential store will still collide, because a client holding a token rotated hours ago is outside any sane grace window — that's client-side. This fixes the dropped-response retry, which is almost certainly what hit the 54 orgs above (most of whom are ordinary ChatGPT connector users, not people running 8 sessions).

Worth a follow-up: surface these events in the admin dashboard so a spike is visible without a SQL query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52