### PR TITLE
fix(fts): weight the org column out of BM25 ranking

### DIFF
--- a/packages/db/src/queries/chunks.ts
+++ b/packages/db/src/queries/chunks.ts
@@ -83,6 +83,21 @@ export function getChunksByIds(
     .all();
 }
 
+/**
+ * Keyword search over the contentless FTS5 index.
+ *
+ * Ranking uses bm25(chunks_fts_v2, 1.0, 0.0) rather than the bare `rank`
+ * shorthand. `rank` scores ALL indexed columns, and `org` is a real indexed
+ * column here (it has to be, so the MATCH can scope by it). Since every
+ * document in an org carries the same org token, its BM25 contribution varies
+ * only with document length — which quietly reweights results toward short
+ * chunks regardless of their relevance to the user's actual query.
+ *
+ * Measured against the old standalone index before this was added: identical
+ * result SETS (6,928 = 6,928, zero on either side alone for a sample term) but
+ * near-zero overlap in the top 20. Zeroing the org column's weight restored
+ * 20/20, 19/20, 19/20 agreement on the same queries.
+ */
 export function searchChunksFts(
   db: D1Database,
   query: string,
@@ -94,25 +109,25 @@ export function searchChunksFts(
   if (conversationId) {
     return db
       .prepare(
-        `SELECT c.id AS chunk_id, f.rank AS rank
+        `SELECT c.id AS chunk_id, bm25(chunks_fts_v2, 1.0, 0.0) AS rank
            FROM chunks_fts_v2 f
            JOIN conversation_chunks c ON c.fts_rowid = f.rowid
           WHERE chunks_fts_v2 MATCH ?
             AND c.organization_id = ?
             AND c.conversation_id = ?
-          ORDER BY f.rank LIMIT ?`
+          ORDER BY bm25(chunks_fts_v2, 1.0, 0.0) LIMIT ?`
       )
       .bind(ftsMatch(query, organizationId), organizationId, conversationId, limit)
       .all<{ chunk_id: string; rank: number }>();
   }
   return db
     .prepare(
-      `SELECT c.id AS chunk_id, f.rank AS rank
+      `SELECT c.id AS chunk_id, bm25(chunks_fts_v2, 1.0, 0.0) AS rank
          FROM chunks_fts_v2 f
          JOIN conversation_chunks c ON c.fts_rowid = f.rowid
         WHERE chunks_fts_v2 MATCH ?
           AND c.organization_id = ?
-        ORDER BY f.rank LIMIT ?`
+        ORDER BY bm25(chunks_fts_v2, 1.0, 0.0) LIMIT ?`
     )
     .bind(ftsMatch(query, organizationId), organizationId, limit)
     .all<{ chunk_id: string; rank: number }>();


### PR DESCRIPTION
Follow-up to #398, caught by comparing the new index against the old one before dropping it.

## Symptom

Same query, same org, both indexes returning 20 results — **near-zero overlap** in the top 20:

| term | old ∩ new (top 20) |
|---|---|
| deploy | 0 |
| database | 9 |
| engram | 3 |
| error | 0 |
| migration | 0 |

## Not a recall bug

Comparing the FULL match sets rather than the top 20:

```
migration, org_T9cQ…
  old_total  6928
  new_total  6928
  in_both    6928
  only_old      0
  only_new      0
```

Identical. Every chunk the old index finds, the new one finds. The backfill is correct.

## Cause

`ORDER BY rank` scores **all** indexed columns, and `org` is necessarily a real indexed column in the new table — it has to be, or the MATCH could not scope by it. Every document in an organization carries the same org token, so its BM25 contribution varies only with document length. That quietly reweights results toward short chunks regardless of their relevance to what the user actually searched for.

## Fix

`bm25(chunks_fts_v2, 1.0, 0.0)` — full weight on `chunk_text`, zero on `org`. Restores agreement with the old index on the same queries:

| term | overlap after fix |
|---|---|
| migration | 20/20 |
| deploy | 19/20 |
| error | 19/20 |

The remaining one-off differences are tie-breaking between equal scores.

`bm25()` returns negative values (lower = better) exactly as `rank` does, so the ordering direction and the caller's rank-position map in `search.ts` are unaffected.

The reasoning is written into a doc comment above `searchChunksFts`, since `ORDER BY rank` is the obvious thing to reach for and would silently reintroduce this.

216 tests pass; typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52