### PR TITLE
Add whoami tool: which account is this connection using?

### DIFF
--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -6,6 +6,7 @@ import { registerGetConversation } from "./tools/get-conversation.js";
 import { registerListConversations } from "./tools/list-conversations.js";
 import { registerDeleteConversation } from "./tools/delete-conversation.js";
 import { registerMemoryStatus } from "./tools/memory-status.js";
+import { registerWhoami } from "./tools/whoami.js";
 import { registerResolveVault } from "./tools/resolve-vault.js";
 import { registerVaultSet } from "./tools/vault-set.js";
 import { registerVaultGet } from "./tools/vault-get.js";
@@ -74,6 +75,7 @@ export function createMcpServer(env: Env, auth: AuthContext): McpServer {
   registerListConversations(server, env, auth);
   registerDeleteConversation(server, env, auth);
   registerMemoryStatus(server, env, auth);
+  registerWhoami(server, env, auth);
 
   // First-party-only tools. External OAuth clients (auth.apiKeyId is
   // "oauth:<client_id>") get the memory-only surface: the secrets vault

--- a/apps/mcp-server/src/mcp/tools/whoami.ts
+++ b/apps/mcp-server/src/mcp/tools/whoami.ts
@@ -1,0 +1,56 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getOrganizationById } from "@getengram/db";
+import type { Env, AuthContext } from "../../types.js";
+
+/**
+ * whoami — which Engram account is this session talking to?
+ *
+ * Exists because the answer has repeatedly been non-obvious in practice: the
+ * owner ran two orgs for months, a daemon quietly wrote to the wrong one for
+ * a day after they were merged, and a ChatGPT connector held tokens bound to
+ * an org that no longer had any data. Every one of those cost real debugging
+ * time that a one-word tool call would have answered.
+ *
+ * Deliberately read-only and registered for EVERY auth kind, including
+ * external OAuth clients — identity confusion is most likely precisely in
+ * the connector clients with the narrowed tool surface.
+ */
+export function registerWhoami(server: McpServer, env: Env, auth: AuthContext) {
+  server.tool(
+    "whoami",
+    "Show which Engram account this connection is using — organization name, email, tier, and how you are authenticated. Use when unsure which account memories are being saved to or searched from.",
+    {},
+    {
+      title: "Who am I",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    async () => {
+      const org = (await getOrganizationById(env.DB, auth.organizationId)) as {
+        name: string | null;
+        email: string | null;
+        tier: string;
+        deleted_at: string | null;
+      } | null;
+
+      const viaOAuth = auth.apiKeyId.startsWith("oauth:");
+      const lines = [
+        `Organization: ${org?.name ?? "(unnamed)"} <${org?.email ?? "no email"}>`,
+        `Org ID: ${auth.organizationId}`,
+        `Tier: ${org?.tier ?? auth.tier}`,
+        `Auth: ${viaOAuth ? `OAuth client (${auth.apiKeyId.slice(6)})` : `API key (${auth.apiKeyId})`}`,
+        auth.seatId ? `Seat: ${auth.seatId}` : null,
+        // Soft-deleted orgs still authenticate (that keeps account restore
+        // reachable) — but anything saved here purges with the org, which is
+        // exactly the surprise this tool exists to surface.
+        org?.deleted_at
+          ? `⚠️ WARNING: this account is scheduled for deletion (since ${org.deleted_at}). Anything saved here will be purged. If this is unexpected, restore the account or reconnect with the right one.`
+          : null,
+      ].filter(Boolean);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    },
+  );
+}


### PR DESCRIPTION
Shows org name/email/id, tier, auth method (API key vs OAuth client), seat — and warns loudly if the connected org is scheduled for deletion (soft-deleted orgs still authenticate by design, so a stale connection can silently save into an org that will purge).

Motivated by three real incidents this week: a daemon writing to the wrong org post-merge, a ChatGPT connector bound to an emptied org, and 'which account am I in?' having no answer short of a database query.

Registered for all auth kinds including external OAuth connectors — that's where identity confusion actually happens. Read-only, fully annotated for the connector directory.

typecheck clean, 220/220 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52