### PR TITLE
Correct the legal entity name: Engram AI Inc

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "engram",
   "owner": {
-    "name": "Get Engram Inc",
+    "name": "Engram AI Inc",
     "url": "https://getengram.app"
   },
   "plugins": [

--- a/docs/launch/devto-blog-post.md
+++ b/docs/launch/devto-blog-post.md
@@ -144,4 +144,4 @@ The free tier is enough to see if it's useful for your workflow. I'd love to hea
 
 ---
 
-*[Engram](https://getengram.app) is built by [Get Engram Inc](https://github.com/get-engram). Questions? hello@getengram.app*
+*[Engram](https://getengram.app) is built by [Engram AI Inc](https://github.com/get-engram). Questions? hello@getengram.app*

--- a/docs/launch/one-memory-everywhere.md
+++ b/docs/launch/one-memory-everywhere.md
@@ -2,7 +2,7 @@
 
 **Engram is the memory that follows you across every AI. Save something in ChatGPT, recall it in Claude or Cursor.**
 
-*Published July 8, 2026 · Get Engram Inc*
+*Published July 8, 2026 · Engram AI Inc*
 
 ---
 

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -2,7 +2,7 @@
 
 **An Engram whitepaper on seven use cases for persistent agent memory**
 
-*Published April 11, 2026 · Get Engram Inc*
+*Published April 11, 2026 · Engram AI Inc*
 
 ---
 
@@ -183,6 +183,6 @@ If any of the seven patterns in this paper describe a gap on your own team, the 
 
 ---
 
-*Written by an agent, for agents. Published April 11, 2026 by Get Engram Inc, Delaware. Comments and corrections: [hello@getengram.app](mailto:hello@getengram.app).*
+*Written by an agent, for agents. Published April 11, 2026 by Engram AI Inc, Delaware. Comments and corrections: [hello@getengram.app](mailto:hello@getengram.app).*
 
 *Visit [getengram.app](https://getengram.app) to get started.*

--- a/mcpb/LICENSE
+++ b/mcpb/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Get Engram Inc
+Copyright (c) 2026 Engram AI Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -6,7 +6,7 @@
   "description": "Persistent, searchable memory for Claude. Stores conversations verbatim and retrieves them by meaning.",
   "long_description": "Engram gives Claude a memory that persists across conversations. Everything you choose to save is stored verbatim \u2014 never summarized or compressed \u2014 and retrieved by semantic meaning. The same memory is shared with ChatGPT, Cursor, Claude Code and any other MCP client you connect, so something you told one assistant is findable from all of them. Signing in creates a free account with 10,000 messages of memory that never expire.",
   "author": {
-    "name": "Get Engram Inc",
+    "name": "Engram AI Inc",
     "url": "https://github.com/get-engram"
   },
   "homepage": "https://getengram.app",

--- a/plugins/engram/.claude-plugin/plugin.json
+++ b/plugins/engram/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "engram",
   "description": "Persistent, searchable memory for Claude. Stores conversations verbatim and retrieves them by meaning.",
   "version": "0.1.0",
-  "author": { "name": "Get Engram Inc", "url": "https://getengram.app" },
+  "author": { "name": "Engram AI Inc", "url": "https://getengram.app" },
   "homepage": "https://getengram.app",
   "repository": "https://github.com/get-engram/engram",
   "license": "MIT",


### PR DESCRIPTION
Closes #425. Mechanical replace matching engram-web#227 — the recorded Certificate of Incorporation (DE file 10629591) says **Engram AI Inc**. Plugin author, marketplace.json, MCPB manifest + LICENSE, and doc bylines updated. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN9M783dLGEnvSSP3UNv52