### PR TITLE
feat: maintenance write freeze (prerequisite for the #383 table rebuild)

### DIFF
--- a/apps/mcp-server/src/__tests__/write-freeze.test.ts
+++ b/apps/mcp-server/src/__tests__/write-freeze.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { assertWritesEnabled } from "../services/conversation.js";
+import type { Env } from "../types.js";
+
+/**
+ * The freeze exists so the messages-table rebuild (#383) cannot race with a
+ * concurrent insert. A row written between the copy and the table swap would
+ * be silently dropped — so "writes are refused" must be reliable, and
+ * "writes are allowed" must be the default when the flag is absent.
+ */
+describe("assertWritesEnabled", () => {
+  const env = (v?: string) => ({ WRITES_FROZEN: v }) as unknown as Env;
+
+  it("allows writes when the flag is absent — the normal state", () => {
+    expect(() => assertWritesEnabled(env(undefined))).not.toThrow();
+  });
+
+  it("blocks writes when frozen", () => {
+    expect(() => assertWritesEnabled(env("1"))).toThrow(/maintenance/i);
+  });
+
+  it("only freezes on an exact '1' — no accidental truthiness", () => {
+    // A stray "0", "false" or "" must not take the service down for writes.
+    for (const v of ["0", "false", "", "true", "yes"]) {
+      expect(() => assertWritesEnabled(env(v))).not.toThrow();
+    }
+  });
+
+  it("tells the user nothing is lost, since clients surface this text", () => {
+    try {
+      assertWritesEnabled(env("1"));
+      throw new Error("should have thrown");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toMatch(/nothing is lost/i);
+      expect(msg).toMatch(/retry/i);
+    }
+  });
+});

--- a/apps/mcp-server/src/services/conversation.ts
+++ b/apps/mcp-server/src/services/conversation.ts
@@ -121,6 +121,32 @@ export interface VaultEntryInput {
   secret_type: string;
 }
 
+/**
+ * Maintenance write freeze.
+ *
+ * Set WRITES_FROZEN=1 to reject writes for the length of a maintenance
+ * window. Used for operations that must not race with concurrent inserts —
+ * notably rebuilding the messages table to reclaim freed pages (#383), where
+ * a row written mid-copy would be silently dropped by the table swap.
+ *
+ * Freezing rather than reconciling afterwards is a deliberate choice: it is
+ * the only approach that is zero-loss *by construction* rather than by
+ * getting a delta query right. The rebuild takes minutes, and the CLI daemon
+ * already queues locally and retries on failure, so for the largest writers
+ * this degrades to a pause rather than an error.
+ *
+ * Reads, search and recall stay fully available throughout.
+ */
+export function assertWritesEnabled(env: Env): void {
+  if (env.WRITES_FROZEN === "1") {
+    throw new Error(
+      "Engram is paused for a few minutes of scheduled maintenance. " +
+        "Nothing already saved is affected, and nothing is lost — retry shortly, " +
+        "or let your client retry automatically.",
+    );
+  }
+}
+
 export async function appendMessages(
   env: Env,
   organizationId: string,
@@ -128,6 +154,8 @@ export async function appendMessages(
   messageInputs: MessageInput[],
   vaultEntries?: VaultEntryInput[]
 ): Promise<Message[]> {
+  assertWritesEnabled(env);
+
   // Verify conversation exists and belongs to org
   const conv = await getConversationById(env.DB, conversationId, organizationId);
   if (!conv) {

--- a/apps/mcp-server/src/types.ts
+++ b/apps/mcp-server/src/types.ts
@@ -12,6 +12,11 @@ export interface Env {
   STRIPE_PRICE_ID_TEAM: string;
   APP_URL: string; // e.g. "https://getengram.app"
   ADMIN_SECRET: string; // wrangler secret for /api/admin/* routes
+  /** "1" pauses all writes for a maintenance window. Set and cleared with
+   *  `wrangler secret put/delete WRITES_FROZEN` — takes effect on new
+   *  requests without a redeploy, so a window can be opened and closed in
+   *  seconds. Reads are unaffected. */
+  WRITES_FROZEN?: string;
   // Supabase JWT secret — used to verify access tokens from engram-web.
   // The dashboard sends the user's Supabase access token as a Bearer on
   // /signup; the worker verifies the HS256 signature and extracts the


### PR DESCRIPTION
Prerequisite for #383. Reclaiming the ~5 GB of dead pages means rebuilding the messages table — copy to a new table, drop the old, rename — and **a row inserted between the copy and the swap would be silently dropped.**

## Why freeze rather than reconcile

The alternative is copying live, then catching up on a delta by `created_at` before swapping. That's cleverer and it's what I originally proposed, but it is only zero-loss *if the delta query is right*, and it cannot catch UPDATEs at all (`messages` has no `updated_at`).

Freezing is zero-loss **by construction**. Nothing is written during the window, so nothing can be missed.

That trade only makes sense if the window is short — so I measured it before choosing. Rehearsed on a scratch D1 with a messages-shaped table:

```
200,000 rows copied        2s
drop + rename + 3 indexes  3s
rows intact                200,000
file size                  71.7 MB → 52.4 MB
```

Extrapolating to 3.5M rows: a few minutes, not hours. That makes a freeze entirely reasonable and removes the need for delta logic.

## Behaviour

`WRITES_FROZEN=1` makes `appendMessages` throw before doing any work. **Reads, search and recall are untouched** — the service stays useful throughout.

Toggled with `wrangler secret put/delete WRITES_FROZEN`, which takes effect on new requests without a redeploy, so the window opens and closes in seconds rather than deploy cycles.

The guard sits in `appendMessages` rather than in middleware because that is the single choke point every write path funnels through — MCP tools, REST, and the CLI alike — so there is no route to add later and forget.

The error text matters: clients surface it to users, so it says explicitly that nothing is lost and to retry. The CLI daemon already queues locally and retries on failure, so for the heaviest writers this degrades to a pause rather than an error.

## Tests

4, covering the two things that matter: writes are allowed when the flag is **absent** (the normal state — a bug here takes the product down), and only an exact `"1"` freezes, so a stray `"0"` or `"false"` cannot.

224 mcp-server tests pass; typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52