### PR TITLE
merge-orgs: skip already-rewritten vectors so giant conversations can finish

### DIFF
--- a/apps/mcp-server/src/routes/merge-orgs.ts
+++ b/apps/mcp-server/src/routes/merge-orgs.ts
@@ -142,15 +142,24 @@ async function moveConversation(
     const ids = batch.map((c) => c.vectorize_id).filter((v): v is string => !!v);
     if (ids.length === 0) continue;
     const existing = await env.VECTORIZE.getByIds(ids);
-    if (existing.length === 0) continue;
+    // Skip vectors a previous attempt already rewrote. This is what lets a
+    // 5,000-chunk conversation complete across several attempts: it needs
+    // ~300 upsert calls, more than Vectorize's rate window allows in a
+    // single request, and without this filter every retry restarted from
+    // zero and hit the same 40041 at the same depth — the giants could
+    // never finish. With it, every attempt makes durable forward progress.
+    const todo = existing.filter(
+      (v) => (v.metadata as { organization_id?: string } | undefined)?.organization_id !== toOrg,
+    );
+    if (todo.length === 0) continue;
     await env.VECTORIZE.upsert(
-      existing.map((v) => ({
+      todo.map((v) => ({
         id: v.id,
         values: v.values,
         metadata: { ...(v.metadata ?? {}), organization_id: toOrg },
       })),
     );
-    vectors += existing.length;
+    vectors += todo.length;
   }
 
   // --- 4. messages ---------------------------------------------------------


### PR DESCRIPTION
Recreation of #420 (closed — cut from a stale local main, conflicted). Retries filter out vectors whose metadata is already rewritten, so 5,000+-chunk conversations complete incrementally across rate-limit windows instead of restarting from zero and failing at the same depth forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52