### PR TITLE
merge-orgs: skip already-rewritten vectors so giant conversations can finish

### DIFF
--- a/apps/mcp-server/src/routes/merge-orgs.ts
+++ b/apps/mcp-server/src/routes/merge-orgs.ts
@@ -136,15 +136,24 @@ async function moveConversation(
   for (const batch of chunkArray(chunks, VECTOR_BATCH)) {
     const ids = batch.map((c) => c.id);
     const existing = await env.VECTORIZE.getByIds(ids);
-    if (existing.length === 0) continue;
+    // Skip vectors a previous attempt already rewrote. This is what lets a
+    // 5,000-chunk conversation complete across several attempts: each one
+    // needs ~300 upsert calls, more than Vectorize's rate window allows in a
+    // single request, and without this filter every retry restarted from
+    // zero and hit the same 40041 at the same depth — the giants could never
+    // finish. With it, every attempt makes durable forward progress.
+    const todo = existing.filter(
+      (v) => (v.metadata as { organization_id?: string } | undefined)?.organization_id !== toOrg,
+    );
+    if (todo.length === 0) continue;
     await env.VECTORIZE.upsert(
-      existing.map((v) => ({
+      todo.map((v) => ({
         id: v.id,
         values: v.values,
         metadata: { ...(v.metadata ?? {}), organization_id: toOrg },
       })),
     );
-    vectors += existing.length;
+    vectors += todo.length;
   }
 
   // --- 4. messages ---------------------------------------------------------

--- a/apps/mcp-server/src/routes/merge-orgs.ts
+++ b/apps/mcp-server/src/routes/merge-orgs.ts
@@ -40,8 +40,9 @@ type HonoEnv = { Bindings: Env; Variables: Record<string, never> };
 
 const mergeOrgs = new Hono<HonoEnv>();
 
-/** Vectorize getByIds/upsert are capped well below this; stay conservative. */
-const VECTOR_BATCH = 100;
+/** Vectorize getByIds rejects payloads over 20 ids (VECTOR_GET_ERROR 40007,
+ *  hit in production on a 45-chunk conversation). 20 exactly. */
+const VECTOR_BATCH = 20;
 /** D1 bound-parameter ceiling is ~100; keep id lists under it. */
 const ID_BATCH = 90;
 
@@ -80,10 +81,17 @@ async function moveConversation(
   // --- 1. chunks -----------------------------------------------------------
   // Read before repointing: we need chunk_text and fts_rowid to rebuild the
   // FTS entries, and the contentless index cannot give the text back.
+  // Selected by conversation under EITHER org, not just the source. This is
+  // what makes a retry after a mid-conversation failure safe: if a previous
+  // attempt died after repointing the chunks but before rewriting Vectorize
+  // metadata (exactly what the 40007 batch-size failure did), the chunks are
+  // already on the target org — a source-only filter would find nothing,
+  // silently skip the vector rewrite, and strand those memories outside
+  // semantic search forever.
   const chunkRows = await env.DB.prepare(
-    "SELECT id, fts_rowid, chunk_text FROM conversation_chunks WHERE conversation_id = ? AND organization_id = ?",
+    "SELECT id, fts_rowid, chunk_text FROM conversation_chunks WHERE conversation_id = ? AND organization_id IN (?, ?)",
   )
-    .bind(conversationId, fromOrg)
+    .bind(conversationId, fromOrg, toOrg)
     .all<{ id: string; fts_rowid: number | null; chunk_text: string }>();
   const chunks = chunkRows.results ?? [];
 


### PR DESCRIPTION
Fourth and final fix from the production merge run. Conversations with 5,000+ chunks need ~300 upsert calls — beyond Vectorize's rate window for a single request — and every retry restarted the vector pass from zero, failing at the same depth forever. Retries now filter out vectors whose metadata is already rewritten (getByIds returns it), so each attempt makes durable forward progress. 24 conversations remaining in production, including three giants blocked on exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52