### PR TITLE
Record each organization's country and show it in admin

### DIFF
--- a/apps/mcp-server/src/middleware/auth.ts
+++ b/apps/mcp-server/src/middleware/auth.ts
@@ -1,7 +1,9 @@
 import type { Context, Next } from "hono";
+import { requestCountry } from "../utils/geo.js";
 import { hashApiKey } from "@getengram/shared";
 import {
   getApiKeyWithOrg,
+  touchOrganizationCountry,
   updateApiKeyLastUsed,
   getAccessTokenWithOrg,
 } from "@getengram/db";
@@ -89,6 +91,17 @@ export async function authMiddleware(
 
   // Update last_used_at non-blocking
   c.executionCtx.waitUntil(updateApiKeyLastUsed(c.env.DB, row.key_id));
+
+  // Backfill the org's country on first sight. Writes only where country IS
+  // NULL, so this is a no-op for everyone already stamped and costs one cheap
+  // indexed UPDATE once per account. It is how accounts created before the
+  // column existed acquire one — there is no way to derive it retroactively.
+  const country = requestCountry(c.req.raw);
+  if (country) {
+    c.executionCtx.waitUntil(
+      touchOrganizationCountry(c.env.DB, row.organization_id, country).catch(() => {}),
+    );
+  }
 
   await next();
 }

--- a/apps/mcp-server/src/oauth/router.ts
+++ b/apps/mcp-server/src/oauth/router.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { requestCountry } from "../utils/geo.js";
 import { cors } from "hono/cors";
 import {
   generateAccessToken,
@@ -298,7 +299,7 @@ oauth.post("/authorize/approve", async (c) => {
     // Derive referral source from the OAuth client name (e.g. "ChatGPT",
     // "Cursor", "Claude Desktop") — lowercase, fallback to "oauth".
     const ref = (client.client_name || "oauth").toLowerCase().replace(/\s+/g, "-");
-    await insertOrganizationWithEmail(c.env.DB, orgId, email.split("@")[0], email, ref);
+    await insertOrganizationWithEmail(c.env.DB, orgId, email.split("@")[0], email, ref, requestCountry(c.req.raw));
     // Activation parity with /signup (engram#onboarding): connector-directory
     // users never see the dashboard, so this is their only welcome. Seed the
     // getting-started note (their first search hits something real) and fire

--- a/apps/mcp-server/src/routes/admin.ts
+++ b/apps/mcp-server/src/routes/admin.ts
@@ -245,6 +245,10 @@ admin.get("/users", async (c) => {
     total_messages: "total_messages",
     conversations: "conversations",
     email: "o.email",
+    // Without this the Country header renders as sortable but silently falls
+    // back to created_at — the allowlist is what makes the sort real.
+    country: "o.country",
+    referral_source: "o.referral_source",
   };
   const sortCol = allowedSort[sort] ?? "o.created_at";
 
@@ -255,6 +259,7 @@ admin.get("/users", async (c) => {
       o.email,
       o.tier,
       o.referral_source,
+      o.country,
       o.stripe_customer_id,
       o.created_at,
       o.cancel_at_period_end,
@@ -282,6 +287,7 @@ admin.get("/users", async (c) => {
       email: string | null;
       tier: string;
       referral_source: string | null;
+      country: string | null;
       stripe_customer_id: string | null;
       created_at: string;
       cancel_at_period_end: number;

--- a/apps/mcp-server/src/routes/signup.ts
+++ b/apps/mcp-server/src/routes/signup.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { requestCountry } from "../utils/geo.js";
 import {
   generateId,
   generateApiKeyRaw,
@@ -109,7 +110,7 @@ signup.post("/", async (c) => {
   } else {
     orgId = generateId("org");
     const orgName = email.split("@")[0];
-    await insertOrganizationWithEmail(c.env.DB, orgId, orgName, email, ref);
+    await insertOrganizationWithEmail(c.env.DB, orgId, orgName, email, ref, requestCountry(c.req.raw));
     await seedWelcomeConversation(c.env.DB, orgId);
     created = true;
   }
@@ -142,7 +143,7 @@ signup.post("/anonymous", async (c) => {
   const ref = body.ref || body.referral_source || "cli";
   const orgId = generateId("org");
   const orgName = `anon-${orgId.slice(4, 12)}`;
-  await insertOrganization(c.env.DB, orgId, orgName, ref);
+  await insertOrganization(c.env.DB, orgId, orgName, ref, requestCountry(c.req.raw));
   await seedWelcomeConversation(c.env.DB, orgId);
 
   const keyId = generateId("key");

--- a/apps/mcp-server/src/utils/geo.ts
+++ b/apps/mcp-server/src/utils/geo.ts
@@ -1,0 +1,10 @@
+/**
+ * Two-letter country for the request, from Cloudflare's edge geolocation.
+ * Present on every Worker request at no cost and with no lookup. "T1" is what
+ * Cloudflare reports for Tor exits; treat it as unknown rather than a country.
+ */
+export function requestCountry(req: Request): string | null {
+  const cf = (req as Request & { cf?: { country?: string } }).cf;
+  const c = cf?.country;
+  return c && c !== "T1" ? c : null;
+}

--- a/packages/db/migrations/0037_org_country.sql
+++ b/packages/db/migrations/0037_org_country.sql
@@ -1,0 +1,15 @@
+-- Country of origin per organization, for geo analysis (which markets sign up,
+-- which convert, whether a regional price is worth testing).
+--
+-- Source is Cloudflare's request.cf.country, which is free and present on every
+-- Worker request — no IP database, no third-party lookup, no PII beyond a
+-- two-letter code we already receive.
+--
+-- Nullable on purpose: existing rows have no country and there is no way to
+-- derive one retroactively. Active accounts fill in the first time they make an
+-- authenticated request (see touchOrganizationCountry); dormant accounts stay
+-- NULL, which is honest rather than guessed.
+ALTER TABLE organizations ADD COLUMN country TEXT;
+
+-- Supports "signups by country" grouping without scanning the whole table.
+CREATE INDEX IF NOT EXISTS idx_organizations_country ON organizations(country);

--- a/packages/db/src/queries/organizations.ts
+++ b/packages/db/src/queries/organizations.ts
@@ -1,7 +1,13 @@
-export function insertOrganization(db: D1Database, id: string, name: string, referralSource?: string) {
+export function insertOrganization(
+  db: D1Database,
+  id: string,
+  name: string,
+  referralSource?: string,
+  country?: string | null,
+) {
   return db
-    .prepare("INSERT INTO organizations (id, name, referral_source) VALUES (?, ?, ?)")
-    .bind(id, name, referralSource ?? null)
+    .prepare("INSERT INTO organizations (id, name, referral_source, country) VALUES (?, ?, ?, ?)")
+    .bind(id, name, referralSource ?? null, country ?? null)
     .run();
 }
 
@@ -18,10 +24,35 @@ export function insertOrganizationWithEmail(
   name: string,
   email: string,
   referralSource?: string,
+  country?: string | null,
 ) {
   return db
-    .prepare("INSERT INTO organizations (id, name, email, referral_source) VALUES (?, ?, ?, ?)")
-    .bind(id, name, email, referralSource ?? null)
+    .prepare(
+      "INSERT INTO organizations (id, name, email, referral_source, country) VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(id, name, email, referralSource ?? null, country ?? null)
+    .run();
+}
+
+/**
+ * Fill in an organization's country the first time we see a request from it.
+ *
+ * Only ever writes when country IS NULL, which does two things: it backfills
+ * accounts created before the column existed, and it makes the value "where
+ * this account signed up from" rather than "where they last happened to be" —
+ * a stable attribute that does not flicker when someone travels or uses a VPN.
+ *
+ * The WHERE clause means the common case (already set) writes no rows, so this
+ * is cheap to call on every authenticated request.
+ */
+export function touchOrganizationCountry(
+  db: D1Database,
+  id: string,
+  country: string,
+) {
+  return db
+    .prepare("UPDATE organizations SET country = ? WHERE id = ? AND country IS NULL")
+    .bind(country, id)
     .run();
 }
 


### PR DESCRIPTION
Groundwork for the geo/pricing question: today D1 stores no geography at all, so "which countries sign up, and which convert" is unanswerable. Stripe only knows about the handful who reached checkout.

## Source

Cloudflare's `request.cf.country` — free, present on every Worker request, no IP database or third-party lookup, and no PII beyond a two-letter code we already receive. `T1` (Tor exit) is treated as unknown rather than a country.

## Capture

All three account-creation paths: `/signup`, `/signup/anonymous`, and the OAuth connector flow — the last being where most signups actually originate (783 of 1,096 carry a `chatgpt` referral).

## Backfill

Existing rows can't be derived retroactively, so the auth middleware stamps country on the first authenticated request, writing **only** `WHERE country IS NULL`. Two consequences worth stating:

- the value means *where this account signed up from*, not *where they last were* — it doesn't flicker with travel or a VPN
- the common case (already stamped) writes no rows, so it's cheap enough to run on every request

Dormant accounts stay NULL and render as `—` rather than being guessed, so the coverage gap stays visible in any geo analysis rather than silently biasing it.

## Also

`country` and `referral_source` added to the admin sort allowlist. A `SortableHeader` whose field is missing from that map renders as sortable and silently sorts by `created_at` — `referral_source` already had that bug.

Migration `0037_org_country.sql` adds the nullable column plus an index for grouping.

typecheck clean, 220/220 tests pass. Pairs with engram-web (admin column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52