### PR TITLE
migration: drop the old chunks_fts index

### DIFF
--- a/packages/db/migrations/0036_drop_old_fts.sql
+++ b/packages/db/migrations/0036_drop_old_fts.sql
@@ -1,0 +1,33 @@
+-- Drop the original standalone FTS5 index, superseded by the contentless
+-- chunks_fts_v2 created in 0035.
+--
+-- This is the step that actually reclaims the space. Migration 0035 added the
+-- new index without removing the old one, so BOTH have been resident:
+--
+--   chunks_fts_content   836 MB   duplicate copy of every chunk's text
+--   chunks_fts_data      306 MB   the old index
+--   chunks_fts_v2_data   659 MB   the new index
+--
+-- which pushed the database to 9.02 GB against a 10 GB cap. Keeping the old
+-- index that long was deliberate: it was the rollback path while the new one
+-- was verified, and it earned its keep by exposing a ranking regression that
+-- comparison against it caught (see #400).
+--
+-- Verification completed before this migration was written:
+--   * recall identical -- 6,928 = 6,928 matching chunks for a sample term,
+--     with zero on either side alone
+--   * ranking restored to 20/20, 19/20, 19/20 top-20 agreement after #400
+--   * live searches through the deployed worker return relevant results
+--   * every code reference to chunks_fts repointed to chunks_fts_v2 (#402),
+--     which MUST be deployed before this runs -- deleteConversationById and
+--     deleteOrganizationById used the old table inside db.batch(), so a
+--     missing table would have failed the whole batch and broken deletion
+--     rather than degrading it.
+--
+-- DROP TABLE on an FTS5 virtual table removes its shadow tables
+-- (_data, _idx, _content, _docsize, _config) together.
+--
+-- Expect this to be slow, and possibly to report a 7429 timeout while having
+-- succeeded -- exactly what 0035 did on this database. If it reports failure,
+-- check whether the table is actually gone before retrying.
+DROP TABLE IF EXISTS chunks_fts;


### PR DESCRIPTION
The step that actually reclaims the space. Closes the #385 sequence.

## Why the database is at 9.02 GB

Migration 0035 added the contentless index without removing the old one, so both have been resident:

```
chunks_fts_content   836 MB   ← duplicate copy of every chunk's text
chunks_fts_data      306 MB   ← the old index
chunks_fts_v2_data   659 MB   ← the new index
```

Against a 10 GB cap. Holding the old index that long was deliberate — it was the rollback path — and it paid for itself by exposing the ranking regression that comparing against it caught (#400). Without it, keyword search would have quietly gotten worse and nobody would ever have filed a bug.

## Verified before writing this

- **recall identical** — 6,928 = 6,928 matching chunks for a sample term, zero on either side alone
- **ranking restored** — 20/20, 19/20, 19/20 top-20 agreement after #400
- **live searches** through the deployed worker return relevant results
- **every code reference repointed** to `chunks_fts_v2` in #402

## Sequencing is load-bearing

**#402 must be deployed before this runs.** `deleteConversationById` and `deleteOrganizationById` used the old table inside `db.batch()` — a missing table fails the *entire batch*, so this would have broken conversation deletion and the 30-day account purge outright rather than degrading them. That's why the fix shipped as its own PR first rather than riding along here.

## Expect a scary-looking failure

`DROP TABLE` on an FTS5 virtual table removes its shadow tables (`_data`, `_idx`, `_content`, `_docsize`, `_config`) together — over a gigabyte on a database already at 90%.

0035 reported `7429 storage operation exceeded timeout` on this database **while having actually succeeded**. If that happens again, check whether the table is gone before retrying rather than assuming the migration failed.

## After merge

Post-drop I'll confirm the table is gone, `chunks_fts_v2` is intact, search still works, and report the actual size reclaimed — expected ~1.14 GB, taking the database from 9.02 GB to roughly 7.9 GB.

216 tests pass; typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52