### PR TITLE
feat(report): put revenue in the daily email, drop the heavy-user list

### DIFF
--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -4,6 +4,7 @@ import { compressContent, ENCODING_GZIP } from "../utils/compress.js";
 import type { Env } from "../types.js";
 import { sendDailyReport } from "../services/daily-report.js";
 import { syncOrganizationFromStripe } from "../services/stripe-sync.js";
+import { computeMrr } from "../services/mrr.js";
 import { ftsRowid, orgFtsToken } from "@getengram/db";
 
 type AdminEnv = { Bindings: Env };
@@ -137,82 +138,9 @@ admin.get("/metrics", async (c) => {
     referralMap[row.source] = row.count;
   }
 
-  // MRR — live from Stripe (real amounts, not hardcoded tier prices). Sums
-  // active subscription items; yearly plans are normalized to monthly.
-  // "external" excludes subs whose customer maps to an internal org (the
-  // owner's own accounts). Fail-soft: metrics must render without Stripe.
-  // at_risk_* = subscriptions still 'active' in Stripe but already scheduled to
-  // cancel (cancel_at_period_end / cancel_at). They pay this period and then
-  // stop, so counting them in headline MRR overstates recurring revenue —
-  // external_cents is the honest "committed" number to lead with.
-  const mrr = {
-    total_cents: 0,
-    external_cents: 0,
-    subscriptions: 0,
-    external_subscriptions: 0,
-    at_risk_cents: 0,
-    at_risk_subscriptions: 0,
-  };
-  try {
-    if (c.env.STRIPE_SECRET_KEY) {
-      const subsRes = await fetch(
-        "https://api.stripe.com/v1/subscriptions?status=active&limit=100",
-        { headers: { Authorization: `Bearer ${c.env.STRIPE_SECRET_KEY}` } },
-      );
-      if (subsRes.ok) {
-        const subs = (await subsRes.json()) as {
-          data: Array<{
-            customer: string;
-            cancel_at_period_end?: boolean;
-            cancel_at?: number | null;
-            items: {
-              data: Array<{
-                quantity?: number;
-                price?: { unit_amount?: number | null; recurring?: { interval?: string; interval_count?: number } };
-              }>;
-            };
-          }>;
-        };
-        const internalCustomers = new Set(
-          (
-            await c.env.DB.prepare(
-              // Owner's own accounts are tagged referral_source='internal'
-              // (see POST /admin/comp-internal). No personal emails in code.
-              "SELECT stripe_customer_id FROM organizations WHERE stripe_customer_id IS NOT NULL AND referral_source = 'internal'",
-            ).all<{ stripe_customer_id: string }>()
-          ).results?.map((r) => r.stripe_customer_id) ?? [],
-        );
-        for (const s of subs.data) {
-          let cents = 0;
-          for (const item of s.items?.data ?? []) {
-            const unit = item.price?.unit_amount ?? 0;
-            const qty = item.quantity ?? 1;
-            const interval = item.price?.recurring?.interval ?? "month";
-            const count = item.price?.recurring?.interval_count ?? 1;
-            const monthly =
-              interval === "year" ? (unit * qty) / (12 * count) : (unit * qty) / count;
-            cents += monthly;
-          }
-          mrr.total_cents += Math.round(cents);
-          mrr.subscriptions += 1;
-          if (!internalCustomers.has(s.customer)) {
-            mrr.external_cents += Math.round(cents);
-            mrr.external_subscriptions += 1;
-            // Both of Stripe's scheduled-cancel mechanisms count.
-            const cancelling =
-              Boolean(s.cancel_at_period_end) ||
-              (typeof s.cancel_at === "number" && s.cancel_at > 0);
-            if (cancelling) {
-              mrr.at_risk_cents += Math.round(cents);
-              mrr.at_risk_subscriptions += 1;
-            }
-          }
-        }
-      }
-    }
-  } catch {
-    // leave zeros — the dashboard treats 0 subs as "unavailable"
-  }
+  // Live MRR from Stripe. Shared with the daily report so the email and the
+  // dashboard cannot drift apart — see services/mrr.ts for the at-risk logic.
+  const mrr = await computeMrr(c.env);
 
   return c.json({
     mrr,

--- a/apps/mcp-server/src/services/daily-report.ts
+++ b/apps/mcp-server/src/services/daily-report.ts
@@ -2,6 +2,7 @@
 // emailed by engram-web (which owns SMTP). The scheduled handler POSTs the
 // JSON to `${APP_URL}/api/reports/daily` authenticated with ADMIN_SECRET.
 import type { Env } from "../types.js";
+import { computeMrr, committedCents, committedSubscriptions } from "./mrr.js";
 
 export interface DailyReport {
   generated_at: string;
@@ -32,12 +33,18 @@ export interface DailyReport {
   /** Emails of team/enterprise orgs — engram-web flags support-inbox mail
    *  from these as PRIORITY (only paid team tiers get priority support). */
   priority_support_emails: string[];
-  top_orgs_7d: Array<{
-    email: string | null;
-    name: string;
-    tier: string;
-    messages_7d: number;
-  }>;
+  /** Live revenue from Stripe, same source as the admin dashboard.
+   *  Replaces the old top_orgs_7d "biggest users by message count" list —
+   *  message volume tracked neither revenue nor engagement (the heaviest
+   *  storers were frequently the ones who had never run a search). */
+  revenue: {
+    /** External minus already-cancelling: what will still be here next month. */
+    committed_cents: number;
+    committed_subscriptions: number;
+    at_risk_cents: number;
+    at_risk_subscriptions: number;
+    external_cents: number;
+  };
 }
 
 export async function buildDailyReport(env: Env): Promise<DailyReport> {
@@ -61,7 +68,6 @@ export async function buildDailyReport(env: Env): Promise<DailyReport> {
     activeOrgs24,
     newSignups,
     referrals,
-    topOrgs,
     teamEmails,
   ] = await Promise.all([
     db
@@ -114,18 +120,15 @@ export async function buildDailyReport(env: Env): Promise<DailyReport> {
       .all<{ ref: string; n: number }>(),
     db
       .prepare(
-        `SELECT o.email, o.name, o.tier, COUNT(m.id) AS messages_7d
-         FROM messages m JOIN organizations o ON o.id = m.organization_id
-         WHERE m.created_at >= datetime('now','-7 day') AND o.deleted_at IS NULL
-         GROUP BY o.id ORDER BY messages_7d DESC LIMIT 5`,
-      )
-      .all<{ email: string | null; name: string; tier: string; messages_7d: number }>(),
-    db
-      .prepare(
         "SELECT email FROM organizations WHERE tier IN ('team','enterprise') AND email IS NOT NULL AND deleted_at IS NULL",
       )
       .all<{ email: string }>(),
   ]);
+
+  // Fetched after the DB batch rather than inside it — it is an HTTP call to
+  // Stripe, not a D1 query, and must not fail the whole report if Stripe is
+  // down (computeMrr returns zeros on failure).
+  const mrr = await computeMrr(env);
 
   const byTier: Record<string, number> = {};
   for (const r of tiers.results ?? []) byTier[r.tier] = r.n;
@@ -152,7 +155,16 @@ export async function buildDailyReport(env: Env): Promise<DailyReport> {
     referrals_all_time: refs,
     d1_latency_ms: d1LatencyMs,
     priority_support_emails: (teamEmails.results ?? []).map((r) => r.email.toLowerCase()),
-    top_orgs_7d: topOrgs.results ?? [],
+    // Revenue, from the same source the admin dashboard uses. Leads with
+    // committed (external minus already-cancelling) because that is the
+    // number that will still be here next month.
+    revenue: {
+      committed_cents: committedCents(mrr),
+      committed_subscriptions: committedSubscriptions(mrr),
+      at_risk_cents: mrr.at_risk_cents,
+      at_risk_subscriptions: mrr.at_risk_subscriptions,
+      external_cents: mrr.external_cents,
+    },
   };
 }
 

--- a/apps/mcp-server/src/services/mrr.ts
+++ b/apps/mcp-server/src/services/mrr.ts
@@ -1,0 +1,111 @@
+import type { Env } from "../types.js";
+
+export interface Mrr {
+  /** All active subscriptions, including the owner's own accounts. */
+  total_cents: number;
+  /** Excludes the owner's internal accounts — real customer revenue. */
+  external_cents: number;
+  subscriptions: number;
+  external_subscriptions: number;
+  /** Still 'active' in Stripe but already scheduled to cancel. */
+  at_risk_cents: number;
+  at_risk_subscriptions: number;
+}
+
+/** external_cents minus what is already scheduled to cancel — the honest
+ *  "money that will still be here next month" figure. */
+export function committedCents(m: Mrr): number {
+  return Math.max(0, m.external_cents - m.at_risk_cents);
+}
+
+export function committedSubscriptions(m: Mrr): number {
+  return Math.max(0, m.external_subscriptions - m.at_risk_subscriptions);
+}
+
+/**
+ * Live MRR from Stripe. Sums active subscription items and normalizes yearly
+ * plans to monthly, rather than trusting hardcoded tier prices — a comped or
+ * legacy-priced account would otherwise be counted at list price.
+ *
+ * `at_risk_*` covers subscriptions Stripe still reports as active but which
+ * are already scheduled to cancel (either `cancel_at_period_end` or a
+ * `cancel_at` timestamp — both of Stripe's mechanisms count). They pay this
+ * period and then stop, so folding them into the headline overstates
+ * recurring revenue.
+ *
+ * Fail-soft by design: callers render without Stripe, so an outage returns
+ * zeros rather than throwing. A zero subscription count means "unavailable",
+ * not "no customers".
+ */
+export async function computeMrr(env: Env): Promise<Mrr> {
+  const mrr: Mrr = {
+    total_cents: 0,
+    external_cents: 0,
+    subscriptions: 0,
+    external_subscriptions: 0,
+    at_risk_cents: 0,
+    at_risk_subscriptions: 0,
+  };
+  try {
+    if (!env.STRIPE_SECRET_KEY) return mrr;
+    const subsRes = await fetch(
+      "https://api.stripe.com/v1/subscriptions?status=active&limit=100",
+      { headers: { Authorization: `Bearer ${env.STRIPE_SECRET_KEY}` } },
+    );
+    if (!subsRes.ok) return mrr;
+    const subs = (await subsRes.json()) as {
+      data: Array<{
+        customer: string;
+        cancel_at_period_end?: boolean;
+        cancel_at?: number | null;
+        items: {
+          data: Array<{
+            quantity?: number;
+            price?: {
+              unit_amount?: number | null;
+              recurring?: { interval?: string; interval_count?: number };
+            };
+          }>;
+        };
+      }>;
+    };
+
+    // Owner's own accounts are tagged referral_source='internal' (see
+    // POST /admin/comp-internal), so the exclusion stays data-driven and no
+    // personal emails live in the code.
+    const internalCustomers = new Set(
+      (
+        await env.DB.prepare(
+          "SELECT stripe_customer_id FROM organizations WHERE stripe_customer_id IS NOT NULL AND referral_source = 'internal'",
+        ).all<{ stripe_customer_id: string }>()
+      ).results?.map((r) => r.stripe_customer_id) ?? [],
+    );
+
+    for (const s of subs.data) {
+      let cents = 0;
+      for (const item of s.items?.data ?? []) {
+        const unit = item.price?.unit_amount ?? 0;
+        const qty = item.quantity ?? 1;
+        const interval = item.price?.recurring?.interval ?? "month";
+        const count = item.price?.recurring?.interval_count ?? 1;
+        cents += interval === "year" ? (unit * qty) / (12 * count) : (unit * qty) / count;
+      }
+      mrr.total_cents += Math.round(cents);
+      mrr.subscriptions += 1;
+      if (!internalCustomers.has(s.customer)) {
+        mrr.external_cents += Math.round(cents);
+        mrr.external_subscriptions += 1;
+        const cancelling =
+          Boolean(s.cancel_at_period_end) ||
+          (typeof s.cancel_at === "number" && s.cancel_at > 0);
+        if (cancelling) {
+          mrr.at_risk_cents += Math.round(cents);
+          mrr.at_risk_subscriptions += 1;
+        }
+      }
+    }
+  } catch {
+    // leave zeros — callers treat 0 subscriptions as "unavailable"
+  }
+  return mrr;
+}


### PR DESCRIPTION
The daily report gathered *"top 5 orgs by messages in 7 days"* and **no revenue at all** — the two things backwards.

Message volume turned out to track neither revenue nor engagement. The heaviest storers were frequently accounts that had **never run a single search** (qbartel07: 10,000 messages, zero searches), while the actual paying customers sat mid-table. It was a leaderboard of the wrong thing.

## Changes

Swaps that query for live MRR, and extracts the Stripe computation out of `routes/admin.ts` into `services/mrr.ts` so the email and the dashboard read from one implementation and can't drift. `admin.ts` loses ~3,200 characters of inline logic and calls `computeMrr()` instead.

The report sends **committed** revenue (external minus already-cancelling) with the at-risk figure separate, so the headline is the money that will still be here next month rather than the money currently billing. With three of your subscriptions cancelling, that's the difference between reporting $36 and $81.

## Two deliberate choices

**`computeMrr` runs after the D1 batch, not inside it.** It's an HTTP call to Stripe, not a query — a Stripe outage must not fail the whole report. It returns zeros on failure, and callers treat a zero subscription count as "unavailable" rather than "no customers".

**The `revenue` field is optional on the receiving end.** This repo and engram-web deploy independently, so the email template must render a payload that predates this change. Covered by a test in get-engram/engram-web#210.

Pairs with get-engram/engram-web#210, which renders it.

220 tests pass; typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52