### PR TITLE
Add a Claude Code plugin with OAuth-based install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "engram",
+  "owner": {
+    "name": "Get Engram Inc",
+    "url": "https://getengram.app"
+  },
+  "plugins": [
+    {
+      "name": "engram",
+      "source": "./plugins/engram",
+      "description": "Persistent, searchable memory for Claude. Stores conversations verbatim and retrieves them by meaning.",
+      "version": "0.1.0",
+      "category": "productivity"
+    }
+  ]
+}

--- a/plugins/engram/.claude-plugin/plugin.json
+++ b/plugins/engram/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "engram",
+  "description": "Persistent, searchable memory for Claude. Stores conversations verbatim and retrieves them by meaning.",
+  "version": "0.1.0",
+  "author": { "name": "Get Engram Inc", "url": "https://getengram.app" },
+  "homepage": "https://getengram.app",
+  "repository": "https://github.com/get-engram/engram",
+  "license": "MIT",
+  "keywords": ["memory", "search", "mcp", "context", "recall"]
+}

--- a/plugins/engram/.mcp.json
+++ b/plugins/engram/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "engram": {
+      "type": "http",
+      "url": "https://mcp.getengram.app/mcp"
+    }
+  }
+}

--- a/plugins/engram/README.md
+++ b/plugins/engram/README.md
@@ -1,0 +1,30 @@
+# Engram for Claude Code
+
+Persistent, searchable memory. Conversations are stored verbatim and retrieved
+by meaning — nothing is summarized away.
+
+## Install
+
+```
+/plugin marketplace add get-engram/engram
+/plugin install engram@engram
+```
+
+Then restart Claude Code. The first time a memory tool is used you'll be sent
+through a browser sign-in; there is no API key to copy and no config file to
+edit. Approve once and the connection persists.
+
+## What you get
+
+- `search` — semantic search across everything you've stored
+- `create_conversation` / `append_messages` — save a conversation
+- `get_conversation`, `list_conversations`, `delete_conversation`
+- `memory_status` — usage against your plan
+
+A bundled skill teaches Claude when to search and what's worth saving, so
+memory accumulates without being asked.
+
+## Accounts
+
+A free account is created as part of sign-in; 10,000 messages of memory that
+never expire. https://getengram.app for plans.

--- a/plugins/engram/skills/engram-memory/SKILL.md
+++ b/plugins/engram/skills/engram-memory/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: engram-memory
+description: Use Engram as persistent memory across sessions — search it before starting work on a project, and save decisions and their reasoning before finishing. Use whenever the user refers to earlier work, past decisions, or something discussed in a previous session.
+---
+
+# Using Engram as memory
+
+Engram stores conversations verbatim and retrieves them by meaning. Unlike a
+summary-based memory, nothing is compressed or paraphrased — what was said is
+what comes back.
+
+## Search before you assume
+
+At the start of work on a project, and any time the user references something
+from before ("like we discussed", "the thing we decided", "last time"), search
+first rather than asking them to repeat it:
+
+```
+search
+  query: "<what you need to know>"
+  limit: 5
+```
+
+Search by meaning, not keywords. "why did we pick this database" works better
+than "database". If the first search misses, rephrase rather than giving up —
+the index is semantic, so a different angle often finds it.
+
+## Save what you would regret losing
+
+Before finishing a substantial piece of work, save it:
+
+```
+create_conversation
+  title: "<concise description of what was decided or built>"
+  tags: [<project>, <topic>]
+
+append_messages
+  conversation_id: "<id from above>"
+  messages:
+    - role: "user"
+      content: "<what was asked>"
+    - role: "assistant"
+      content: "<what was done, and WHY>"
+```
+
+**Save:** decisions and their reasoning, bugs and what actually caused them,
+constraints the user stated, preferences they expressed, anything you had to
+work out that isn't obvious from the code.
+
+**Don't save:** routine file reads, trivial exchanges, or anything already
+recorded in the repository or git history. Those are already durable; storing
+them again adds noise to future searches.
+
+## The reasoning matters more than the outcome
+
+"We chose Cloudflare D1" is nearly useless six months later. "We chose D1
+because we wanted to stay on Cloudflare and accepted the 10 GB cap, planning to
+shard per-organization later" is the note that prevents the decision being
+relitigated. Always record the why.


### PR DESCRIPTION
Copies the model Stripe uses: one plugin, installed in two commands, authenticated in the browser.

```
/plugin marketplace add get-engram/engram
/plugin install engram@engram
```

## Why this is the highest-leverage thing available

Two thirds of signups never store a single message. The most likely reason is the step between "signed up" and "connected": today that means hand-editing an MCP config and pasting an API key. This removes that step entirely.

It also compounds the only channel that works — 783 of 1,096 signups already arrive through ChatGPT connector discovery. This is the same motion for Claude Code.

## No credentials, because the server already supports the flow

Verified against production, not assumed:

| endpoint | result |
|---|---|
| `/.well-known/oauth-protected-resource` | RFC 9728 metadata ✅ |
| `/.well-known/oauth-authorization-server` | RFC 8414, PKCE `S256` ✅ |
| `/oauth/register` | RFC 7591 dynamic client registration ✅ |
| `POST /mcp` unauthenticated | `401` + `WWW-Authenticate: Bearer resource_metadata=…` ✅ |

So the bundled `.mcp.json` contains a URL and nothing else. The client discovers the authorization server, registers itself, and runs the flow.

Worth stating plainly: the obvious move was to copy the repo's existing dev `.mcp.json`, which hardcodes `Bearer YOUR_ENGRAM_API_KEY`. That would have shipped a plugin that recreates the exact friction it exists to remove.

## The skill is not decoration

Tools alone don't change behaviour. An agent handed memory tools and no guidance still won't search before assuming or save before finishing — which is precisely the difference between an account that stores one message and one that accumulates. The bundled skill covers when to search, what's worth saving (and what isn't, so future searches stay signal-dense), and that reasoning outlives outcomes.

## Layout

```
.claude-plugin/marketplace.json      # marketplace, so `marketplace add` works on this repo
plugins/engram/
  .claude-plugin/plugin.json
  .mcp.json                          # URL only — OAuth does the rest
  skills/engram-memory/SKILL.md
  README.md
```

All three manifests validate as JSON.

## Not done here

Untested end-to-end — it needs to be installed from a real branch to confirm the flow. Submitting to `claude-plugins-official` is a separate step and should wait until this is proven working from our own marketplace. Cursor/Codex/ChatGPT variants of the same manifest are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52