### PR TITLE
perf(fts): contentless FTS5 — stop storing every chunk's text twice

### DIFF
--- a/apps/mcp-server/src/__tests__/fts-keys.test.ts
+++ b/apps/mcp-server/src/__tests__/fts-keys.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { ftsRowid, orgFtsToken, ftsMatch } from "@getengram/db";
+
+/**
+ * A contentless FTS5 index returns rowids and nothing else, so these three
+ * functions are the entire bridge between a MATCH result and the chunk it
+ * came from. If any of them is unstable, keyword search silently returns the
+ * wrong rows or none at all.
+ */
+describe("ftsRowid", () => {
+  it("is deterministic — re-indexing a window must overwrite, not duplicate", () => {
+    const id = "chk_conv_abc_10_20_0";
+    expect(ftsRowid(id)).toBe(ftsRowid(id));
+  });
+
+  it("stays inside JavaScript's exact integer range", () => {
+    // A rowid past 2^53 loses precision in JS and would address a different
+    // row than the one written.
+    for (const id of ["a", "chk_x", "chk_" + "z".repeat(200), "🙂"]) {
+      const r = ftsRowid(id);
+      expect(Number.isSafeInteger(r)).toBe(true);
+      expect(r).toBeGreaterThan(0);
+    }
+  });
+
+  it("separates ids that differ only slightly", () => {
+    expect(ftsRowid("chk_conv_a_1_2_0")).not.toBe(ftsRowid("chk_conv_a_1_2_1"));
+    expect(ftsRowid("chk_conv_a_1_2_0")).not.toBe(ftsRowid("chk_conv_b_1_2_0"));
+  });
+
+  it("has no collisions across a realistic id space", () => {
+    // Shape mirrors chunkId(): conversation + sequence window + index.
+    const seen = new Set<number>();
+    for (let conv = 0; conv < 200; conv++) {
+      for (let seq = 0; seq < 50; seq++) {
+        seen.add(ftsRowid(`chk_conv_${conv}_${seq * 6}_${seq * 6 + 5}_0`));
+      }
+    }
+    expect(seen.size).toBe(200 * 50);
+  });
+});
+
+describe("orgFtsToken", () => {
+  it("collapses an org id to a single FTS token", () => {
+    // unicode61 splits on non-alphanumerics, so `org_Abc` would index as
+    // `org` + `abc` and EVERY org would share the `org` token.
+    expect(orgFtsToken("org_Osnqdz3Hhf7RZZNk2dnBW")).toBe("orgOsnqdz3Hhf7RZZNk2dnBW");
+    expect(orgFtsToken("org_a-b_c")).toMatch(/^[A-Za-z0-9]+$/);
+  });
+
+  it("is stable for the same id", () => {
+    expect(orgFtsToken("org_x-y")).toBe(orgFtsToken("org_x-y"));
+  });
+});
+
+describe("ftsMatch", () => {
+  it("scopes the query to one org inside the index", () => {
+    expect(ftsMatch("deploy", "org_abc")).toBe("org:orgabc AND (deploy)");
+  });
+
+  it("preserves FTS5 operators the user may have typed", () => {
+    const m = ftsMatch('"exact phrase" OR pref*', "org_abc");
+    expect(m).toContain('"exact phrase" OR pref*');
+    expect(m.startsWith("org:orgabc AND (")).toBe(true);
+  });
+
+  it("documents that the token is not the tenant boundary", () => {
+    // These two distinct org ids collapse to the same token. That is
+    // ACCEPTABLE only because every caller also filters on
+    // conversation_chunks.organization_id in the join — this test exists to
+    // make that dependency explicit rather than incidental.
+    expect(orgFtsToken("org_ab-cd")).toBe(orgFtsToken("org_abcd"));
+  });
+});

--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -4,6 +4,7 @@ import { compressContent, ENCODING_GZIP } from "../utils/compress.js";
 import type { Env } from "../types.js";
 import { sendDailyReport } from "../services/daily-report.js";
 import { syncOrganizationFromStripe } from "../services/stripe-sync.js";
+import { ftsRowid, orgFtsToken } from "@getengram/db";
 
 type AdminEnv = { Bindings: Env };
 
@@ -1059,6 +1060,62 @@ admin.get("/search-coverage-v2", async (c) => {
 // \'r2:<orig>\'). Verify-before-swap => content is never lost. Resumable via
 // the rowid cursor; idempotent (only touches non-r2 rows). Each shrinking
 // UPDATE frees D1 pages, so running this also un-wedges a full database.
+// ---------------------------------------------------------------------------
+// POST /admin/backfill-fts?batch=500&after=<rowid> — populate the contentless
+// chunks_fts_v2 index (migration 0035) from conversation_chunks, and stamp
+// each chunk's fts_rowid so search can join back to it.
+//
+// Cursor-paged over conversation_chunks.rowid, idempotent (re-running a batch
+// overwrites the same FTS rowids), and safe to run while the old chunks_fts
+// still exists — nothing reads v2 until the deploy that switches the queries.
+// ---------------------------------------------------------------------------
+admin.post("/backfill-fts", async (c) => {
+  const batch = Math.min(1000, Math.max(1, parseInt(c.req.query("batch") ?? "500", 10)));
+  const after = parseInt(c.req.query("after") ?? "0", 10);
+
+  const rows = await c.env.DB.prepare(
+    `SELECT rowid AS rid, id, organization_id, chunk_text
+       FROM conversation_chunks
+      WHERE rowid > ? AND fts_rowid IS NULL
+      ORDER BY rowid LIMIT ?`,
+  )
+    .bind(after, batch)
+    .all<{ rid: number; id: string; organization_id: string; chunk_text: string }>();
+
+  const list = rows.results ?? [];
+  if (list.length === 0) {
+    return c.json({ done: true, indexed: 0, next_after: after });
+  }
+
+  const stmts = list.flatMap((r) => {
+    const rid = ftsRowid(r.id);
+    return [
+      // Clear any prior entry first: a re-run must overwrite, not duplicate
+      // the terms for this chunk.
+      c.env.DB.prepare("DELETE FROM chunks_fts_v2 WHERE rowid = ?").bind(rid),
+      c.env.DB.prepare(
+        "INSERT INTO chunks_fts_v2(rowid, chunk_text, org) VALUES (?, ?, ?)",
+      ).bind(rid, r.chunk_text, orgFtsToken(r.organization_id)),
+      // Stamped LAST in the batch so a partial failure leaves fts_rowid NULL
+      // and the row is simply picked up again on the next run.
+      c.env.DB.prepare("UPDATE conversation_chunks SET fts_rowid = ? WHERE id = ?").bind(
+        rid,
+        r.id,
+      ),
+    ];
+  });
+
+  await c.env.DB.batch(stmts);
+
+  const nextAfter = list[list.length - 1].rid;
+  return c.json({
+    done: false,
+    indexed: list.length,
+    next_after: nextAfter,
+    hint: `POST /admin/backfill-fts?batch=${batch}&after=${nextAfter}`,
+  });
+});
+
 admin.post("/backfill-content-to-r2", async (c) => {
   const batch = Math.min(800, Math.max(1, parseInt(c.req.query("batch") ?? "400", 10)));
   const after = parseInt(c.req.query("after") ?? "0", 10);

--- a/packages/db/migrations/0035_contentless_fts.sql
+++ b/packages/db/migrations/0035_contentless_fts.sql
@@ -1,0 +1,46 @@
+-- Contentless FTS5: stop storing every chunk's text twice.
+--
+-- The original chunks_fts is a standalone FTS5 table, so SQLite keeps a
+-- complete second copy of every chunk in chunks_fts_content — on top of
+-- conversation_chunks.chunk_text. Measured on production 2026-09-01:
+--
+--   chunks_fts_content   848 MB   duplicate text
+--   chunks_fts_data      304 MB   the actual index
+--
+-- Contentless (content='') keeps only the index. Verified against D1's SQLite
+-- build before writing this: content='' is accepted, explicit rowids round
+-- trip through MATCH, column filters still scope by org, and
+-- contentless_delete=1 allows deleting by rowid ALONE. That last one matters —
+-- without it, removing a row from a contentless index requires re-supplying
+-- the original text, which becomes impossible once #384 moves chunk text to R2.
+--
+-- Two consequences drive the shape below:
+--   1. A contentless table cannot return column values, so matches come back
+--      as rowids and have to be resolved to chunk ids by joining. That needs a
+--      stable integer per chunk -> conversation_chunks.fts_rowid.
+--   2. organization_id can no longer ride along as an UNINDEXED column, so org
+--      scoping moves into the MATCH expression as a column filter. That keeps
+--      the filtering inside the index rather than scanning every org's matches
+--      and discarding them afterwards.
+
+-- Stable integer key linking a chunk to its FTS row. Derived deterministically
+-- from the chunk id (see ftsRowid() in packages/db), so re-indexing the same
+-- window is an idempotent overwrite rather than a duplicate.
+ALTER TABLE conversation_chunks ADD COLUMN fts_rowid INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_chunks_fts_rowid
+  ON conversation_chunks(fts_rowid);
+
+-- The `org` column is indexed (not UNINDEXED) precisely so it can be used as a
+-- MATCH column filter: 'org:<token> AND chunk_text:<query>'.
+CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts_v2 USING fts5(
+  chunk_text,
+  org,
+  content='',
+  contentless_delete=1
+);
+
+-- Deliberately NOT backfilled here. Populating 571k chunks inside a migration
+-- would run far past D1's statement limits on a database already at 8.3 GB.
+-- The backfill runs afterwards via POST /admin/backfill-fts in batches, and
+-- the old chunks_fts is dropped in a follow-up migration once verified.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -10,3 +10,4 @@ export * from "./queries/audit-log.js";
 export * from "./queries/vault.js";
 export * from "./queries/named-secrets.js";
 export * from "./queries/oauth.js";
+export * from "./queries/fts-keys.js";

--- a/packages/db/src/queries/chunks.ts
+++ b/packages/db/src/queries/chunks.ts
@@ -1,3 +1,5 @@
+import { ftsRowid, orgFtsToken, ftsMatch } from "./fts-keys.js";
+
 export function insertChunks(
   db: D1Database,
   chunks: Array<{
@@ -20,12 +22,17 @@ export function insertChunks(
   // its fresh FTS row. All in one D1 batch/transaction.
   const ids = chunks.map((c) => c.id);
   const ph = ids.map(() => "?").join(",");
+  const rowids = chunks.map((c) => ftsRowid(c.id));
+  const rph = rowids.map(() => "?").join(",");
   const stmts = [
-    db.prepare(`DELETE FROM chunks_fts WHERE chunk_id IN (${ph})`).bind(...ids),
+    // Contentless FTS deletes by rowid alone (contentless_delete=1), so the
+    // old text is not needed to clear a stale entry — which is what keeps
+    // this working once chunk text moves to R2.
+    db.prepare(`DELETE FROM chunks_fts_v2 WHERE rowid IN (${rph})`).bind(...rowids),
     ...chunks.flatMap((c) => [
       db
         .prepare(
-          "INSERT OR REPLACE INTO conversation_chunks (id, conversation_id, organization_id, chunk_text, chunk_summary, start_sequence, end_sequence, vectorize_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+          "INSERT OR REPLACE INTO conversation_chunks (id, conversation_id, organization_id, chunk_text, chunk_summary, start_sequence, end_sequence, vectorize_id, fts_rowid) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
         )
         .bind(
           c.id,
@@ -35,14 +42,16 @@ export function insertChunks(
           c.chunkSummary,
           c.startSequence,
           c.endSequence,
-          c.vectorizeId
+          c.vectorizeId,
+          ftsRowid(c.id)
         ),
-      // Dual-write into FTS5 index for keyword search
+      // Dual-write into the FTS5 index for keyword search. The rowid is
+      // derived from the chunk id so this is an idempotent overwrite.
       db
         .prepare(
-          "INSERT INTO chunks_fts(chunk_text, chunk_id, organization_id) VALUES (?, ?, ?)"
+          "INSERT INTO chunks_fts_v2(rowid, chunk_text, org) VALUES (?, ?, ?)"
         )
-        .bind(c.chunkText, c.id, c.organizationId),
+        .bind(ftsRowid(c.id), c.chunkText, orgFtsToken(c.organizationId)),
     ]),
   ];
   return db.batch(stmts);
@@ -85,21 +94,27 @@ export function searchChunksFts(
   if (conversationId) {
     return db
       .prepare(
-        `SELECT chunk_id, rank FROM chunks_fts
-         WHERE chunks_fts MATCH ? AND organization_id = ?
-           AND chunk_id IN (SELECT id FROM conversation_chunks WHERE conversation_id = ?)
-         ORDER BY rank LIMIT ?`
+        `SELECT c.id AS chunk_id, f.rank AS rank
+           FROM chunks_fts_v2 f
+           JOIN conversation_chunks c ON c.fts_rowid = f.rowid
+          WHERE chunks_fts_v2 MATCH ?
+            AND c.organization_id = ?
+            AND c.conversation_id = ?
+          ORDER BY f.rank LIMIT ?`
       )
-      .bind(query, organizationId, conversationId, limit)
+      .bind(ftsMatch(query, organizationId), organizationId, conversationId, limit)
       .all<{ chunk_id: string; rank: number }>();
   }
   return db
     .prepare(
-      `SELECT chunk_id, rank FROM chunks_fts
-       WHERE chunks_fts MATCH ? AND organization_id = ?
-       ORDER BY rank LIMIT ?`
+      `SELECT c.id AS chunk_id, f.rank AS rank
+         FROM chunks_fts_v2 f
+         JOIN conversation_chunks c ON c.fts_rowid = f.rowid
+        WHERE chunks_fts_v2 MATCH ?
+          AND c.organization_id = ?
+        ORDER BY f.rank LIMIT ?`
     )
-    .bind(query, organizationId, limit)
+    .bind(ftsMatch(query, organizationId), organizationId, limit)
     .all<{ chunk_id: string; rank: number }>();
 }
 
@@ -110,7 +125,7 @@ export function deleteChunksFts(
 ) {
   return db
     .prepare(
-      "DELETE FROM chunks_fts WHERE chunk_id IN (SELECT id FROM conversation_chunks WHERE conversation_id = ? AND organization_id = ?)"
+      "DELETE FROM chunks_fts_v2 WHERE rowid IN (SELECT fts_rowid FROM conversation_chunks WHERE conversation_id = ? AND organization_id = ? AND fts_rowid IS NOT NULL)"
     )
     .bind(conversationId, organizationId);
 }
@@ -153,8 +168,10 @@ export function deleteChunksByIds(
   const ph = ids.map(() => "?").join(",");
   return db.batch([
     db
-      .prepare(`DELETE FROM chunks_fts WHERE chunk_id IN (${ph})`)
-      .bind(...ids),
+      .prepare(
+        `DELETE FROM chunks_fts_v2 WHERE rowid IN (${ids.map(() => "?").join(",")})`
+      )
+      .bind(...ids.map(ftsRowid)),
     db
       .prepare(
         `DELETE FROM conversation_chunks WHERE id IN (${ph}) AND organization_id = ?`

--- a/packages/db/src/queries/fts-keys.ts
+++ b/packages/db/src/queries/fts-keys.ts
@@ -1,0 +1,76 @@
+/**
+ * Key derivation for the contentless FTS5 index (migration 0035).
+ *
+ * A contentless FTS table cannot return column values — a MATCH gives back
+ * rowids and nothing else. So each chunk needs a stable integer rowid that we
+ * can store alongside it and join on afterwards.
+ */
+
+/**
+ * Deterministic 53-bit rowid for a chunk.
+ *
+ * Derived from the chunk id rather than allocated, so re-indexing the same
+ * window (chunk ids are already deterministic — see chunkId()) produces the
+ * same rowid and overwrites in place instead of duplicating.
+ *
+ * FNV-1a, folded to 53 bits so the value stays inside JavaScript's exact
+ * integer range. SQLite rowids are 64-bit, but a value that loses precision in
+ * JS would silently address the wrong row.
+ *
+ * Collision risk at 571k chunks is about 1.8e-5 (birthday bound over 2^53).
+ * A collision merges two chunks' terms in the keyword index — it cannot lose
+ * a message, since the text of record lives in conversation_chunks and R2, and
+ * semantic search is unaffected.
+ */
+export function ftsRowid(chunkId: string): number {
+  // 64-bit FNV-1a using two 32-bit halves; JS bitwise ops are 32-bit only.
+  let h1 = 0x811c9dc5;
+  let h2 = 0x01000193;
+  for (let i = 0; i < chunkId.length; i++) {
+    const c = chunkId.charCodeAt(i);
+    h1 = Math.imul(h1 ^ c, 0x01000193) >>> 0;
+    h2 = Math.imul(h2 ^ (c + i), 0x85ebca6b) >>> 0;
+  }
+  // Fold to 53 bits: 21 high bits from h1, 32 low bits from h2.
+  const folded = (h1 >>> 11) * 0x100000000 + h2;
+  // rowid 0 is legal but easy to confuse with "unset"; shift it off zero.
+  return folded === 0 ? 1 : folded;
+}
+
+/**
+ * Org identifier reduced to a single FTS token.
+ *
+ * FTS5's default unicode61 tokenizer splits on non-alphanumerics, so an id
+ * like `org_Osnqdz3Hhf7RZZNk2dnBW` would index as two tokens — `org` plus the
+ * rest — and every organization would share the `org` token, making the column
+ * filter useless. Stripping the separators yields one token per org.
+ *
+ * This is a search *hint*, not an authorization boundary: two ids could in
+ * principle collapse to the same token (`org_ab-cd` and `org_abcd`). Callers
+ * MUST still filter on conversation_chunks.organization_id in the join. The
+ * token narrows the index scan; the join is what guarantees correctness.
+ */
+export function orgFtsToken(organizationId: string): string {
+  return organizationId.replace(/[^A-Za-z0-9]/g, "");
+}
+
+/**
+ * Build the MATCH expression for a scoped keyword search.
+ *
+ * Produces `org:<token> AND (<user query>)`, so FTS5 prunes to one
+ * organization inside the index instead of returning every org's matches for
+ * a common word and discarding them afterwards.
+ *
+ * The user's query is embedded as-is, preserving today's behaviour where FTS5
+ * operators (AND/OR/NOT, prefix*, "phrases") work. A malformed query raises an
+ * FTS5 syntax error exactly as it does today, and search.ts already catches
+ * that and degrades to semantic-only.
+ *
+ * SAFETY: this is not the tenant boundary. A crafted query could in principle
+ * break the grouping, and two org ids could collapse to the same token — which
+ * is why every caller also filters on conversation_chunks.organization_id in
+ * the join. The token is an optimisation; the join is the guarantee.
+ */
+export function ftsMatch(query: string, organizationId: string): string {
+  return `org:${orgFtsToken(organizationId)} AND (${query})`;
+}


### PR DESCRIPTION
Closes #385. This is the single biggest step toward the ~93k-user ceiling discussed in #383/#394.

## The waste

`chunks_fts` is a **standalone** FTS5 table, so SQLite keeps a complete second copy of every chunk in `chunks_fts_content` — on top of `conversation_chunks.chunk_text`:

```
chunks_fts_content   848 MB   ← duplicate text
chunks_fts_data      304 MB   ← the actual index
```

848 MB of the same words stored twice, in a database with a hard 10 GB cap. Contentless (`content=''`) keeps only the index — taking per-message D1 footprint from ~800 to ~558 bytes, and capacity from ~3.5M messages to ~18M.

## Verified against D1 before writing any code

Ran on a scratch database, because guessing here would have been expensive:

| check | result |
|---|---|
| `content=''` | accepted |
| explicit rowids | round-trip through `MATCH` with rank |
| column filters | `'org:X AND chunk_text:Y'` correctly excluded an **identical string** in another org |
| `contentless_delete=1` | accepted; `DELETE ... WHERE rowid = ?` removes one row, siblings survive |

**That last row was the real risk.** Without `contentless_delete`, removing a row from a contentless index requires re-supplying the original text — which becomes impossible once #384 moves chunk text to R2. The two changes would have deadlocked. They don't.

## Two consequences shaped the design

**Contentless tables can't return column values** — `MATCH` yields rowids and nothing else. So each chunk needs a stable integer: `conversation_chunks.fts_rowid`, derived deterministically from the chunk id (FNV-1a folded to 53 bits so it stays exact in JS — a rowid past 2^53 would silently address a different row). Deterministic because chunk ids already are, so re-indexing a window overwrites in place instead of duplicating.

**`organization_id` can't ride along as an UNINDEXED column**, so org scoping moves into the MATCH expression as a column filter. This keeps pruning *inside* the index rather than returning every org's matches for a common word and filtering afterwards.

## The org token is not the tenant boundary

Worth being explicit, since it looks like a security control and isn't one. Two ids can collapse to the same token (`org_ab-cd`, `org_abcd`), and a crafted query could in principle break the grouping.

**Every read also filters `conversation_chunks.organization_id` in the join.** The token narrows the scan; the join guarantees correctness. There's a test asserting the collision case specifically so that dependency stays visible instead of becoming folklore.

## Backfill

A cursor-paged admin endpoint, not migration SQL — 571k rows can't be indexed inside a migration on an 8.3 GB database. It stamps `fts_rowid` **last** per row, so a partial failure leaves it `NULL` and the row is simply retried.

## Deploy order matters

1. **migrate** — creates `chunks_fts_v2` + `fts_rowid`; nothing reads them yet
2. **deploy** — reads and writes switch to v2
3. **backfill** — `POST /admin/backfill-fts` until `done:true`
4. **verify**, then drop `chunks_fts` in a follow-up migration

Between 2 and 3, keyword search only covers newly-written chunks. Semantic search via Vectorize is unaffected, and `search.ts` already fuses the two and falls back cleanly — so this is partial recall on the secondary path, not an outage. Backfilling before the deploy would require dual-writing both indexes for no real benefit at this scale.

## Tests

9 new covering the key derivation: determinism, staying inside `Number.isSafeInteger`, no collisions across a realistic 10k-id space, operator preservation, and the org-token collision case.

216 mcp-server tests pass (was 207). Typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52