### PR TITLE
fix(fts): repoint remaining chunks_fts references before dropping the old index

### DIFF
--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -1306,11 +1306,15 @@ admin.post("/reclaim-space", async (c) => {
     result.email_log_error = e instanceof Error ? e.message : String(e);
   }
   if (scope === "fts") {
-    // The FTS5 keyword index duplicates chunk_text. Emptying it frees that
-    // duplicate; semantic (vector) search still works, and the index is
-    // rebuildable from conversation_chunks. No user data lost.
+    // Emergency space lever. Since migration 0035 the index is contentless,
+    // so this no longer frees a duplicate copy of chunk_text (there isn't
+    // one) — it frees the ~660MB index itself. Keyword search degrades to
+    // semantic-only until POST /admin/backfill-fts rebuilds it, and
+    // fts_rowid stamps must be cleared too or the backfill will skip every
+    // row it already marked. No user data is lost either way.
     try {
-      const r = await c.env.DB.prepare("DELETE FROM chunks_fts").run();
+      await c.env.DB.prepare("UPDATE conversation_chunks SET fts_rowid = NULL").run();
+      const r = await c.env.DB.prepare("DELETE FROM chunks_fts_v2").run();
       result.chunks_fts_deleted = r.meta?.changes ?? 0;
     } catch (e) {
       result.chunks_fts_error = e instanceof Error ? e.message : String(e);

--- a/packages/db/src/queries/conversations.ts
+++ b/packages/db/src/queries/conversations.ts
@@ -148,8 +148,10 @@ export function getOrgConversationCount(db: D1Database, organizationId: string) 
 
 export function deleteConversationById(db: D1Database, id: string, organizationId: string) {
   return db.batch([
-    // FTS delete must come before chunks delete (subquery references conversation_chunks)
-    db.prepare("DELETE FROM chunks_fts WHERE chunk_id IN (SELECT id FROM conversation_chunks WHERE conversation_id = ? AND organization_id = ?)").bind(id, organizationId),
+    // FTS delete must come before chunks delete (subquery references conversation_chunks).
+    // Targets chunks_fts_v2 by rowid — the contentless index (migration 0035)
+    // cannot be addressed by chunk_id, and the old chunks_fts is being dropped.
+    db.prepare("DELETE FROM chunks_fts_v2 WHERE rowid IN (SELECT fts_rowid FROM conversation_chunks WHERE conversation_id = ? AND organization_id = ? AND fts_rowid IS NOT NULL)").bind(id, organizationId),
     db.prepare("DELETE FROM conversation_chunks WHERE conversation_id = ? AND organization_id = ?").bind(id, organizationId),
     db.prepare("DELETE FROM messages WHERE conversation_id = ? AND organization_id = ?").bind(id, organizationId),
     db.prepare("DELETE FROM conversation_tags WHERE conversation_id = ? AND organization_id = ?").bind(id, organizationId),

--- a/packages/db/src/queries/organizations.ts
+++ b/packages/db/src/queries/organizations.ts
@@ -129,7 +129,7 @@ export function deleteOrganizationById(db: D1Database, id: string) {
   return db.batch([
     // FTS delete must come before chunks (subquery references conversation_chunks)
     db.prepare(
-      "DELETE FROM chunks_fts WHERE chunk_id IN (SELECT id FROM conversation_chunks WHERE organization_id = ?)",
+      "DELETE FROM chunks_fts_v2 WHERE rowid IN (SELECT fts_rowid FROM conversation_chunks WHERE organization_id = ? AND fts_rowid IS NOT NULL)",
     ).bind(id),
     // CASCADE handles the rest, but explicit deletes are safer for ordering
     db.prepare("DELETE FROM conversation_chunks WHERE organization_id = ?").bind(id),


### PR DESCRIPTION
Found while preparing the migration to drop the old `chunks_fts`. **Dropping it first would have broken deletion outright.**

## Three references survived #398

| location | what it does |
|---|---|
| `deleteConversationById` | `DELETE FROM chunks_fts ...` |
| `deleteOrganizationById` | `DELETE FROM chunks_fts ...` |
| `/admin/reclaim?scope=fts` | `DELETE FROM chunks_fts` |

The first two run inside `db.batch()`, so a missing table fails the **entire batch** — every conversation delete and every 30-day account purge would have started erroring, not degrading.

My earlier "zero references to the old table" check was scoped to `chunks.ts` and missed these two files entirely.

## They were already wrong

Since #398 deployed, inserts have gone to `chunks_fts_v2` while deletes cleared `chunks_fts`. So deleting a conversation left its chunks searchable in the live index.

Impact turned out to be tiny — 576,926 rows in the index against 576,924 live chunks, so **2 orphans**. Few deletions happened in the window. The two will be cleaned up by any re-index of their conversations, and are not worth a targeted sweep.

## Changes

Both delete paths now target `chunks_fts_v2` by `rowid`, since a contentless index cannot be addressed by `chunk_id`:

```sql
DELETE FROM chunks_fts_v2
 WHERE rowid IN (SELECT fts_rowid FROM conversation_chunks
                  WHERE conversation_id = ? AND organization_id = ?
                    AND fts_rowid IS NOT NULL)
```

The admin reclaim endpoint is repointed too, and its comment corrected — it claimed to free "the duplicate copy of chunk_text", which stopped being true at 0035. It now also nulls `fts_rowid` before emptying the index, otherwise the backfill would skip every row it had already stamped and the index could never be rebuilt.

## Sequencing

This ships **before** the drop migration, deliberately. CI applies migrations and then deploys, so a combined PR would leave a window where the running worker still referenced a table the migration had just removed.

216 mcp-server tests pass; typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52