### PR TITLE
merge-orgs: rewrite vectors by vectorize_id; 20-id cap; repair mode

### DIFF
--- a/apps/mcp-server/src/routes/merge-orgs.ts
+++ b/apps/mcp-server/src/routes/merge-orgs.ts
@@ -89,10 +89,10 @@ async function moveConversation(
   // silently skip the vector rewrite, and strand those memories outside
   // semantic search forever.
   const chunkRows = await env.DB.prepare(
-    "SELECT id, fts_rowid, chunk_text FROM conversation_chunks WHERE conversation_id = ? AND organization_id IN (?, ?)",
+    "SELECT id, vectorize_id, fts_rowid, chunk_text FROM conversation_chunks WHERE conversation_id = ? AND organization_id IN (?, ?)",
   )
     .bind(conversationId, fromOrg, toOrg)
-    .all<{ id: string; fts_rowid: number | null; chunk_text: string }>();
+    .all<{ id: string; vectorize_id: string | null; fts_rowid: number | null; chunk_text: string }>();
   const chunks = chunkRows.results ?? [];
 
   if (chunks.length > 0) {
@@ -134,7 +134,13 @@ async function moveConversation(
   // Workers AI spend, and the vectors stay bit-identical.
   let vectors = 0;
   for (const batch of chunkArray(chunks, VECTOR_BATCH)) {
-    const ids = batch.map((c) => c.id);
+    // vectorize_id, NOT the chunk id. Both are chk_-prefixed, which made the
+    // original mistake invisible: getByIds(chunk ids) matched nothing, so
+    // every "successful" merge silently rewrote zero vectors and the moved
+    // memories dropped out of semantic search. A zero here is now a real
+    // signal, not the normal case.
+    const ids = batch.map((c) => c.vectorize_id).filter((v): v is string => !!v);
+    if (ids.length === 0) continue;
     const existing = await env.VECTORIZE.getByIds(ids);
     if (existing.length === 0) continue;
     await env.VECTORIZE.upsert(
@@ -184,8 +190,8 @@ async function moveConversation(
 mergeOrgs.post("/merge-orgs", async (c) => {
   const dryRun = c.req.query("dry_run") === "1" || c.req.query("dry_run") === "true";
   const body = await c.req
-    .json<{ from_email?: string; to_email?: string; limit?: number }>()
-    .catch(() => ({}) as { from_email?: string; to_email?: string; limit?: number });
+    .json<{ from_email?: string; to_email?: string; limit?: number; conversation_ids?: string[] }>()
+    .catch(() => ({}) as { from_email?: string; to_email?: string; limit?: number; conversation_ids?: string[] });
 
   const fromEmail = body.from_email?.trim();
   const toEmail = body.to_email?.trim();
@@ -205,12 +211,23 @@ mergeOrgs.post("/merge-orgs", async (c) => {
 
   // Everything still sitting on the source org. Re-read every call, so this
   // doubles as the resume cursor and the completion check.
-  const pending = await c.env.DB.prepare(
-    "SELECT id FROM conversations WHERE organization_id = ? ORDER BY created_at",
-  )
-    .bind(from.id)
-    .all<{ id: string }>();
-  const pendingIds = (pending.results ?? []).map((r) => r.id);
+  // Normal mode scans what still sits on the source org. `conversation_ids`
+  // overrides that with an explicit list — the repair path for conversations
+  // a buggy earlier run already moved (headers on the target org, so the
+  // scan can no longer see them) that need their FTS/vector steps re-run.
+  // Every step is idempotent, so re-processing a healthy conversation is a
+  // no-op rather than a double-move.
+  let pendingIds: string[];
+  if (Array.isArray(body.conversation_ids) && body.conversation_ids.length > 0) {
+    pendingIds = body.conversation_ids.filter((x): x is string => typeof x === "string");
+  } else {
+    const pending = await c.env.DB.prepare(
+      "SELECT id FROM conversations WHERE organization_id = ? ORDER BY created_at",
+    )
+      .bind(from.id)
+      .all<{ id: string }>();
+    pendingIds = (pending.results ?? []).map((r) => r.id);
+  }
 
   const totals = await c.env.DB.prepare(
     "SELECT (SELECT COUNT(*) FROM messages WHERE organization_id = ?) AS messages, (SELECT COUNT(*) FROM conversation_chunks WHERE organization_id = ?) AS chunks",

--- a/apps/mcp-server/src/routes/merge-orgs.ts
+++ b/apps/mcp-server/src/routes/merge-orgs.ts
@@ -40,8 +40,9 @@ type HonoEnv = { Bindings: Env; Variables: Record<string, never> };
 
 const mergeOrgs = new Hono<HonoEnv>();
 
-/** Vectorize getByIds/upsert are capped well below this; stay conservative. */
-const VECTOR_BATCH = 100;
+/** Vectorize getByIds rejects payloads over 20 ids (VECTOR_GET_ERROR 40007,
+ *  hit in production on a 45-chunk conversation). 20 exactly. */
+const VECTOR_BATCH = 20;
 /** D1 bound-parameter ceiling is ~100; keep id lists under it. */
 const ID_BATCH = 90;
 
@@ -80,10 +81,17 @@ async function moveConversation(
   // --- 1. chunks -----------------------------------------------------------
   // Read before repointing: we need chunk_text and fts_rowid to rebuild the
   // FTS entries, and the contentless index cannot give the text back.
+  // Selected by conversation under EITHER org, not just the source. This is
+  // what makes a retry after a mid-conversation failure safe: if a previous
+  // attempt died after repointing the chunks but before rewriting Vectorize
+  // metadata (exactly what the 40007 batch-size failure did), the chunks are
+  // already on the target org — a source-only filter would find nothing,
+  // silently skip the vector rewrite, and strand those memories outside
+  // semantic search forever.
   const chunkRows = await env.DB.prepare(
-    "SELECT id, fts_rowid, chunk_text FROM conversation_chunks WHERE conversation_id = ? AND organization_id = ?",
+    "SELECT id, fts_rowid, chunk_text FROM conversation_chunks WHERE conversation_id = ? AND organization_id IN (?, ?)",
   )
-    .bind(conversationId, fromOrg)
+    .bind(conversationId, fromOrg, toOrg)
     .all<{ id: string; fts_rowid: number | null; chunk_text: string }>();
   const chunks = chunkRows.results ?? [];
 


### PR DESCRIPTION
Three fixes from the first production merge run — each found by treating anomalies as signals during a deliberately slow rollout (limit 1 → 2 → 5).

## 1. Vectors were never being rewritten (critical)

Vectors live under `conversation_chunks.vectorize_id` — a **separate** `chk_`-prefixed id from the chunk's own `id`. The merge called `getByIds(chunk ids)`, which matched nothing, so every merge rewrote **zero** vector metadata and every moved memory silently vanished from semantic search (FTS keyword search unaffected — it uses real rowids). The identical prefix made this invisible in review; `"vectors": 0` on a batch that moved 18 chunks is what exposed it.

## 2. Vectorize's 20-id cap

`getByIds` rejects >20 ids (`VECTOR_GET_ERROR 40007`, hit on a 45-chunk conversation). `VECTOR_BATCH` 100 → 20. The chunk read also now selects under **either** org so a mid-conversation failure retries instead of silently skipping.

⚠️ PR #418 claimed to land this but merged a stale branch (created from the wrong base during a dirty-tree failure — its squash even carries an mcpb commit title). Main never got it; this PR actually does.

## 3. Repair mode

`conversation_ids: string[]` in the body bypasses the source-org scan — the repair path for the ~7 conversations the buggy runs already moved, whose headers the scan can no longer see. All steps idempotent; repairing a healthy conversation is a no-op.

## State to repair after deploy

- `conv_n3lcebdDwfwV5QK4XhSZI` (45 chunks): moved via the retry hole — FTS correct, vectors stale
- 6 other moved conversations: vectors stale via bug 1

typecheck clean, 220/220 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52