### PR TITLE
Annotate admin_metrics for connector-directory compliance

### DIFF
--- a/apps/mcp-server/src/mcp/tools/admin-metrics.ts
+++ b/apps/mcp-server/src/mcp/tools/admin-metrics.ts
@@ -29,6 +29,18 @@ export function registerAdminMetrics(
     "admin_metrics",
     "Business metrics dashboard — signups, active users, tier breakdown, storage stats. Requires admin authentication.",
     {},
+    {
+      // Anthropic's connector directory requires every tool to carry these,
+      // and an unannotated tool is a documented rejection reason. This one is
+      // only registered when auth.isAdmin, so a reviewer connecting over OAuth
+      // never sees it — annotated anyway so the rule holds if that gate ever
+      // moves.
+      title: "Admin metrics",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     async () => {
       const denied = adminGuard(auth);
       if (denied) return denied;


### PR DESCRIPTION
Anthropic's connector directory requires every tool to declare read-only / destructive hints, and an unannotated tool is a documented rejection reason.

Audited all 14 tools: 13 already had annotations, `admin_metrics` did not.

It's only registered when `auth.isAdmin`, so a reviewer connecting over OAuth never sees it — this wasn't actually blocking submission. Annotated anyway so the rule holds if that gate ever moves.

Prep for submitting Engram to the Claude connector directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52